### PR TITLE
Recurse combination of namespaces when using mounted apps.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ### Next Release
 
+* [#136](https://github.com/tim-vandecasteele/grape-swagger/pull/134): Recurse combination of namespaces when using mounted apps. Improvement to [#94](https://github.com/tim-vandecasteele/grape-swagger/pull/94) - [@renier](https://github.com/renier).
 * [#100](https://github.com/tim-vandecasteele/grape-swagger/pull/100): Added ability to specify a nickname for an endpoint - [@lhorne](https://github.com/lhorne).
 * [#94](https://github.com/tim-vandecasteele/grape-swagger/pull/94): Added support for namespace descriptions - [@renier](https://github.com/renier).
 * [#110](https://github.com/tim-vandecasteele/grape-swagger/pull/110), [#111](https://github.com/tim-vandecasteele/grape-swagger/pull/111) - Added `responseModel` support - [@bagilevi](https://github.com/bagilevi).

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -25,13 +25,19 @@ module Grape
         end
 
         @combined_namespaces = {}
-        endpoints.each do |endpoint|
-          ns = endpoint.settings.stack.last[:namespace]
-          @combined_namespaces[ns.space] = ns if ns
-        end
+        combine_namespaces(self)
       end
 
       private
+
+      def combine_namespaces(app)
+        app.endpoints.each do |endpoint|
+          ns = endpoint.settings.stack.last[:namespace]
+          @combined_namespaces[ns.space] = ns if ns
+
+          combine_namespaces(endpoint.options[:app]) if endpoint.options[:app]
+        end
+      end
 
       def create_documentation_class
         Class.new(Grape::API) do

--- a/spec/non_default_api_spec.rb
+++ b/spec/non_default_api_spec.rb
@@ -588,6 +588,15 @@ describe 'options: ' do
 
   context 'documented namespace description' do
     before :all do
+      class NestedNamespaceWithDescAPI < Grape::API
+        namespace :nestedspace, desc: 'Description for nested space' do
+          desc 'Nested get'
+          get '/somethingelse' do
+            { foo: 'bar' }
+          end
+        end
+      end
+
       class NamespaceWithDescAPI < Grape::API
         namespace :aspace, desc: 'Description for aspace' do
           desc 'This gets something.'
@@ -595,6 +604,9 @@ describe 'options: ' do
             { bla: 'something' }
           end
         end
+
+        mount NestedNamespaceWithDescAPI
+
         add_swagger_documentation format: :json
       end
       get '/swagger_doc'
@@ -605,11 +617,15 @@ describe 'options: ' do
     end
 
     subject do
-      JSON.parse(last_response.body)['apis'][0]
+      JSON.parse(last_response.body)['apis']
     end
 
     it 'shows the namespace description in the json spec' do
-      expect(subject['description']).to eql('Description for aspace')
+      expect(subject[0]['description']).to eql('Description for aspace')
+    end
+
+    it 'shows the nested namespace description in the json spec' do
+      expect(subject[1]['description']).to eql('Description for nested space')
     end
   end
 


### PR DESCRIPTION
This is an improvement on #94. The combining of namespaces, so that the proper descriptions could be pulled out and added to the swagger docs, was not working when using mounted apps in Grape.
