### PR TITLE
Fix defaultValue.

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -193,7 +193,7 @@ module Grape
                 dataType    = value.is_a?(Hash) ? (value[:type] || 'String').to_s : 'String'
                 description = value.is_a?(Hash) ? value[:desc] || value[:description] : ''
                 required    = value.is_a?(Hash) ? !!value[:required] : false
-                defaultValue = value.is_a?(Hash) ? value[:defaultValue] : nil
+                defaultValue = value.is_a?(Hash) ? value[:default] : nil
                 paramType = if path.include?(":#{param}")
                    'path'
                 else

--- a/spec/grape-swagger_helper_spec.rb
+++ b/spec/grape-swagger_helper_spec.rb
@@ -21,7 +21,7 @@ describe "helpers" do
   context "parsing parameters" do
     it "parses params as query strings for a GET" do
       params = {
-        name: { type: 'String', desc: "A name", required: true, defaultValue: 'default' },
+        name: { type: 'String', desc: "A name", required: true, default: 'default' },
         level: 'max'
       }
       path = "/coolness"


### PR DESCRIPTION
grape-swagger 0.7.2 tries to map
  'defaultValue' -> 'defaultValue'

But there is no such attribute in grape 0.6.1.
This patch makes it work by changing the above to:
  'default' -> 'defaultValue'
