### PR TITLE
Addes support for enum values in entity documentation and form parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@
 * [#126](https://github.com/tim-vandecasteele/grape-swagger/pull/126): Rewritten demo in the `test` folder with CORS enabled - [@dblock](https://github.com/dblock).
 * [#127](https://github.com/tim-vandecasteele/grape-swagger/pull/127): Fixed `undefined method 'reject' for nil:NilClass` error for an invalid route, now returning 404 Not Found - [@dblock](https://github.com/dblock).
 * [#128](https://github.com/tim-vandecasteele/grape-swagger/pull/128): Combine global models and endpoint entities - [@dspaeth-faber](https://github.com/dspaeth-faber).
-* Added support for values in form parameters - [@Antek-drzewiecki](https://github.com/Antek-drzewiecki)
+* [#132](https://github.com/tim-vandecasteele/grape-swagger/pull/132): Addes support for enum values in entity documentation and form parameters - [@Antek-drzewiecki](https://github.com/Antek-drzewiecki).
 * Your Contribution Here
 
 ### 0.7.2 (February 6, 2014)

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ module API
     class Status < Grape::Entity
       expose :text, documentation: { type: 'string', desc: 'Status update text.' }
       expose :links, using: Link, documentation: { type: 'link', is_array: true }
+      expose :numbers, documentation: { type: 'integer', desc: 'favourite number', values: [1,2,3,4] }
     end
 
     class Link < Grape::Entity
@@ -214,6 +215,11 @@ module API
       statuses = Status.all
       type = current_user.admin? ? :full : :default
       present statuses, with: API::Entities::Status, type: type
+    end
+    
+    desc 'Creates a new status', entity: API::Entities::Status, params: API::Entities::Status.documentation
+    post '/statuses' do
+        ...
     end
   end
 end

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -240,10 +240,9 @@ module Grape
                 required      = value.is_a?(Hash) ? !!value[:required] : false
                 default_value = value.is_a?(Hash) ? value[:default] : nil
                 is_array      = value.is_a?(Hash) ? (value[:is_array] || false) : false
-                enum_values        = value.is_a?(Hash) ? value[:values] : nil
-                if enum_values && enum_values.is_a?(Proc)
-                  enum_values = enum_values.call
-                end
+                enum_values   = value.is_a?(Hash) ? value[:values] : nil
+                enum_values   = enum_values.call if enum_values && enum_values.is_a?(Proc)
+
                 if value.is_a?(Hash) && value.key?(:param_type)
                   param_type  = value[:param_type]
                   if is_array
@@ -377,7 +376,15 @@ module Grape
                   property_description = p.delete(:desc)
                   p[:description] = property_description if property_description
 
+                  # rename Grape's 'values' to 'enum'
+                  select_values = p.delete(:values)
+                  if select_values
+                    select_values = select_values.call if select_values.is_a?(Proc)
+                    p[:enum] = select_values
+                  end
+
                   properties[property_name] = p
+
                 end
 
                 result[name] = {

--- a/spec/form_params_spec.rb
+++ b/spec/form_params_spec.rb
@@ -15,7 +15,7 @@ describe 'Form Params' do
       params do
         requires :id, type: Integer, desc: 'id of item'
         requires :name, type: String, desc: 'name of item'
-        requires :conditions, type: Integer, desc: 'conditions of item', values: [1,2,3]
+        requires :conditions, type: Integer, desc: 'conditions of item', values: [1, 2, 3]
       end
       put '/items/:id' do
         {}
@@ -24,7 +24,7 @@ describe 'Form Params' do
       params do
         requires :id, type: Integer, desc: 'id of item'
         requires :name, type: String, desc: 'name of item'
-        optional :conditions, type: String, desc: 'conditions of item', values: Proc.new {['1','2']}
+        optional :conditions, type: String, desc: 'conditions of item', values: proc { %w(1 2) }
       end
       patch '/items/:id' do
         {}
@@ -63,9 +63,9 @@ describe 'Form Params' do
             'nickname' => 'PUT-items--id---format-',
             'method' => 'PUT',
             'parameters' => [
-                { 'paramType' => 'path', 'name' => 'id', 'description' => 'id of item', 'type' => 'integer', 'required' => true, 'allowMultiple' => false, 'format' => 'int32' },
-                { 'paramType' => 'form', 'name' => 'name', 'description' => 'name of item', 'type' => 'string', 'required' => true, 'allowMultiple' => false },
-                { 'paramType' => 'form', 'name' => 'conditions', 'description' => 'conditions of item', 'type' => 'integer', 'required' => true, 'allowMultiple' => false, 'format' => 'int32', 'enum' => [1,2,3] }
+              { 'paramType' => 'path', 'name' => 'id', 'description' => 'id of item', 'type' => 'integer', 'required' => true, 'allowMultiple' => false, 'format' => 'int32' },
+              { 'paramType' => 'form', 'name' => 'name', 'description' => 'name of item', 'type' => 'string', 'required' => true, 'allowMultiple' => false },
+              { 'paramType' => 'form', 'name' => 'conditions', 'description' => 'conditions of item', 'type' => 'integer', 'required' => true, 'allowMultiple' => false, 'format' => 'int32', 'enum' => [1, 2, 3] }
             ],
             'type' => 'void'
           },
@@ -75,9 +75,9 @@ describe 'Form Params' do
             'nickname' => 'PATCH-items--id---format-',
             'method' => 'PATCH',
             'parameters' => [
-                { 'paramType' => 'path', 'name' => 'id', 'description' => 'id of item', 'type' => 'integer', 'required' => true, 'allowMultiple' => false, 'format' => 'int32' },
-                { 'paramType' => 'form', 'name' => 'name', 'description' => 'name of item', 'type' => 'string', 'required' => true, 'allowMultiple' => false },
-                { 'paramType' => 'form', 'name' => 'conditions', 'description' => 'conditions of item', 'type' => 'string', 'required' => false, 'allowMultiple' => false, 'enum' => ['1','2'] }
+              { 'paramType' => 'path', 'name' => 'id', 'description' => 'id of item', 'type' => 'integer', 'required' => true, 'allowMultiple' => false, 'format' => 'int32' },
+              { 'paramType' => 'form', 'name' => 'name', 'description' => 'name of item', 'type' => 'string', 'required' => true, 'allowMultiple' => false },
+              { 'paramType' => 'form', 'name' => 'conditions', 'description' => 'conditions of item', 'type' => 'string', 'required' => false, 'allowMultiple' => false, 'enum' => %w(1 2) }
             ],
             'type' => 'void'
           }


### PR DESCRIPTION
Grape supports has a value restrictions trough arrays or Proc. Swagger UI supports form parameter restrictions trough the enum field. You can also document an entity enum values with the enum field in Swagger UI.  This push request adds parameter value integration between Grape (Entity) and Swagger UI.

Usage:

``` ruby
class Status < Grape::Entity
  expose :text, documentation: { type: 'string', desc: 'Status update text.' }
  expose :links, using: Link, documentation: { type: 'link', is_array: true }
  expose :numbers, documentation: { type: 'integer', desc: 'favourite number', values: [1,2,3,4] } 
end

desc 'Creates a new status', entity: API::Entities::Status, params: API::Entities::Status.documentation
post '/statuses' do
        ...
end

desc 'Creates a new status', entity: API::Entities::Status 
params do
   required :numbers , type: Integer, values:[1,2,3]
   ...
end
post '/statuses' do
  ...
end 
```
