### PR TITLE
Improvements to parse_path

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -152,7 +152,12 @@ module Grape
             def parse_path(path, version)
               # adapt format to swagger format
               parsed_path = path.gsub('(.:format)', '.{format}')
-              parsed_path = parsed_path.gsub(/:([a-z]+)/, '{\1}')
+              # This is attempting to emulate the behavior of 
+              # Rack::Mount::Strexp. We cannot use Strexp directly because 
+              # all it does is generate regular expressions for parsing URLs. 
+              # TODO: Implement a Racc tokenizer to properly generate the 
+              # parsed path.
+              parsed_path = parsed_path.gsub(/:([a-zA-Z_]\w*)/, '{\1}')
               # add the version
               parsed_path = parsed_path.gsub('{version}', version) if version
               parsed_path

--- a/spec/grape-swagger-helper_spec.rb
+++ b/spec/grape-swagger-helper_spec.rb
@@ -51,6 +51,24 @@ describe "helpers" do
 			@api.parse_path(path, nil).should == "{abc}/def.{format}"
 		end
 
+    it "should parse a path that has vars with underscores in the name" do
+      path = "abc/:def_g(.:format)"
+			@api.parse_path(path, nil).should == "abc/{def_g}.{format}"
+      
+    end
+
+    it "should parse a path that has vars with numbers in the name" do
+      path = "abc/:sha1(.:format)"
+			@api.parse_path(path, nil).should == "abc/{sha1}.{format}"
+    end
+
+    it "should parse a path that has multiple variables" do
+      path1 = "abc/:def/:geh(.:format)"
+      path2 = "abc/:def:geh(.:format)"
+			@api.parse_path(path1, nil).should == "abc/{def}/{geh}.{format}"
+			@api.parse_path(path2, nil).should == "abc/{def}{geh}.{format}"
+    end
+
 		it "should parse the path with a specified version" do
 			path = ":abc/{version}/def(.:format)"
 			@api.parse_path(path, 'v1').should == "{abc}/v1/def.{format}"


### PR DESCRIPTION
Hi there,

I found that if I had routes like any of the following, grape-swagger would generate some pretty goofy swagger documentation:
- "/:sha1" parses to "/{sha}1"
- "/:some_name" parses to  "/{some}_name"
- "/:Some_Name" parses to "/:Some_Name"

This behavior causes grape-swagger to generate incorrect swagger specifications. 

The changes I made allow all of these to parse with proper expectations, namely:
- "/:sha1" parses to "/{sha1}"
- "/:some_name" parses to  "/{some_name}"
- "/:Some_Name" parses to "/{Some_Name}"
