### PR TITLE
Fixed fetching namespace options for mounted APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ### Next Release
 
-* [#136](https://github.com/tim-vandecasteele/grape-swagger/pull/134): Recurse combination of namespaces when using mounted apps. Improvement to [#94](https://github.com/tim-vandecasteele/grape-swagger/pull/94) - [@renier](https://github.com/renier).
+* [#136](https://github.com/tim-vandecasteele/grape-swagger/pull/136), [#94](https://github.com/tim-vandecasteele/grape-swagger/pull/94): Recurse combination of namespaces when using mounted apps - [@renier](https://github.com/renier).
 * [#100](https://github.com/tim-vandecasteele/grape-swagger/pull/100): Added ability to specify a nickname for an endpoint - [@lhorne](https://github.com/lhorne).
 * [#94](https://github.com/tim-vandecasteele/grape-swagger/pull/94): Added support for namespace descriptions - [@renier](https://github.com/renier).
 * [#110](https://github.com/tim-vandecasteele/grape-swagger/pull/110), [#111](https://github.com/tim-vandecasteele/grape-swagger/pull/111) - Added `responseModel` support - [@bagilevi](https://github.com/bagilevi).

--- a/spec/namespaced_api_spec.rb
+++ b/spec/namespaced_api_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+describe 'namespace' do
+  context 'at root level' do
+    def app
+      Class.new(Grape::API) do
+        namespace :aspace, desc: 'Description for aspace' do
+          get '/'
+        end
+        add_swagger_documentation format: :json
+      end
+    end
+
+    subject do
+      get '/swagger_doc'
+      JSON.parse(last_response.body)['apis'][0]
+    end
+
+    it 'shows the namespace description in the json spec' do
+      expect(subject['description']).to eql('Description for aspace')
+    end
+  end
+
+  context 'mounted' do
+    def app
+      namespaced_api = Class.new(Grape::API) do
+        namespace :aspace, desc: 'Description for aspace' do
+          get '/'
+        end
+      end
+
+      Class.new(Grape::API) do
+        mount namespaced_api
+        add_swagger_documentation format: :json
+      end
+    end
+
+    subject do
+      get '/swagger_doc'
+      JSON.parse(last_response.body)['apis'][0]
+    end
+
+    it 'shows the namespace description in the json spec' do
+      expect(subject['description']).to eql('Description for aspace')
+    end
+  end
+end

--- a/spec/non_default_api_spec.rb
+++ b/spec/non_default_api_spec.rb
@@ -583,7 +583,6 @@ describe 'options: ' do
       expect(subject.headers['Content-Type']).to eq 'application/json'
       expect(-> { JSON.parse(subject.body) }).to_not raise_error
     end
-
   end
 
   context 'documented namespace description' do


### PR DESCRIPTION
This fixes the scenario where an API is mounted by another API, in the simple case. 

There's a bigger issue is that namespaces can nest and that swagger namespaces != grape namespaces, but that's another can of worms, https://github.com/tim-vandecasteele/grape-swagger/issues/130.
