### PR TITLE
Support description option body_param

### DIFF
--- a/spec/explicit_body_params_spec.rb
+++ b/spec/explicit_body_params_spec.rb
@@ -1,0 +1,53 @@
+require 'spec_helper'
+
+describe "api with body_params option" do
+  before :all do
+    class BodyParamsApi < Grape::API
+      desc 'This posts something.', :notes => "whatever"
+      params do
+        requires :foo
+      end
+      post '/something' do
+        { bla: 'something' }
+      end
+
+      desc 'This posts something else.', {
+        :notes => "whatever",
+        :body_param => true
+      }
+      params do
+        requires :foo
+        requires :bar
+      end
+      post '/something_else' do
+        { bla: 'something_else' }
+      end
+
+      add_swagger_documentation
+    end
+  end
+
+  def app; BodyParamsApi end
+
+  it "returns 'form' paramType without explicit option" do
+    get '/swagger_doc/something.json'
+
+    operation = JSON.parse(last_response.body)["apis"][0]["operations"][0]
+    parameters = operation["parameters"]
+    parameters.size.should == 1
+    parameters[0]["paramType"].should == "form"
+  end
+
+  it "returns 'body' paramType with explicit option" do
+    get '/swagger_doc/something_else.json'
+
+    operation = JSON.parse(last_response.body)["apis"][0]["operations"][0]
+    operation["parameters"].should == [{
+      "name" => "body",
+      "paramType" => "body",
+      "required" => true,
+      "description" => "",
+      "dataType" => "String"
+    }]
+  end
+end

--- a/spec/grape-swagger_helper_spec.rb
+++ b/spec/grape-swagger_helper_spec.rb
@@ -19,29 +19,57 @@ describe "helpers" do
   end
 
   context "parsing parameters" do
-    it "parses params as query strings for a GET" do
-      params = {
+    before do
+      @params = {
         name: { type: 'String', desc: "A name", required: true },
         level: 'max'
       }
-      path = "/coolness"
+      @path = "/coolness"
+    end
+
+    it "parses params as query strings for a GET" do
       method = "GET"
-      @api.parse_params(params, path, method).should == [
+      @api.parse_params(@params, @path, method, nil).should == [
         { paramType: "query", name: :name, description: "A name", dataType: "String", required: true },
         { paramType: "query", name: :level, description: "", dataType: "String", required: false }
       ]
     end
 
     it "parses params as form for a POST" do
-      params = {
-        name: { type: 'String', :desc => "A name", required: true },
-        level: 'max'
-      }
-      path = "/coolness"
       method = "POST"
-      @api.parse_params(params, path, method).should == [
+      @api.parse_params(@params, @path, method, nil).should == [
         { paramType: "form", name: :name, description: "A name", dataType: "String", required: true },
         { paramType: "form", name: :level, description: "", dataType: "String", required: false }
+      ]
+    end
+
+    it "parses params as body with explicit option" do
+      method = "POST"
+      @api.parse_params(@params, @path, method, true).should == [
+        { paramType: "body", name: :body, description: "", dataType: "String", required: true }
+      ]
+    end
+
+    it "parses specific params as body if body_param is an array" do
+      method = "POST"
+      @api.parse_params(@params, @path, method, [:level]).should == [
+        { paramType: "form", name: :name, description: "A name", dataType: "String", required: true },
+        { paramType: "body", name: :body, description: "", dataType: "String", required: true }
+      ]
+    end
+
+    it "does not include path params in body" do
+      method = "FOO"
+      @api.parse_params(@params, "/:level", method, true).should == [
+        { paramType: "path", name: :level, description: "", dataType: "String", required: false },
+        { paramType: "body", name: :body, description: "", dataType: "String", required: true }
+      ]
+    end
+
+    it "body param does not require any parameters to be defined" do
+      method = "FOO"
+      @api.parse_params(nil, @path, method, true).should == [
+        { paramType: "body", name: :body, description: "", dataType: "String", required: true }
       ]
     end
   end


### PR DESCRIPTION
This is a proposal to fix #42. See the included commit message for details.

With this change, we can at least have textarea input for complex types that couldn't be represented with form fields.

The included parameter names and descriptions are lost. We could try to put them in some formatted way into `notes`, but since there's no guarantee that it supports markdown, the result would be messy.

Ideally, this should be eventually solved in #39.
