### PR TITLE
Fix swagger routes generation for grape versioned API

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -11,7 +11,7 @@ module Grape
         original_mount mounts
         @combined_routes ||= {}
         mounts::routes.each do |route|
-          resource = route.route_path.match('\/(.*?)[\.\/\(]').captures.first || '/'
+          resource = route.route_path.match('\/(\w*?)[\.\/\(]').captures.first || '/'
           @combined_routes[resource.downcase] ||= []
           @combined_routes[resource.downcase] << route
         end


### PR DESCRIPTION
Hey @tim-vandecasteele. I've seen @tenaciousflea changes to fix routes generation when specifying API version on path. According to my tests, it has broken routes generation apparently because it has only scoped the namespaced routes. Thus, I've made a very similar change myself that doesn't affect the backwards compatibility. 
I've only changed the routes_path regex to not allow expressions starting with :version (accepts word character only).

I have made some tests and it seems alright.

Hope it solves your problem.
