### PR TITLE
Resources don't need versions or {format}, only routes do.

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -92,12 +92,8 @@ module Grape
 
               routes_array = routes.keys.map do |local_route|
                 next if routes[local_route].all?(&:route_hidden)
-
-                parsed_path = route.route_version ? "/#{route.route_version}" : ""
-                parsed_path += "/#{local_route}"
-                parsed_path += '.{format}' unless @@hide_format
                 {
-                  :path => parsed_path,
+                  :path => "/#{local_route}",
                   #:description => "..."
                 }
               end.compact
@@ -130,10 +126,11 @@ module Grape
               header['Access-Control-Request-Method'] = '*'
 
               models = []
+
               routes = target_class::combined_routes[params[:name]]
 
               ops = routes.reject(&:route_hidden).group_by do |route|
-                parse_path(route.route_path, api_version)
+                parse_path(route.route_path, route.route_version)
               end
 
               apis = []

--- a/spec/api_models_spec.rb
+++ b/spec/api_models_spec.rb
@@ -50,9 +50,9 @@ describe "API Models" do
       "produces" => ["application/json"],
       "operations" => [],
       "apis" => [
-        { "path" => "/something.{format}" },
-        { "path" => "/thing.{format}" },
-        { "path" => "/swagger_doc.{format}" }
+        { "path" => "/something" },
+        { "path" => "/thing" },
+        { "path" => "/swagger_doc" }
       ]
     }
   end

--- a/spec/default_api_spec.rb
+++ b/spec/default_api_spec.rb
@@ -26,8 +26,8 @@ describe "Default API" do
         "produces" => ["application/json"],
         "operations" => [],
         "apis" => [
-          { "path" => "/something.{format}" },
-          { "path" => "/swagger_doc.{format}" }
+          { "path" => "/something" },
+          { "path" => "/swagger_doc" }
         ]
       }
     end

--- a/spec/hide_api_spec.rb
+++ b/spec/hide_api_spec.rb
@@ -34,8 +34,8 @@ describe "a hide mounted api" do
       "produces" => ["application/xml", "application/json", "text/plain"],
       "operations" => [],
       "apis" => [
-        { "path" => "/simple.{format}" },
-        { "path" => "/swagger_doc.{format}" }
+        { "path" => "/simple" },
+        { "path" => "/swagger_doc" }
       ]
     }
   end
@@ -76,8 +76,8 @@ describe "a hide mounted api with same namespace" do
       "produces" => ["application/xml", "application/json", "text/plain"],
       "operations" => [],
       "apis" => [
-        { "path" => "/simple.{format}" },
-        { "path" => "/swagger_doc.{format}" }
+        { "path" => "/simple" },
+        { "path" => "/swagger_doc" }
       ]
     }
   end

--- a/spec/non_default_api_spec.rb
+++ b/spec/non_default_api_spec.rb
@@ -153,8 +153,8 @@ describe "options: " do
         "produces" => ["application/xml", "application/json", "text/plain"],
         "operations" => [],
         "apis" => [
-          { "path" => "/v1/something.{format}" },
-          { "path" => "/v1/swagger_doc.{format}" }
+          { "path" => "/something" },
+          { "path" => "/swagger_doc" }
         ]
       }
     end
@@ -168,7 +168,7 @@ describe "options: " do
         "basePath" => "http://example.org",
         "resourcePath" => "",
         "apis" => [{
-          "path" => "/0.1/something.{format}",
+          "path" => "/v1/something.{format}",
           "operations" => [{
             "produces" => ["application/xml", "application/json", "text/plain"],
             "notes" => nil,
@@ -211,7 +211,7 @@ describe "options: " do
         "produces" => ["application/xml", "application/json", "text/plain"],
         "operations" => [],
         "apis" => [
-          { "path" => "/something.{format}" }
+          { "path" => "/something" }
         ]
       }
     end
@@ -500,7 +500,7 @@ describe "options: " do
         "produces" => ["application/xml", "application/json", "text/plain"],
         "operations" => [],
         "apis" => [
-          { "path" => "/first.{format}" }
+          { "path" => "/first" }
         ]
       }
     end
@@ -515,7 +515,7 @@ describe "options: " do
         "produces" => ["application/xml", "application/json", "text/plain"],
         "operations" => [],
         "apis" => [
-          { "path" => "/second.{format}" }
+          { "path" => "/second" }
         ]
       }
     end

--- a/spec/simple_mounted_api_spec.rb
+++ b/spec/simple_mounted_api_spec.rb
@@ -76,12 +76,12 @@ describe "a simple mounted api" do
       "produces" => ["application/xml", "application/json", "text/plain"],
       "operations" => [],
       "apis" => [
-        { "path" => "/simple.{format}" },
-        { "path" => "/simple-test.{format}" },
-        { "path" => "/simple_with_headers.{format}" },
-        { "path" => "/items.{format}" },
-        { "path" => "/custom.{format}" },
-        { "path" => "/swagger_doc.{format}" }
+        { "path" => "/simple" },
+        { "path" => "/simple-test" },
+        { "path" => "/simple_with_headers" },
+        { "path" => "/items" },
+        { "path" => "/custom" },
+        { "path" => "/swagger_doc" }
       ]
     }
   end


### PR DESCRIPTION
I don't think it makes sense to add a version or a `.{format}` to resource names. They don't represent routes, only the name of a combination of resources.

I believe this section is only to link to deeper section. I'm learning as I'm doing this. :)