### PR TITLE
Support relative base paths for swagger_doc API

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -71,7 +71,7 @@ module Grape
               {
                 apiVersion: api_version,
                 swaggerVersion: "1.1",
-                basePath: base_path || request.base_url,
+                basePath: URI.join(request.base_url, base_path || '').to_s,
                 operations:[],
                 apis: routes_array
               }
@@ -106,7 +106,7 @@ module Grape
               {
                 apiVersion: api_version,
                 swaggerVersion: "1.1",
-                basePath: base_path || request.base_url,
+                basePath: URI.join(request.base_url, base_path || '').to_s,
                 resourcePath: "",
                 apis: routes_array
               }
@@ -192,7 +192,7 @@ class Object
   #   @person.try(:name)
   #
   # File activesupport/lib/active_support/core_ext/object/try.rb#L32
-   def try(*a, &b)
+  def try(*a, &b)
     if a.empty? && block_given?
       yield self
     else

--- a/spec/simple_mounted_api_spec.rb
+++ b/spec/simple_mounted_api_spec.rb
@@ -20,36 +20,72 @@ describe "a simple mounted api" do
           "XAuthToken" => {description: "A required header.", required: true},
           "XOtherHeader" => {description: "An optional header.", required: false}
         },
-	:http_codes => {
-		403 => "invalid pony",
-		405 => "no ponies left!"
-	}
+        :http_codes => {
+          403 => "invalid pony",
+          405 => "no ponies left!"
+        }
       }
       get '/simple_with_headers' do
         {:bla => 'something_else'}
       end
     end
+  end
 
-    class SimpleApi < Grape::API
-      mount SimpleMountedApi
-      add_swagger_documentation
+  context "without base path" do
+    before(:all) do
+      class SimpleApi < Grape::API
+        mount SimpleMountedApi
+        add_swagger_documentation
+      end
+    end
+
+    def app; SimpleApi end
+
+    it "retrieves swagger-documentation on /swagger_doc" do
+      get '/swagger_doc'
+      last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org\", :operations=>[], :apis=>[{:path=>\"/swagger_doc/simple.{format}\"}, {:path=>\"/swagger_doc/simple_with_headers.{format}\"}, {:path=>\"/swagger_doc/swagger_doc.{format}\"}]}"
+    end
+
+    it "retrieves the documentation for mounted-api" do
+      get '/swagger_doc/simple'
+      last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org\", :resourcePath=>\"\", :apis=>[{:path=>\"/simple.{format}\", :operations=>[{:notes=>\"_test_\", :summary=>\"this gets something\", :nickname=>\"GET-simple---format-\", :httpMethod=>\"GET\", :parameters=>[]}]}]}"
+    end
+
+    it "retrieves the documentation for mounted-api that includes headers" do
+      get '/swagger_doc/simple_with_headers'
+      last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org\", :resourcePath=>\"\", :apis=>[{:path=>\"/simple_with_headers.{format}\", :operations=>[{:notes=>nil, :summary=>\"this gets something else\", :nickname=>\"GET-simple_with_headers---format-\", :httpMethod=>\"GET\", :parameters=>[{:paramType=>\"header\", :name=>\"XAuthToken\", :description=>\"A required header.\", :dataType=>\"String\", :required=>true}, {:paramType=>\"header\", :name=>\"XOtherHeader\", :description=>\"An optional header.\", :dataType=>\"String\", :required=>false}], :errorResponses=>[{:code=>403, :reason=>\"invalid pony\"}, {:code=>405, :reason=>\"no ponies left!\"}]}]}]}"
     end
   end
 
-  def app; SimpleApi end
+  context "with absolute base path", focus: true do
+    before(:all) do
+      class SimpleApiWithAbsBase < Grape::API
+        mount SimpleMountedApi
+        add_swagger_documentation({base_path: 'http://api.example.org/grape-api'})
+      end
+    end
 
-  it "retrieves swagger-documentation on /swagger_doc" do
-    get '/swagger_doc'
-    last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org\", :operations=>[], :apis=>[{:path=>\"/swagger_doc/simple.{format}\"}, {:path=>\"/swagger_doc/simple_with_headers.{format}\"}, {:path=>\"/swagger_doc/swagger_doc.{format}\"}]}"
+    def app; SimpleApiWithAbsBase end
+
+    it "should return the absolute base path" do
+      get '/swagger_doc'
+      last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://api.example.org/grape-api\", :operations=>[], :apis=>[{:path=>\"/swagger_doc/simple.{format}\"}, {:path=>\"/swagger_doc/simple_with_headers.{format}\"}, {:path=>\"/swagger_doc/swagger_doc.{format}\"}]}"
+    end
   end
 
-  it "retrieves the documentation for mounted-api" do
-    get '/swagger_doc/simple'
-    last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org\", :resourcePath=>\"\", :apis=>[{:path=>\"/simple.{format}\", :operations=>[{:notes=>\"_test_\", :summary=>\"this gets something\", :nickname=>\"GET-simple---format-\", :httpMethod=>\"GET\", :parameters=>[]}]}]}"
-  end
+  context "with relative base path", focus: true do
+    before(:all) do
+      class SimpleApiWithRelBase < Grape::API
+        mount SimpleMountedApi
+        add_swagger_documentation({base_path: '/grape-api'})
+      end
+    end
 
-  it "retrieves the documentation for mounted-api that includes headers" do
-    get '/swagger_doc/simple_with_headers'
-    last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org\", :resourcePath=>\"\", :apis=>[{:path=>\"/simple_with_headers.{format}\", :operations=>[{:notes=>nil, :summary=>\"this gets something else\", :nickname=>\"GET-simple_with_headers---format-\", :httpMethod=>\"GET\", :parameters=>[{:paramType=>\"header\", :name=>\"XAuthToken\", :description=>\"A required header.\", :dataType=>\"String\", :required=>true}, {:paramType=>\"header\", :name=>\"XOtherHeader\", :description=>\"An optional header.\", :dataType=>\"String\", :required=>false}], :errorResponses=>[{:code=>403, :reason=>\"invalid pony\"}, {:code=>405, :reason=>\"no ponies left!\"}]}]}]}"
+    def app; SimpleApiWithRelBase end
+
+    it "should return the relative base path" do
+      get '/swagger_doc'
+      last_response.body.should == "{:apiVersion=>\"0.1\", :swaggerVersion=>\"1.1\", :basePath=>\"http://example.org/grape-api\", :operations=>[], :apis=>[{:path=>\"/swagger_doc/simple.{format}\"}, {:path=>\"/swagger_doc/simple_with_headers.{format}\"}, {:path=>\"/swagger_doc/swagger_doc.{format}\"}]}"
+    end
   end
 end


### PR DESCRIPTION
Support relative and absolute base paths for
`add_swagger_documentation`. If a relative path is specified it should
take the base URL from the request and join it with the specified
relative base path.
