### PR TITLE
Add the ability to set API info (title, description, license, terms and contact email)

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -45,9 +45,10 @@ module Grape
               :markdown => false,
               :hide_documentation_path => false,
               :hide_format => false,
-              :models => []
+              :models => [],
+              :info => {}
             }
-            options = defaults.merge(options)
+            options.reverse_merge!(defaults)
 
             target_class = options[:target_class]
             @@mount_path = options[:mount_path]
@@ -57,6 +58,7 @@ module Grape
             @@hide_format = options[:hide_format]
             api_version = options[:api_version]
             base_path = options[:base_path]
+            info = options[:info]
 
             desc 'Swagger compatible API description'
             get @@mount_path do
@@ -78,7 +80,8 @@ module Grape
                 swaggerVersion: "1.1",
                 basePath: parse_base_path(base_path, request),
                 operations:[],
-                apis: routes_array
+                apis: routes_array,
+                info: parse_info(info)
               }
             end
 
@@ -112,15 +115,15 @@ module Grape
                 }
               }.compact
 
-              api_description = {
+              {
                 apiVersion: api_version,
                 swaggerVersion: "1.1",
                 basePath: parse_base_path(base_path, request),
                 resourcePath: "",
                 apis: routes_array
-              }
-              api_description[:models] = parse_entity_models(models) unless models.empty?
-              api_description
+              }.tap do |api_description|
+                api_description[:models] = parse_entity_models(models) unless models.empty?
+              end
             end
           end
 
@@ -149,6 +152,16 @@ module Grape
               end
             end
 
+            def parse_info(info)
+              {
+                contact: info[:contact],
+                description: info[:description],
+                license: info[:license],
+                licenseUrl: info[:license_url],
+                termsOfServiceUrl: info[:terms_of_service_url],
+                title: info[:title]
+              }.delete_if { |key, value| value.blank? }
+            end
 
             def parse_header_params(params)
               if params

--- a/spec/api_models_spec.rb
+++ b/spec/api_models_spec.rb
@@ -30,6 +30,7 @@ describe "API Models" do
       "apiVersion" => "0.1",
       "swaggerVersion" => "1.1",
       "basePath" => "http://example.org",
+      "info" => {},
       "operations" => [],
       "apis" => [
         { "path" => "/swagger_doc/something.{format}" },

--- a/spec/default_api_spec.rb
+++ b/spec/default_api_spec.rb
@@ -2,31 +2,81 @@ require 'spec_helper'
 
 describe "Default API" do
 
-  before :all do
-    class NotAMountedApi < Grape::API
-      format :json
-      desc 'This gets something.'
-      get '/something' do
-        { bla: 'something' }
+  context 'with no additional options' do
+    before :all do
+      class NotAMountedApi < Grape::API
+        format :json
+        desc 'This gets something.'
+        get '/something' do
+          { bla: 'something' }
+        end
+        add_swagger_documentation
       end
-      add_swagger_documentation
+    end
+
+    def app; NotAMountedApi; end
+
+    it "should document something" do
+      get '/swagger_doc'
+      JSON.parse(last_response.body).should == {
+        "apiVersion" => "0.1",
+        "swaggerVersion" => "1.1",
+        "basePath" => "http://example.org",
+        "info" => {},
+        "operations" => [],
+        "apis" => [
+          { "path" => "/swagger_doc/something.{format}" },
+          { "path" => "/swagger_doc/swagger_doc.{format}" }
+        ]
+      }
     end
   end
 
-  def app; NotAMountedApi; end
+  context 'with API info' do
+    before :all do
+      class ApiInfoTest < Grape::API
+        format :json
+        add_swagger_documentation info: {
+          title: 'My API Title',
+          description: 'A description of my API',
+          license: 'Apache 2',
+          license_url: 'http://test.com',
+          terms_of_service_url: 'http://terms.com',
+          contact: 'support@test.com'
+        }
+      end
+      get '/swagger_doc'
+    end
 
-  it "should document something" do
-    get '/swagger_doc'
-    JSON.parse(last_response.body).should == {
-      "apiVersion" => "0.1",
-      "swaggerVersion" => "1.1",
-      "basePath" => "http://example.org",
-      "operations" => [],
-      "apis" => [
-        { "path" => "/swagger_doc/something.{format}" },
-        { "path" => "/swagger_doc/swagger_doc.{format}" }
-      ]
-    }
+    def app; ApiInfoTest; end
+
+    subject do
+      JSON.parse(last_response.body)['info']
+    end
+
+    it 'should document API title' do
+      expect(subject['title']).to eql('My API Title')
+    end
+
+    it 'should document API description' do
+      expect(subject['description']).to eql('A description of my API')
+    end
+
+    it 'should document the license' do
+      expect(subject['license']).to eql('Apache 2')
+    end
+
+    it 'should document the license url' do
+      expect(subject['licenseUrl']).to eql('http://test.com')
+    end
+
+    it 'should document the terms of service url' do
+      expect(subject['termsOfServiceUrl']).to eql('http://terms.com')
+    end
+
+    it 'should document the contact email' do
+      expect(subject['contact']).to eql('support@test.com')
+    end
   end
 
 end

--- a/spec/hide_api_spec.rb
+++ b/spec/hide_api_spec.rb
@@ -30,6 +30,7 @@ describe "a hide mounted api" do
       "apiVersion" => "0.1",
       "swaggerVersion" => "1.1",
       "basePath" => "http://example.org",
+      "info" => {},
       "operations" => [],
       "apis" => [
         { "path" => "/swagger_doc/simple.{format}" },
@@ -70,6 +71,7 @@ describe "a hide mounted api with same namespace" do
       "apiVersion" => "0.1",
       "swaggerVersion" => "1.1",
       "basePath" => "http://example.org",
+      "info" => {},
       "operations" => [],
       "apis" => [
         { "path" => "/swagger_doc/simple.{format}" },

--- a/spec/non_default_api_spec.rb
+++ b/spec/non_default_api_spec.rb
@@ -120,6 +120,7 @@ describe "options: " do
         "apiVersion" => "0.1",
         "swaggerVersion" => "1.1",
         "basePath" => "http://example.org",
+        "info" => {},
         "operations" => [],
         "apis" => [
           { "path" => "/v1/swagger_doc/something.{format}" },
@@ -172,6 +173,7 @@ describe "options: " do
         "apiVersion" => "0.1",
         "swaggerVersion" => "1.1",
         "basePath" => "http://example.org",
+        "info" => {},
         "operations" => [],
         "apis" => [
           { "path" => "/swagger_doc/something.{format}" }
@@ -455,6 +457,7 @@ describe "options: " do
         "apiVersion" => "0.1",
         "swaggerVersion" => "1.1",
         "basePath" => "http://example.org",
+        "info" => {},
         "operations" => [],
         "apis" => [
           { "path" => "/first/swagger_doc/first.{format}" }
@@ -468,6 +471,7 @@ describe "options: " do
         "apiVersion" => "0.1",
         "swaggerVersion" => "1.1",
         "basePath" => "http://example.org",
+        "info" => {},
         "operations" => [],
         "apis" => [
           { "path" => "/second/swagger_doc/second.{format}" }

--- a/spec/simple_mounted_api_spec.rb
+++ b/spec/simple_mounted_api_spec.rb
@@ -72,6 +72,7 @@ describe "a simple mounted api" do
       "apiVersion" => "0.1",
       "swaggerVersion" => "1.1",
       "basePath" => "http://example.org",
+      "info" => {},
       "operations" => [],
       "apis" => [
         { "path" => "/swagger_doc/simple.{format}" },


### PR DESCRIPTION
I needed to have an API introduction and didn't see any way to do this, so I added it. Now you can say:

``` ruby
add_swagger_documentation info: {
  title: 'api title here',
  description: 'a longer description of the api and use cases/etc here',
  contact: 'contact email',
  license: 'the name of the license',
  license_url: 'the url of the license',
  terms_of_service_url: 'the url of the api terms and conditions'
}
```
