### PR TITLE
added responseModel support

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -140,9 +140,8 @@ module Grape
               ops.each do |path, routes|
                 operations = routes.map do |route|
                   notes       = as_markdown(route.route_notes)
-                  http_codes  = parse_http_codes(route.route_http_codes)
-
                   models << route.route_entity if route.route_entity
+                  http_codes  = parse_http_codes(route.route_http_codes, models)
 
                   operation = {
                     :produces   => content_types_for(target_class),
@@ -309,13 +308,14 @@ module Grape
               result
             end
 
-            def parse_http_codes codes
+            def parse_http_codes codes, models
               codes ||= {}
-              codes.map do |k, v|
+              codes.map do |k, v, m|
+                models << m if m
                 {
                   code: k,
                   message: v,
-                  #responseModel: ...
+                  responseModel: (parse_entity_name(m) if m)
                 }
               end
             end

--- a/spec/response_model_spec.rb
+++ b/spec/response_model_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe "responseModel" do
+  before :all do
+    module Entities
+      class Something < Grape::Entity
+        expose :text, :documentation => { :type => "string", :desc => "Content of something." }
+      end
+
+      class Error < Grape::Entity
+        expose :code, :documentation => { :type => "string", :desc => "Error code" }
+        expose :message, :documentation => { :type => "string", :desc => "Error message" }
+      end
+    end
+
+    class ResponseModelApi < Grape::API
+      format :json
+      desc 'This returns something or an error', {
+        entity: Entities::Something,
+        http_codes: [
+          [200, "OK", Entities::Something],
+          [403, "Refused to return something", Entities::Error]
+        ]
+      }
+      get '/something/:id' do
+        if params[:id] == 1
+          something = OpenStruct.new text: 'something'
+          present something, with: Entities::Something
+        else
+          error = OpenStruct.new code: 'some_error', message: "Some error"
+          present error, with: Entities::Error
+        end
+      end
+
+      add_swagger_documentation
+    end
+  end
+
+  def app; ResponseModelApi; end
+
+  it "should document specified models" do
+    get '/swagger_doc/something'
+    parsed_response = JSON.parse(last_response.body)
+    parsed_response["apis"][0]["operations"][0]["responseMessages"].should == 
+      [
+        {
+          "code"=>200,
+          "message"=>"OK",
+          "responseModel"=>"Something"
+        },
+        {
+          "code"=>403,
+          "message"=>"Refused to return something",
+          "responseModel"=>"Error"
+        }
+      ]
+    parsed_response["models"].keys.should include "Error"
+    parsed_response["models"]["Error"].should == {
+      "id" => "Error",
+      "name" => "Error",
+      "properties" => {
+        "code" => { "type" => "string", "description" => "Error code" },
+        "message" => { "type" => "string", "description" => "Error message" }
+      }
+    }
+  end
+end


### PR DESCRIPTION
Include the entity defined in `http_codes` as a `responseModel`.

Example:

```
desc 'This returns something or an error', {
  entity: Entities::Something,
  http_codes: [
    [200, "OK", Entities::Something],
    [403, "Refused to return something", Entities::Error]
  ]
}
```
