### PR TITLE
Fix for Virtus::Attribute::Boolean data type

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -240,6 +240,8 @@ module Grape
 
                 raw_data_type = value.is_a?(Hash) ? (value[:type] || 'string').to_s : 'string'
                 data_type     = case raw_data_type
+                                when "Virtus::Attribute::Boolean"
+                                  'boolean'
                                 when 'Boolean', 'Date', 'Integer', 'String'
                                   raw_data_type.downcase
                                 when 'BigDecimal'


### PR DESCRIPTION
This converts this datatype now seen in the newest Grape rails conversions into the proper type for Swagger
