### PR TITLE
Adding support for form parameters for PUT and PATCH method types

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -123,7 +123,11 @@ module Grape
                   dataType = value.is_a?(Hash) ? value[:type]||'String' : 'String'
                   description = value.is_a?(Hash) ? value[:desc] || value[:description] : ''
                   required = value.is_a?(Hash) ? !!value[:required] : false
-                  paramType = path.include?(":#{param}") ? 'path' : (method == 'POST') ? 'form' : 'query'
+                  paramType = if path.include?(":#{param}")
+                    'path'
+                  else
+                    %w[ POST PUT PATCH ].include?(method) ? 'form' : 'query'
+                  end
                   name = (value.is_a?(Hash) && value[:full_name]) || param
                   {
                     paramType: paramType,

--- a/spec/form_params_spec.rb
+++ b/spec/form_params_spec.rb
@@ -1,0 +1,89 @@
+require 'spec_helper'
+
+describe "Form Params" do
+
+  before :all do
+    class FormParamApi < Grape::API
+      format :json
+
+      params do
+        requires :name, type: String, desc: "name of item"
+      end
+      post '/items' do
+        {}
+      end
+
+      params do
+        requires :id, type: Integer, desc: "id of item"
+        requires :name, type: String, desc: "name of item"
+      end
+      put '/items/:id' do
+        {}
+      end
+
+      params do
+        requires :id, type: Integer, desc: "id of item"
+        requires :name, type: String, desc: "name of item"
+      end
+      patch '/items/:id' do
+        {}
+      end
+
+      add_swagger_documentation
+    end
+  end
+
+  def app; FormParamApi; end
+
+  it "retrieves the documentation form params" do
+    get '/swagger_doc/items.json'
+
+    JSON.parse(last_response.body).should == {
+      "apiVersion" => "0.1",
+      "swaggerVersion" => "1.1",
+      "basePath" => "http://example.org",
+      "resourcePath" => "",
+      "apis" => [
+        {
+          "path" => "/items.{format}",
+          "operations" => [
+            {
+              "notes" => nil,
+              "summary" => "",
+              "nickname" => "POST-items---format-",
+              "httpMethod" => "POST",
+              "parameters" => [ { "paramType" => "form", "name" => "name", "description" => "name of item", "dataType" => "String", "required" => true } ]
+            }
+          ]
+        },
+        {
+          "path" => "/items/{id}.{format}",
+          "operations" => [
+            {
+              "notes" => nil,
+              "summary" => "",
+              "nickname" => "PUT-items--id---format-",
+              "httpMethod" => "PUT",
+              "parameters" => [ { "paramType" => "path", "name" => "id", "description" => "id of item", "dataType" => "Integer", "required" => true },
+                                { "paramType" => "form", "name" => "name", "description" => "name of item", "dataType" => "String", "required" => true} ]
+            }
+          ]
+        },
+        {
+          "path" => "/items/{id}.{format}",
+          "operations" => [
+            {
+              "notes" => nil,
+              "summary" => "",
+              "nickname" => "PATCH-items--id---format-",
+              "httpMethod" => "PATCH",
+              "parameters" => [ { "paramType" => "path", "name" => "id", "description" => "id of item", "dataType" => "Integer", "required" => true },
+                                { "paramType" => "form", "name" => "name", "description" => "name of item", "dataType" => "String", "required" => true } ]
+            }
+          ]
+        }
+      ]
+    }
+  end
+
+end


### PR DESCRIPTION
Adds support for form parameter type for PUT and PATCH methods.

Such as the name parameter in the example below.

``` ruby
class FormParamApi < Grape::API
  format :json

  params do
    requires :name, type: String, desc: "name of item"
  end
  post '/items' do
    {}
  end

  params do
    requires :id, type: Integer, desc: "id of item"
    requires :name, type: String, desc: "name of item"
  end
  put '/items/:id' do
    {}
  end

  params do
    requires :id, type: Integer, desc: "id of item"
    requires :name, type: String, desc: "name of item"
  end
  patch '/items/:id' do
    {}
  end

  add_swagger_documentation
end
```
