### PR TITLE
Empty route created due to bug in route_path matching, results in: 0 : error http://localhost:9292/swagger_doc/.json

### DIFF
--- a/spec/simple_mounted_api_spec.rb
+++ b/spec/simple_mounted_api_spec.rb
@@ -14,7 +14,11 @@ describe "a simple mounted api" do
         :headers => {
           "XAuthToken" => {description: "A required header.", required: true}, 
           "XOtherHeader" => {description: "An optional header.", required: false}
-        }
+        },
+	:http_codes => {
+		403 => "invalid pony",
+		405 => "no ponies left!"
+	}
       }
       get '/simple_with_headers' do
         {:bla => 'something_else'}
@@ -41,6 +45,6 @@ describe "a simple mounted api" do
 
   it "retrieves the documentation for mounted-api that includes headers" do
     get '/swagger_doc/simple_with_headers'
-    last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org\", :resourcePath=>\"\", :apis=>[{:path=>\"/simple_with_headers.{format}\", :operations=>[{:notes=>nil, :summary=>\"this gets something else\", :nickname=>\"GET-simple_with_headers---format-\", :httpMethod=>\"GET\", :parameters=>[{:paramType=>\"header\", :name=>\"XAuthToken\", :description=>\"A required header.\", :dataType=>\"String\", :required=>true}, {:paramType=>\"header\", :name=>\"XOtherHeader\", :description=>\"An optional header.\", :dataType=>\"String\", :required=>false}]}]}]}"
+    last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org\", :resourcePath=>\"\", :apis=>[{:path=>\"/simple_with_headers.{format}\", :operations=>[{:notes=>nil, :summary=>\"this gets something else\", :nickname=>\"GET-simple_with_headers---format-\", :httpMethod=>\"GET\", :parameters=>[{:paramType=>\"header\", :name=>\"XAuthToken\", :description=>\"A required header.\", :dataType=>\"String\", :required=>true}, {:paramType=>\"header\", :name=>\"XOtherHeader\", :description=>\"An optional header.\", :dataType=>\"String\", :required=>false}], :errorResponses=>[{:code=>403, :reason=>\"invalid pony\"}, {:code=>405, :reason=>\"no ponies left!\"}]}]}]}"
   end
 end


### PR DESCRIPTION
When attempting to mount an API which has a 'root' route, i.e. a get without any resource:

``` ruby
module API
        class BreaksSwagger < Grape::API
                desc "Document root, i.e. GET http://host/"
                get do
                end     
        end     
end
```

We get a route with an empty path, which breaks swagger as it tries to GET /.json:

``` ruby
{""=>[version=v1, method=GET, path=/(.:format)]}
```

This is due to a little bug on on line 14 of lib/grape-swagger.rb:

``` ruby
resource = route.route_path.match('\/(\w*?)[\.\/\(]').captures.first || '/'
```

Fixing the logic to return a route of "/" still breaks swagger as it tries to GET //.json

This works, but it looks pretty of goofy in swagger and I figured you'd want to implement something less hacky.

``` ruby
          resource = route.route_path.match('\/(\w*?)[\.\/\(]').captures.first
          resource.empty? && resource = 'doc_root'
```

So for now, the pull request just drops the route entirely as completely breaks swagger by default, and the doc_root thing is a bit of a hack.
