### PR TITLE
Add version handling

### DIFF
--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -5,11 +5,11 @@
 
 Gem::Specification.new do |s|
   s.name = "grape-swagger"
-  s.version = "0.7.1"
+  s.version = "0.7.2"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Tim Vandecasteele"]
-  s.date = "2014-02-04"
+  s.date = "2014-02-06"
   s.description = "A simple way to add proper auto generated documentation - that can be displayed with swagger - to your inline described grape API"
   s.email = "tim.vandecasteele@gmail.com"
   s.extra_rdoc_files = [
@@ -38,7 +38,9 @@ Gem::Specification.new do |s|
     "spec/hide_api_spec.rb",
     "spec/non_default_api_spec.rb",
     "spec/simple_mounted_api_spec.rb",
-    "spec/spec_helper.rb"
+    "spec/spec_helper.rb",
+    "test/config.ru",
+    "test/nested_api.rb"
   ]
   s.homepage = "http://github.com/tim-vandecasteele/grape-swagger"
   s.licenses = ["MIT"]


### PR DESCRIPTION
Give ability to grape-swagger to distinguish  and handle multiple grape api versions.

Repurposing api_version to pull desired version from query string.
Only routes for the specified version will be returned

Possible related issues:
[141](https://github.com/tim-vandecasteele/grape-swagger/issues/141)
[146](https://github.com/tim-vandecasteele/grape-swagger/issues/146)
[38](https://github.com/tim-vandecasteele/grape-swagger/issues/38)