### PR TITLE
added a look up for nested presenters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Rewritten .gemspec and removed Jeweler - [@dblock](https://github.com/dblock).
 * Added `GrapeEntity::VERSION` - [@dblock](https://github.com/dblock).
 * Added Rubocop, Ruby-style linter - [@dblock](https://github.com/dblock).
+* Adding support for generating nested models from composed Grape Entities [@dspaeth-faber](https://github.com/dspaeth-faber)
 * Your Contribution Here
 
 ### 0.7.2 (February 6, 2014)

--- a/README.md
+++ b/README.md
@@ -106,6 +106,16 @@ module API
   module Entities
     class Status < Grape::Entity
       expose :text, :documentation => { :type => "string", :desc => "Status update text." }
+      expose :links, using: Link, :documentation => { type: 'link', is_array: true }
+    end
+    
+    class Link < Grape::Entity
+      def self.entity_name 
+        'link'
+      end
+    
+      expose :href, :documentation => { :type => 'url' }
+      expose :rel, :documentation => { :type => 'string'}
     end
   end
 

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -150,7 +150,7 @@ module Grape
                               route.route_entity
                             end
 
-                  models = models.flatten.compact
+                  models = models_with_included_presenters(models.flatten.compact)
 
                   operation = {
                     notes: notes.to_s,
@@ -376,6 +376,26 @@ module Grape
               end
 
               result
+            end
+
+            def models_with_included_presenters(models)
+              all_models = models
+
+              models.each do |model|
+                properties = model.exposures
+                documented_properties = {}
+
+                model.documentation.keys.each_with_object(documented_properties) do |k, hash|
+                  hash[k] = properties[k] if properties.key?(k)
+                end
+
+                properties_configuration = documented_properties.values
+                additional_models = properties_configuration.map { |config| config[:using] }.compact
+
+                all_models += additional_models
+              end
+
+              all_models
             end
 
             def is_primitive?(type)


### PR DESCRIPTION
When you expose a property with a presenter like this:

``` ruby
expose :links, using: Link, :documentation => { type: 'array', items: {'$ref' => 'link'} }
```

The Link entity does not apear in the documentation unless you use it direktly for another action.
With this PR directly used presenters (not recursivly) are looked up and used.

Furthor more  I did change parse_entity_name to use `instance_variable_get(:@root)`
because the property name must match my $ref entry. When you dont change this
the shown model name can differ from the linked one. Example:

``` ruby
module API
  class Link < Grape::Entity
      root 'links', 'link'
  end
end
```

Would be displayed as "link" for the Modelname, but I have to define

``` ruby
expose :links, using: Link, :documentation => { type: 'array', items: {'$ref' => 'API::Link'} }
```

And swagger would display the property like this:

links (array[API::Link], optional)
