### PR TITLE
combined global models with endpoint entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Added Rubocop, Ruby-style linter - [@dblock](https://github.com/dblock).
 * [#126](https://github.com/tim-vandecasteele/grape-swagger/pull/126): Rewritten demo in the `test` folder with CORS enabled - [@dblock](https://github.com/dblock).
 * [#127](https://github.com/tim-vandecasteele/grape-swagger/pull/127): Fixed `undefined method 'reject' for nil:NilClass` error for an invalid route, now returning 404 Not Found - [@dblock](https://github.com/dblock).
+* [#128](https://github.com/tim-vandecasteele/grape-swagger/pull/128): Combine global models and endpoint entities - [@dspaeth-faber](https://github.com/dspaeth-faber).
 * Your Contribution Here
 
 ### 0.7.2 (February 6, 2014)

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -147,11 +147,9 @@ module Grape
 
                   http_codes  = parse_http_codes(route.route_http_codes, models)
 
-                  models << if @@models.present?
-                              @@models
-                            elsif route.route_entity.present?
-                              route.route_entity
-                            end
+                  models << @@models if @@models.present?
+
+                  models << route.route_entity if route.route_entity.present?
 
                   models = models_with_included_presenters(models.flatten.compact)
 

--- a/spec/api_global_models_spec.rb
+++ b/spec/api_global_models_spec.rb
@@ -8,6 +8,10 @@ describe 'Global Models' do
         class Thing < Grape::Entity
           expose :text, documentation: { type: 'string', desc: 'Content of something.' }
         end
+
+        class CombinedThing < Grape::Entity
+          expose :text, documentation: { type: 'string', desc: 'Content of something.' }
+        end
       end
     end
   end
@@ -18,6 +22,14 @@ describe 'Global Models' do
       get '/thing' do
         thing = OpenStruct.new text: 'thing'
         present thing, with: Entities::Some::Thing
+      end
+
+      desc 'This gets combined thing.',
+           params: Entities::Some::CombinedThing.documentation,
+           entity: Entities::Some::CombinedThing
+      get '/combined_thing' do
+        thing = OpenStruct.new text: 'thing'
+        present thing, with: Entities::Some::CombinedThing
       end
 
       add_swagger_documentation models: [Entities::Some::Thing]
@@ -38,5 +50,27 @@ describe 'Global Models' do
             'text' => { 'type' => 'string', 'description' => 'Content of something.' }
           }
         })
+  end
+
+  it 'uses global models and route endpoint specific entities together' do
+    get '/swagger_doc/combined_thing.json'
+    json = JSON.parse(last_response.body)
+
+    expect(json['models']).to include(
+                                  'Some::Thing' => {
+                                    'id' => 'Some::Thing',
+                                    'properties' => {
+                                      'text' => { 'type' => 'string', 'description' => 'Content of something.' }
+                                    }
+                                  })
+
+    expect(json['models']).to include(
+                                  'Some::CombinedThing' => {
+                                    'id' => 'Some::CombinedThing',
+                                    'properties' => {
+                                      'text' => { 'type' => 'string', 'description' => 'Content of something.' }
+                                    }
+                                  })
+
   end
 end


### PR DESCRIPTION
Global models override entities defined with an endpoint. I think it's preferable to combine these models. 
