### PR TITLE
Support resource groupings for prefixed APIs

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -13,7 +13,7 @@ module Grape
 
         @combined_routes = {}
         routes.each do |route|
-          resource = route.route_path.match('\/(\w*?)[\.\/\(]').captures.first
+          resource = route.route_path.split(route.route_prefix).last.match('\/(\w*?)[\.\/\(]').captures.first
           next if resource.empty?
           resource.downcase!
           @combined_routes[resource] ||= []

--- a/spec/non_default_api_spec.rb
+++ b/spec/non_default_api_spec.rb
@@ -257,7 +257,7 @@ describe "options: " do
     end
   end
 
-  context "versioned API" do
+  context "prefixed and versioned API" do
     before :all do
       class VersionedMountedApi < Grape::API
         prefix 'api'
@@ -278,7 +278,8 @@ describe "options: " do
     def app; SimpleApiWithVersion end
 
     it "parses version and places it in the path" do
-      get '/swagger_doc/api.json'
+      get '/swagger_doc/something.json'
+
       JSON.parse(last_response.body)["apis"].each do |api|
         api["path"].should start_with "/api/v1/"
       end


### PR DESCRIPTION
The fact that an API has a prefix (e.g., /api) should not affect the
way resources are grouped for documentation purposes.  This patch
updates the hardcoded single level of resource grouping to ignore the
prefix (which available as part of the route object).
