### PR TITLE
Added formatting options to swagger metadata

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -42,7 +42,7 @@ module Grape
               :markdown => false,
               :hide_documentation_path => false,
               :hide_format => false,
-              :formatting => {}
+              :format => nil,
             }
             options = defaults.merge(options)
 
@@ -55,9 +55,10 @@ module Grape
             api_version = options[:api_version]
             base_path = options[:base_path]
 
-            [:format, :default_format, :default_error_formatter].each do |method|
-              next unless options[:formatting][method]
-              send(method, options[:formatting][method])
+            if options[:format]
+              [:format, :default_format, :default_error_formatter].each do |method|
+                send(method, options[:format])
+              end
             end
 
             desc 'Swagger compatible API description'

--- a/spec/non_default_api_spec.rb
+++ b/spec/non_default_api_spec.rb
@@ -349,9 +349,7 @@ describe "options: " do
 
       class SimpleJSONFormattedAPI < Grape::API
         mount JSONDefaultFormatAPI
-        add_swagger_documentation formatting: {format: :json,
-                                               default_format: :json,
-                                               default_error_formatter: :json} 
+        add_swagger_documentation format: :json
       end
     end
 


### PR DESCRIPTION
Trying to use the current version of grape-swagger with swagger-ui resulted in some headaches because by default grape-swagger generates API meta-data in XML but swagger-ui and the rest of our APIs at my organization are expecting JSON.

To solve this problem I added a section to setup options called `:formatting`. This hash can accept `:format`, `:default_format`, and `:default_error_formatter`. These options can be passed in when calling `add_swagger_documentation`.

Example

``` ruby
add_swagger_documentation formatting: {format: :json,
                                       default_format: :json,
                                       default_error_formatter: :json}
```
