### PR TITLE
Custom header support

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -49,18 +49,16 @@ to specify header parameters seperately in a block after the description.
 
 ``` ruby
 desc "Return super-secret information", {
-  headers: [
-    {
-      name: "XAuthToken",
+  headers: {
+    "XAuthToken" => {
       description: "Valdates your identity",
       required: true 
     },
-    {
-      name: "XOptionalHeader",
+    XOptionalHeader" => {
       description: "Not reallly needed",
       required: false 
     }
-  ]
+  }
 }
 ```
 

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -130,15 +130,14 @@ module Grape
             
             def parse_header_params(params)
               if params
-                params.map do |details|
-                  name = details[:name]
+                params.map do |param, value|
                   dataType = 'String'
-                  description = details[:description]
-                  required = details[:required]
+                  description = value.is_a?(Hash) ? value[:description] : ''
+                  required = value.is_a?(Hash) ? !!value[:required] : false
                   paramType = "header"
                   {
                     paramType: paramType,
-                    name: name,
+                    name: param,
                     description: description,
                     dataType: dataType,
                     required: required

--- a/spec/grape-swagger-helper_spec.rb
+++ b/spec/grape-swagger-helper_spec.rb
@@ -59,7 +59,7 @@ describe "helpers" do
 	
 	context "parsing header parameters" do
 		it "should parse params for the header" do
-			params = [{name: "XAuthToken", description: "A required header.", required: true}]
+			params = {"XAuthToken" => { description: "A required header.", required: true}}
 			@api.parse_header_params(params).should == 
 			[	
 				{paramType: "header", name: "XAuthToken", description:"A required header.", dataType: "String", required: true}

--- a/spec/simple_mounted_api_spec.rb
+++ b/spec/simple_mounted_api_spec.rb
@@ -11,7 +11,10 @@ describe "a simple mounted api" do
       end
       
       desc 'this gets something else', {
-        :headers => [{name: "XAuthToken", description: "A required header.", required: true}]
+        :headers => {
+          "XAuthToken" => {description: "A required header.", required: true}, 
+          "XOtherHeader" => {description: "An optional header.", required: false}
+        }
       }
       get '/simple_with_headers' do
         {:bla => 'something_else'}
@@ -38,6 +41,6 @@ describe "a simple mounted api" do
 
   it "retrieves the documentation for mounted-api that includes headers" do
     get '/swagger_doc/simple_with_headers'
-    last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org\", :resourcePath=>\"\", :apis=>[{:path=>\"/simple_with_headers.{format}\", :operations=>[{:notes=>nil, :summary=>\"this gets something else\", :nickname=>\"GET-simple_with_headers---format-\", :httpMethod=>\"GET\", :parameters=>[{:paramType=>\"header\", :name=>\"XAuthToken\", :description=>\"A required header.\", :dataType=>\"String\", :required=>true}]}]}]}"
+    last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org\", :resourcePath=>\"\", :apis=>[{:path=>\"/simple_with_headers.{format}\", :operations=>[{:notes=>nil, :summary=>\"this gets something else\", :nickname=>\"GET-simple_with_headers---format-\", :httpMethod=>\"GET\", :parameters=>[{:paramType=>\"header\", :name=>\"XAuthToken\", :description=>\"A required header.\", :dataType=>\"String\", :required=>true}, {:paramType=>\"header\", :name=>\"XOtherHeader\", :description=>\"An optional header.\", :dataType=>\"String\", :required=>false}]}]}]}"
   end
 end


### PR DESCRIPTION
Allows the passing of a headers hash inside the desc block with the notes:

``` ruby
desc "Return super-secret information", {
  notes: "SUPER SECRET",
  headers: {
    "XAuthToken" => {
      description: "Valdates your identity",
      required: true 
    },
    "XOptionalHeader" => {
      description: "Not reallly needed",
      required: false 
    }
  }
}
```

Swagger is then able to add header parameters as appropriate.

I have added information to the README to cover this.

This also adds tests to the helpers so that they can be tested independently.
