### PR TITLE
Adding documentation for swagger spec creation for HTTP status codes

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -140,6 +140,16 @@ desc "Reserve a virgin in heaven", {
 }
 ```
 
+You can also document the HTTP status codes that your API returns with this syntax:
+
+``` ruby
+get '/', :http_codes => [
+  [400, "Invalid parameter entry"],
+] do
+  ...
+end
+```
+
 ## Contributing to grape-swagger
 
 * Check out the latest master to make sure the feature hasn't been implemented or the bug hasn't been fixed yet.


### PR DESCRIPTION
grape-swagger can also generate swagger UI compliant documentation of the HTTP status codes but I couldn't find an explanation anywhere what the syntax for this is.

This commit adds the missing explanation for this.

Related to issue #74
