### PR TITLE
Route prefixes can be symbols

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -17,7 +17,7 @@ module Grape
 
         @combined_routes = {}
         routes.each do |route|
-          route_match = route.route_path.split(route.route_prefix).last.match('\/([\w|-]*?)[\.\/\(]')
+          route_match = route.route_path.split(route.route_prefix.to_s).last.match('\/([\w|-]*?)[\.\/\(]')
           next if route_match.nil?
           resource = route_match.captures.first
           next if resource.empty?


### PR DESCRIPTION
Symbols can't be used to split. So whenever the prefix is a `Symbol`, 

```
TypeError: wrong argument type Symbol (expected Regexp)
```

Since prefixes can't be anything else than a `String` or `Symbol`, you can safely convert to a `String`.
