### PR TITLE
Fix problem with using prefix name somewhere in api paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * [#162](https://github.com/tim-vandecasteele/grape-swagger/pull/162): Fix performance issue related to having a large number of models - [@elado](https://github.com/elado).
 * [#169](https://github.com/tim-vandecasteele/grape-swagger/pull/169): Test against multiple versions of Grape - [@dblock](https://github.com/dblock).
 * [#166](https://github.com/tim-vandecasteele/grape-swagger/pull/166): Ensure compatibility with Grape 0.8.0 or newer - [@dblock](https://github.com/dblock).
+* [#174](https://github.com/tim-vandecasteele/grape-swagger/pull/172): Fix problem with using prefix name somewhere in api paths - [@grzesiek](https://github.com/grzesiek).
+
 * Your contribution here.
 
 ### 0.8.0 (August 30, 2014)

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -17,7 +17,7 @@ module Grape
 
         @combined_routes = {}
         routes.each do |route|
-          route_match = route.route_path.split(route.route_prefix).last.match('\/([\w|-]*?)[\.\/\(]')
+          route_match = route.route_path.split(/^.*?#{route.route_prefix.to_s}/).last.match('\/([\w|-]*?)[\.\/\(]')
           next if route_match.nil?
           resource = route_match.captures.first
           next if resource.empty?

--- a/spec/api_paths_spec.rb
+++ b/spec/api_paths_spec.rb
@@ -1,0 +1,67 @@
+require 'spec_helper'
+
+describe 'simple api with prefix' do
+
+  before :all do
+    class ApiWithPrefix < Grape::API
+      prefix :api
+
+      desc 'This gets apitest'
+      get '/apitest' do
+        { test: 'something' }
+      end
+    end
+
+    class SimpleApiWithPrefix < Grape::API
+      mount ApiWithPrefix
+      add_swagger_documentation
+    end
+
+  end
+
+  def app
+    SimpleApiWithPrefix
+  end
+
+  it 'should not raise TypeError exception' do
+  end
+
+  it 'retrieves swagger-documentation on /swagger_doc that contains apitest' do
+    get '/swagger_doc.json'
+    expect(JSON.parse(last_response.body)).to eq(
+      'apiVersion' => '0.1',
+      'swaggerVersion' => '1.2',
+      'info' => {},
+      'produces' => Grape::ContentTypes::CONTENT_TYPES.values.uniq,
+      'apis' => [
+        { 'path' => '/apitest.{format}', 'description' => 'Operations about apitests' },
+        { 'path' => '/swagger_doc.{format}', 'description' => 'Operations about swagger_docs' }
+      ]
+    )
+  end
+
+  context 'retrieves the documentation for apitest that' do
+    it 'contains returns something in URL' do
+      get '/swagger_doc/apitest.json'
+      expect(JSON.parse(last_response.body)).to eq(
+        'apiVersion' => '0.1',
+        'swaggerVersion' => '1.2',
+        'basePath' => 'http://example.org',
+        'resourcePath' => '/apitest',
+        'produces' => Grape::ContentTypes::CONTENT_TYPES.values.uniq,
+        'apis' => [{
+          'path' => '/api/apitest.{format}',
+          'operations' => [{
+            'notes' => '',
+            'summary' => 'This gets apitest',
+            'nickname' => 'GET-api-apitest---format-',
+            'method' => 'GET',
+            'parameters' => [],
+            'type' => 'void'
+          }]
+        }]
+      )
+    end
+  end
+
+end


### PR DESCRIPTION
Hi. 

I've encountered problem with generating documentation when I used prefix string somewhere is API path.
For example, you can use `prefix :api` and use

``` ruby
get :apitest do
  "test api"
end
```

Generated path for this, is, for example, `/api/something/apitest`.

The problem is when in

``` ruby
route_match = route.route_path.split(route.route_prefix).last.match('\/([\w|-]*?)[\.\/\(]')
```

`route_path` is spitted incorrectly because second "api" is also matched.

My solutions changes this code to match only first `route_prefix` occurrence (greedy RegExp). This is quick solution, and probably needs deeper investigation. It also fixes problem with

``` ruby
grape-swagger-0.8.0/lib/grape-swagger.rb:20:in `split': wrong argument type Symbol (expected Regexp) (TypeError)
```

what happens when prefix is a Symbol.

Kind regards,
 Grzegorz
