### PR TITLE
Fixing the :hide_documentation_path option for prefixed APIs

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -17,7 +17,10 @@ module Grape
           next if resource.empty?
           resource.downcase!
           @combined_routes[resource] ||= []
-          @combined_routes[resource] << route
+
+          unless @@hide_documentation_path and route.route_path.include? @@mount_path
+            @combined_routes[resource] << route
+          end
         end
 
       end

--- a/spec/non_default_api_spec.rb
+++ b/spec/non_default_api_spec.rb
@@ -115,6 +115,7 @@ describe "options: " do
 
     it "gets the documentation on a versioned path /v1/swagger_doc" do
       get '/v1/swagger_doc.json'
+
       JSON.parse(last_response.body).should == {
         "apiVersion" => "0.1",
         "swaggerVersion" => "1.1",
@@ -150,7 +151,6 @@ describe "options: " do
 
   context "overriding hiding the documentation paths" do
     before :all do
-
       class HideDocumentationPathMountedApi < Grape::API
         desc 'This gets something.'
         get '/something' do
@@ -178,6 +178,88 @@ describe "options: " do
         ]
       }
     end
+  end
+
+  context "overriding hiding the documentation paths in prefixed API" do
+    before :all do
+      class HideDocumentationPathMountedApi < Grape::API
+        desc 'This gets something.'
+        get '/something' do
+          { bla: 'something' }
+        end
+      end
+
+      class PrefixedApiWithHiddenDocumentation < Grape::API
+        prefix "abc"
+        mount HideDocumentationPathMountedApi
+        add_swagger_documentation :hide_documentation_path => true
+      end
+
+    end
+
+    def app; PrefixedApiWithHiddenDocumentation end
+
+    it "it doesn't show the documentation path on /abc/swagger_doc/abc.json" do
+      get '/abc/swagger_doc/abc.json'
+
+      JSON.parse(last_response.body).should == {
+          "apiVersion"=>"0.1",
+          "swaggerVersion"=>"1.1",
+          "basePath"=>"http://example.org",
+          "resourcePath"=>"",
+          "apis"=>
+              [{"path"=>"/abc/something.{format}",
+                "operations"=>
+                    [{"notes"=>nil,
+                      "summary"=>"This gets something.",
+                      "nickname"=>"GET-abc-something---format-",
+                      "httpMethod"=>"GET",
+                      "parameters"=>[]}]}
+          ]}
+    end
+
+  end
+
+  context "overriding hiding the documentation paths in prefixed and versioned API" do
+    before :all do
+      class HideDocumentationPathMountedApi2 < Grape::API
+        desc 'This gets something.'
+        get '/something' do
+          { bla: 'something' }
+        end
+      end
+
+      class PrefixedAndVersionedApiWithHiddenDocumentation < Grape::API
+        prefix "abc"
+        version 'v20', :using => :path
+
+        mount HideDocumentationPathMountedApi2
+
+        add_swagger_documentation :hide_documentation_path => true, :api_version => self.version
+      end
+    end
+
+    def app; PrefixedAndVersionedApiWithHiddenDocumentation end
+
+    it "it doesn't show the documentation path on /abc/v1/swagger_doc/abc.json" do
+      get '/abc/v20/swagger_doc/abc.json'
+
+      JSON.parse(last_response.body).should == {
+          "apiVersion"=>"v20",
+          "swaggerVersion"=>"1.1",
+          "basePath"=>"http://example.org",
+          "resourcePath"=>"",
+          "apis"=>
+              [{"path"=>"/abc/v20/something.{format}",
+                "operations"=>
+                    [{"notes"=>nil,
+                      "summary"=>"This gets something.",
+                      "nickname"=>"GET-abc--version-something---format-",
+                      "httpMethod"=>"GET",
+                      "parameters"=>[]}]}
+              ]}
+    end
+
   end
 
   context "overriding the mount-path" do


### PR DESCRIPTION
I discovered an issue that when mounting an API like `/api/v1/<some_endpoint>` the :hide_documentation_path just didn't do anything. The reason was that the piece of code with `routes.reject!` only checked the top most path, and didn't recurse down.

I tried myself at a fix and also added two more tests. I don't think it is optimal yet but it works for me.
