### PR TITLE
fix for empty captures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ GEM
     coderay (1.0.7)
     descendants_tracker (0.0.1)
     diff-lcs (1.1.3)
+    ffi (1.9.3-java)
     git (1.2.5)
     grape (0.5.0)
       activesupport
@@ -31,6 +32,7 @@ GEM
       rake
       rdoc
     json (1.7.3)
+    json (1.7.3-java)
     kramdown (0.13.7)
     method_source (0.8)
     multi_json (1.7.7)
@@ -39,6 +41,11 @@ GEM
       coderay (~> 1.0.5)
       method_source (~> 0.8)
       slop (~> 3.3.1)
+    pry (0.9.10-java)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.3.1)
+      spoon (~> 0.0)
     rack (1.5.2)
     rack-accept (0.4.5)
       rack (>= 0.4)
@@ -64,11 +71,14 @@ GEM
     shoulda-matchers (1.2.0)
       activesupport (>= 3.0.0)
     slop (3.3.2)
+    spoon (0.0.4)
+      ffi
     virtus (0.5.5)
       backports (~> 3.3)
       descendants_tracker (~> 0.0.1)
 
 PLATFORMS
+  java
   ruby
 
 DEPENDENCIES

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -13,7 +13,9 @@ module Grape
 
         @combined_routes = {}
         routes.each do |route|
-          resource = route.route_path.split(route.route_prefix).last.match('\/([\w|-]*?)[\.\/\(]').captures.first
+          route_match = route.route_path.split(route.route_prefix).last.match('\/([\w|-]*?)[\.\/\(]')
+          next if route_match.nil?
+          resource = route_match.captures.first
           next if resource.empty?
           resource.downcase!
           @combined_routes[resource] ||= []


### PR DESCRIPTION
I found that sometimes grape-swagger tries to generate documentation for paths that dosen't even match base url patern. Specs passes.
