### PR TITLE
Fix build on Rbx.

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -26,7 +26,7 @@ module Grape
           next if resource.empty?
           resource.downcase!
           @combined_routes[resource] ||= []
-          next if @@hide_documentation_path && route.route_path.include?(@@mount_path)
+          next if documentation_class.hide_documentation_path && route.route_path.include?(documentation_class.mount_path)
           @combined_routes[resource] << route
         end
 
@@ -311,6 +311,14 @@ module Grape
               else
                 request.base_url
               end
+            end
+
+            def hide_documentation_path
+              @@hide_documentation_path
+            end
+
+            def mount_path
+              @@mount_path
             end
 
             def setup(options)

--- a/spec/api_global_models_spec.rb
+++ b/spec/api_global_models_spec.rb
@@ -20,15 +20,13 @@ describe 'Global Models' do
 
   subject do
     Class.new(Grape::API) do
-      desc 'This gets thing.', params: Entities::Some::Thing.documentation
+      desc 'This gets thing.'
       get '/thing' do
         thing = OpenStruct.new text: 'thing'
         present thing, with: Entities::Some::Thing
       end
 
-      desc 'This gets combined thing.',
-           params: Entities::Some::CombinedThing.documentation,
-           entity: Entities::Some::CombinedThing
+      desc 'This gets combined thing.', entity: Entities::Some::CombinedThing
       get '/combined_thing' do
         thing = OpenStruct.new text: 'thing'
         present thing, with: Entities::Some::CombinedThing


### PR DESCRIPTION
I don't understand why this happens, but it's not material for the spec:

```
     Failure/Error: get '/thing' do
     TypeError:
       Unable to clone/dup String class
     # kernel/common/string.rb:39:in `dup (clone)'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/activesupport-4.1.8/lib/active_support/core_ext/object/deep_dup.rb:14:in `deep_dup'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/activesupport-4.1.8/lib/active_support/core_ext/object/deep_dup.rb:43:in `deep_dup'
     # kernel/common/enumerable.rb:83:in `each_with_object'
     # kernel/common/hash.rb:342:in `each'
     # kernel/common/enumerable.rb:81:in `each_with_object'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/activesupport-4.1.8/lib/active_support/core_ext/object/deep_dup.rb:42:in `deep_dup'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/activesupport-4.1.8/lib/active_support/core_ext/object/deep_dup.rb:43:in `deep_dup'
     # kernel/common/enumerable.rb:83:in `each_with_object'
     # kernel/common/hash.rb:342:in `each'
     # kernel/common/enumerable.rb:81:in `each_with_object'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/activesupport-4.1.8/lib/active_support/core_ext/object/deep_dup.rb:42:in `deep_dup'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/activesupport-4.1.8/lib/active_support/core_ext/object/deep_dup.rb:43:in `deep_dup'
     # kernel/common/enumerable.rb:83:in `each_with_object'
     # kernel/common/hash.rb:342:in `each'
     # kernel/common/enumerable.rb:81:in `each_with_object'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/activesupport-4.1.8/lib/active_support/core_ext/object/deep_dup.rb:42:in `deep_dup'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/activesupport-4.1.8/lib/active_support/core_ext/object/deep_dup.rb:43:in `deep_dup'
     # kernel/common/enumerable.rb:83:in `each_with_object'
     # kernel/common/hash.rb:342:in `each'
     # kernel/common/enumerable.rb:81:in `each_with_object'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/activesupport-4.1.8/lib/active_support/core_ext/object/deep_dup.rb:42:in `deep_dup'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/bundler/gems/grape-443d48721fa6/lib/grape/util/inheritable_values.rb:39:in `initialize_copy'
     # kernel/common/kernel.rb:313:in `initialize_clone'
     # kernel/common/type.rb:432:in `object_initialize_clone'
     # kernel/alpha.rb:234:in `clone'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/bundler/gems/grape-443d48721fa6/lib/grape/util/inheritable_setting.rb:49:in `point_in_time_copy'
     # kernel/common/kernel.rb:769:in `tap'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/bundler/gems/grape-443d48721fa6/lib/grape/util/inheritable_setting.rb:45:in `point_in_time_copy'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/bundler/gems/grape-443d48721fa6/lib/grape/endpoint.rb:55:in `initialize'
     # kernel/alpha.rb:94:in `new'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/bundler/gems/grape-443d48721fa6/lib/grape/dsl/routing.rb:113:in `route'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/bundler/gems/grape-443d48721fa6/lib/grape/dsl/routing.rb:123:in `__script__'
     # ./spec/api_global_models_spec.rb:25:in `__script__'
     # kernel/common/eval.rb:203:in `module_eval'
     # kernel/common/module.rb:33:in `initialize'
     # kernel/common/class.rb:18:in `initialize'
     # kernel/alpha.rb:94:in `new'
     # ./spec/api_global_models_spec.rb:22:in `__script__'
     # kernel/common/hash.rb:356:in `fetch'
     # ./spec/api_global_models_spec.rb:43:in `app'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/rack-test-0.6.2/lib/rack/test/methods.rb:31:in `build_rack_mock_session'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/rack-test-0.6.2/lib/rack/test/methods.rb:27:in `rack_mock_session'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/rack-test-0.6.2/lib/rack/test/methods.rb:42:in `build_rack_test_session'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/rack-test-0.6.2/lib/rack/test/methods.rb:38:in `rack_test_session'
     # /Users/dblock/.rvm/gems/rbx-2.2.6/gems/rack-test-0.6.2/lib/rack/test/methods.rb:46:in `current_session'
     # ./spec/api_global_models_spec.rb:60:in `__script__'
     # kernel/common/eval.rb:101:in `instance_exec'
     # kernel/bootstrap/array.rb:87:in `map'
     # kernel/bootstrap/array.rb:87:in `map'
     # kernel/common/kernel.rb:447:in `load'
     # kernel/common/block_environment.rb:53:in `call_on_instance'
     # kernel/common/eval.rb:176:in `eval'
     # kernel/delta/code_loader.rb:66:in `load_script'
     # kernel/delta/code_loader.rb:152:in `load_script'
     # kernel/loader.rb:649:in `script'
     # kernel/loader.rb:831:in `main'

```
