### PR TITLE
Work with symbol as with string

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -17,7 +17,7 @@ module Grape
 
         @combined_routes = {}
         routes.each do |route|
-          route_match = route.route_path.split(route.route_prefix).last.match('\/([\w|-]*?)[\.\/\(]')
+          route_match = route.route_path.split(route.route_prefix.to_s).last.match('\/([\w|-]*?)[\.\/\(]')
           next if route_match.nil?
           resource = route_match.captures.first
           next if resource.empty?


### PR DESCRIPTION
In Grape you can add prefix as string or symbol (https://github.com/intridea/grape#basic-usage), but symbol prefix cause an error grape-swagger. This pull request fixed it
