### PR TITLE
Fix: document default/root APIs.

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,0 +1,41 @@
+### Next Release
+
+* Added Rails 4 support - [@jrhe](https://github.com/jrhe).
+* Fix: document APIs at root level - [@dblock](https://github.com/dblock).
+
+### 0.5.0 (March 28, 2013)
+
+* Added Grape 0.5.0 support - [@tim-vandecasteele](https://github.com/tim-vandecasteele).
+
+### 0.4.0 (March 28, 2013)
+
+* Support https - [@cutalion](https://github.com/cutalion).
+
+### 0.3.0 (October 19, 2012)
+
+* Added version support - [@agileanimal](https://github.com/agileanimal), [@fknappe](https://github.com/fknappe).
+* Added support for nested parameters - [@tim-vandecasteele](https://github.com/tim-vandecasteele).
+* Added basic support for specifying parameters that need to be passed in the header - [@agileanimal](https://github.com/agileanimal).
+* Add possibility to hide the documentation paths in the generated swagger documentation - [@tim-vandecasteele](https://github.com/tim-vandecasteele).
+
+### 0.2.1 (August 17, 2012)
+
+* Added support for markdown in notes field - [@tim-vandecasteele](https://github.com/tim-vandecasteele).
+* Fix: compatibility with Rails - [@qwert666](https://github.com/qwert666).
+* Fix: swagger UI history - [@tim-vandecasteele](https://github.com/tim-vandecasteele).
+
+### 0.2.0 (July 27, 2012)
+
+* Use resource as root for swagger - [@tim-vandecasteele](https://github.com/tim-vandecasteele).
+* Added support for file uploads, and proper `paramType` - [@tim-vandecasteele](https://github.com/tim-vandecasteele).
+* Added tests - [@nathanvda](https://github.com/nathanvda).
+
+### 0.1.0 (July 19, 2012)
+
+* Added some configurability to the generated documentation - [@tim-vandecasteele](https://github.com/tim-vandecasteele).
+* Adapted to rails plugin structure - [@tim-vandecasteele](https://github.com/tim-vandecasteele).
+* Allowed cross origin, so swagger can be used from official site - [@tim-vandecasteele](https://github.com/tim-vandecasteele).
+
+### 0.0.0 (July 19, 2012)
+
+* Initial public release - [@tim-vandecasteele](https://github.com/tim-vandecasteele).

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -5,24 +5,21 @@ module Grape
     class << self
       attr_reader :combined_routes
 
-      alias original_mount mount
-
-      def mount(mounts)
-        original_mount mounts
-        @combined_routes ||= {}
-        mounts::routes.each do |route|
-          resource = route.route_path.match('\/(\w*?)[\.\/\(]').captures.first
-          next if resource.empty?
-          @combined_routes[resource.downcase] ||= []
-          @combined_routes[resource.downcase] << route
-        end
-      end
-
       def add_swagger_documentation(options={})
         documentation_class = create_documentation_class
 
         documentation_class.setup({:target_class => self}.merge(options))
         mount(documentation_class)
+
+        @combined_routes = {}
+        routes.each do |route|
+          resource = route.route_path.match('\/(\w*?)[\.\/\(]').captures.first
+          next if resource.empty?
+          resource.downcase!
+          @combined_routes[resource] ||= []
+          @combined_routes[resource] << route
+        end
+
       end
 
       private

--- a/spec/default_api_spec.rb
+++ b/spec/default_api_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+describe "Default API" do
+
+  before(:all) do
+    class NotAMountedApi < Grape::API
+      desc 'this gets something'
+      get '/something' do
+        {:bla => 'something'}
+      end
+      add_swagger_documentation
+    end
+  end
+
+  def app; NotAMountedApi; end
+
+  it "should document something" do
+    get '/swagger_doc'
+    last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org\", :operations=>[], :apis=>[{:path=>\"/swagger_doc/something.{format}\"}, {:path=>\"/swagger_doc/swagger_doc.{format}\"}]}"
+  end
+
+end


### PR DESCRIPTION
- Allow documenting API methods at root.
- Added CHANGELOG.
- Don't monkey-patch `mount`.
