### PR TITLE
Use GitHub Flavored Markdown for parsing the markdown

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source "http://rubygems.org"
 
 gem 'grape', '>= 0.2.0'
 gem 'grape-entity', '~> 0.3.0'
-gem 'kramdown'
+gem 'github-markdown'
 
 # Add dependencies to develop your gem here.
 # Include everything needed to run rake, tests, features, etc.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ GEM
     diff-lcs (1.1.3)
     ffi (1.9.3-java)
     git (1.2.5)
+    github-markdown (0.6.4)
     grape (0.5.0)
       activesupport
       builder
@@ -33,7 +34,6 @@ GEM
       rdoc
     json (1.7.3)
     json (1.7.3-java)
-    kramdown (0.13.7)
     method_source (0.8)
     multi_json (1.7.7)
     multi_xml (0.5.4)
@@ -83,10 +83,10 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (> 1.0.0)
+  github-markdown
   grape (>= 0.2.0)
   grape-entity (~> 0.3.0)
   jeweler (~> 1.8.4)
-  kramdown
   pry
   rack-test
   rdoc (~> 3.12)

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -1,4 +1,4 @@
-require 'kramdown'
+require 'github/markdown'
 
 module Grape
   class API
@@ -167,7 +167,7 @@ module Grape
           helpers do
 
             def as_markdown(description)
-              description && @@markdown ? Kramdown::Document.new(strip_heredoc(description)).to_html : description
+              description && @@markdown ? GitHub::Markdown.render_gfm(strip_heredoc(description)) : description
             end
 
             def parse_params(params, path, method)


### PR DESCRIPTION
It would really help if we could use GitHub Flavored Markdown. Especially for code snippets.

Since Kramdown uses Coderay for highlighting stuff, it's really hard to customize the highlighting colours (it adds `style="color:..."` to DOM nodes... not nice to override).

Using GFM really just sets the language attribute on DOM nodes. Syntax highlighting can then be more easily done with front-end libraries like Prism, Rainbow, Highlight.js...
