### PR TITLE
handle grape's :prefix correctly

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -13,7 +13,11 @@ module Grape
 
         @combined_routes = {}
         routes.each do |route|
-          resource = route.route_path.match('\/(\w*?)[\.\/\(]').captures.first
+          if prefix.nil?
+            resource = route.route_path.match('\/(\w*?)[\.\/\(]').captures.first
+          else
+            resource = route.route_path.match('\/'+prefix.gsub(/^\/+/, '')+'\/(\w*?)[\.\/\(]').captures.first
+          end
           next if resource.empty?
           resource.downcase!
           @combined_routes[resource] ||= []


### PR DESCRIPTION
When you use :prefix on the grape API for which you want to generate the swagger doc, it currently shows it all as a single resource on that prefix.

With this pull request, it'll keep the old behaviour when :prefix isn't specified, but strip out the prefix of the resource name when it is.
