### PR TITLE
if base_path is relative make it absolute using request.base_uri

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -219,7 +219,13 @@ module Grape
             end
 
             def parse_base_path(base_path, request)
-              (base_path.is_a?(Proc) ? base_path.call(request) : base_path) || request.base_url
+              if base_path.is_a?(Proc)
+                base_path.call(request)
+              elsif base_path.is_a?(String)
+                URI(base_path).relative? ? URI.join(request.base_url, base_path).to_s : base_path
+              else
+                request.base_url
+              end
             end
           end
         end

--- a/spec/non_default_api_spec.rb
+++ b/spec/non_default_api_spec.rb
@@ -62,6 +62,35 @@ describe "options: " do
     end
   end
 
+  context "relative base_path" do
+    before :all do
+
+      class RelativeBasePathMountedApi < Grape::API
+        desc 'This gets something.'
+        get '/something' do
+          { bla: 'something' }
+        end
+      end
+
+      class SimpleApiWithRelativeBasePath < Grape::API
+        mount RelativeBasePathMountedApi
+        add_swagger_documentation base_path: "/some_value"
+      end
+    end
+
+    def app; SimpleApiWithRelativeBasePath end
+
+    it "retrieves the given base-path on /swagger_doc" do
+      get '/swagger_doc.json'
+      JSON.parse(last_response.body)["basePath"].should == "http://example.org/some_value"
+    end
+
+    it "retrieves the same given base-path for mounted-api" do
+      get '/swagger_doc/something.json'
+      JSON.parse(last_response.body)["basePath"].should == "http://example.org/some_value"
+    end
+  end
+
   context "overriding the version" do
     before :all do
 


### PR DESCRIPTION
This PR fixes some troubles with relative path and swagger-ui version 1.2.
"The spec says base path needs to be absolute." from here -> https://github.com/wordnik/swagger-ui/issues/114
