### PR TITLE
Should be able to override the generated nicknames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next Release
 
+* [#100](https://github.com/tim-vandecasteele/grape-swagger/pull/100): Added ability to specify a nickname for an endpoint - [@lhorne](https://github.com/lhorne).
 * [#94](https://github.com/tim-vandecasteele/grape-swagger/pull/94): Added support for namespace descriptions - [@renier](https://github.com/renier).
 * [#110](https://github.com/tim-vandecasteele/grape-swagger/pull/110), [#111](https://github.com/tim-vandecasteele/grape-swagger/pull/111) - Added `responseModel` support - [@bagilevi](https://github.com/bagilevi).
 * [#105](https://github.com/tim-vandecasteele/grape-swagger/pull/105): Fixed compatibility with Swagger-UI - [@CraigCottingham](https://github.com/CraigCottingham).

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ desc 'Hide this endpoint', {
 }
 ```
 
+
+# Overriding auto generated nickname for an endpoint
+
+You can specify a swagger nickname to use instead of the auto generated name by adding ```:nickname => 'string'``` in the description of the endpoint.
+
+``` ruby
+desc 'get a full list of Pets', {
+  :nickname => 'getAllPets'
+}
+```
+
+
 ## Grape Entities
 
 Add the [grape-entity](https://github.com/agileanimal/grape-entity) gem to our Gemfile.

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -178,6 +178,7 @@ module Grape
                     end
                   end
 
+                  operation[:nickname] = route.route_nickname if route.route_nickname
                   operation
                 end.compact
                 apis << {

--- a/spec/non_default_api_spec.rb
+++ b/spec/non_default_api_spec.rb
@@ -590,4 +590,26 @@ describe 'options: ' do
       expect(subject['description']).to eql('Description for aspace')
     end
   end
+
+  context 'override nickname' do
+    before :all do
+      class NicknameAPI < Grape::API
+        desc 'This gets something.', nickname: 'getSomething'
+        get '/something' do
+          { bla: 'something' }
+        end
+        add_swagger_documentation
+      end
+    end
+
+    def app
+      NicknameAPI
+    end
+
+    it 'documents the user-specified nickname' do
+      get '/swagger_doc/something.json'
+      ret = JSON.parse(last_response.body)
+      ret['apis'][0]['operations'][0]['nickname'].should == 'getSomething'
+    end
+  end
 end


### PR DESCRIPTION
Currently we have to accept the nickname that is auto generated for each operation. It would be nice to be able to specify a nickname in the endpoint directly.

/Leon

Fixing CHANGELOG.markdown to accout for the 0.7.2 release,
Adding override of auto generated nickname.
