### PR TITLE
Allow Classes for type declarations inside documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.8.1 (Next)
 
 * Your contribution here.
+* [#154](https://github.com/tim-vandecasteele/grape-swagger/pull/154):  Allow Classes for type declarations inside documentation - [@mrmargolis](https://github.com/mrmargolis).
 
 ### 0.8.0 (August 30, 2014)
 

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -426,6 +426,7 @@ module Grape
             end
 
             def generate_typeref(type)
+              type = type.to_s.sub(/^[A-Z]/) { |f| f.downcase } if type.is_a?(Class)
               if is_primitive? type
                 { 'type' => type }
               else

--- a/spec/api_global_models_spec.rb
+++ b/spec/api_global_models_spec.rb
@@ -7,10 +7,12 @@ describe 'Global Models' do
       module Some
         class Thing < Grape::Entity
           expose :text, documentation: { type: 'string', desc: 'Content of something.' }
+          expose :name, documentation: { type: String, desc: 'Name of something.' }
         end
 
         class CombinedThing < Grape::Entity
           expose :text, documentation: { type: 'string', desc: 'Content of something.' }
+          expose :created_at, documentation: { type: DateTime, desc: 'Creation of something.' }
         end
       end
     end
@@ -47,7 +49,8 @@ describe 'Global Models' do
         'Some::Thing' => {
           'id' => 'Some::Thing',
           'properties' => {
-            'text' => { 'type' => 'string', 'description' => 'Content of something.' }
+            'text' => { 'type' => 'string', 'description' => 'Content of something.' },
+            'name' => { 'type' => 'string', 'description' => 'Name of something.' }
           }
         })
   end
@@ -60,7 +63,8 @@ describe 'Global Models' do
                                   'Some::Thing' => {
                                     'id' => 'Some::Thing',
                                     'properties' => {
-                                      'text' => { 'type' => 'string', 'description' => 'Content of something.' }
+                                      'text' => { 'type' => 'string', 'description' => 'Content of something.' },
+                                      'name' => { 'type' => 'string', 'description' => 'Name of something.' }
                                     }
                                   })
 
@@ -68,7 +72,8 @@ describe 'Global Models' do
                                   'Some::CombinedThing' => {
                                     'id' => 'Some::CombinedThing',
                                     'properties' => {
-                                      'text' => { 'type' => 'string', 'description' => 'Content of something.' }
+                                      'text' => { 'type' => 'string', 'description' => 'Content of something.' },
+                                      'created_at' => { 'type' => 'dateTime', 'description' => 'Creation of something.' }
                                     }
                                   })
 


### PR DESCRIPTION
Grape requires types to be specified using Classes, not strings.  This was problematic when using Entity.documentation to specify params restrictions while also exposing the entity as a Model to grape-swagger.

```
           module Entities
             class Game < Grape::Entity
                expose :level_name, documentation: { type: String }
             end
           end


          #in a grape endpoint
           params do
             requires :all, using: Entities::Game.documentation
           end
```

Without this patch the above code causes grape-swagger to consider String distinct from 'string' when type checking for swagger output on Models.  This breaks the swagger UI with "this.dataType.toLowerCase is not a function swagger"
