### PR TITLE
Accept :using as a string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#179](https://github.com/tim-vandecasteele/grape-swagger/pull/179): Document `Virtus::Attribute::Boolean` as boolean - [@eashman](https://github.com/eashman), [@dblock](https://github.com/dblock).
 * [#178](https://github.com/tim-vandecasteele/grape-swagger/issues/178): Fixed `Hash` parameters, now exposed as Swagger `object` types - [@dblock](https://github.com/dblock).
 * [#167](https://github.com/tim-vandecasteele/grape-swagger/pull/167): Support mutli-tenanted APIs, don't cache `base_path` - [@bradrobertson](https://github.com/bradrobertson), (https://github.com/dblock).
+* [#185](https://github.com/tim-vandecasteele/grape-swagger/pull/185): Support strings in `Grape::Entity.expose`'s `:using` option - [@jhollinger](https://github.com/jhollinger).
 * Your contribution here.
 
 ### 0.8.0 (August 30, 2014)

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -258,7 +258,10 @@ module Grape
               models.each do |model|
                 # get model references from exposures with a documentation
                 nested_models = model.exposures.map do |_, config|
-                  config[:using] if config.key?(:documentation)
+                  if config.key?(:documentation)
+                    model = config[:using]
+                    model.respond_to?(:constantize) ? model.constantize : model
+                  end
                 end.compact
 
                 # get all nested models recursively

--- a/spec/response_model_spec.rb
+++ b/spec/response_model_spec.rb
@@ -11,6 +11,11 @@ describe 'responseModel' do
         class Something < Grape::Entity
           expose :text, documentation: { type: 'string', desc: 'Content of something.' }
           expose :kind, using: Kind, documentation: { type: 'MyAPI::Kind', desc: 'The kind of this something.' }
+          expose :relation, using: 'MyAPI::Entities::Relation', documentation: { type: 'MyAPI::Relation', desc: 'A related model.' }
+        end
+
+        class Relation < Grape::Entity
+          expose :name, documentation: { type: 'string', desc: 'Name' }
         end
 
         class Error < Grape::Entity
@@ -82,7 +87,8 @@ describe 'responseModel' do
       'id' => 'MyAPI::Something',
       'properties' => {
         'text' => { 'type' => 'string', 'description' => 'Content of something.' },
-        'kind' => { '$ref' => 'MyAPI::Kind', 'description' => 'The kind of this something.' }
+        'kind' => { '$ref' => 'MyAPI::Kind', 'description' => 'The kind of this something.' },
+        'relation' => { '$ref' => 'MyAPI::Relation', 'description' => 'A related model.' }
       }
     )
 
@@ -91,6 +97,14 @@ describe 'responseModel' do
       'id' => 'MyAPI::Kind',
       'properties' => {
         'title' => { 'type' => 'string', 'description' => 'Title of the kind.' }
+      }
+    )
+
+    expect(subject['models'].keys).to include 'MyAPI::Relation'
+    expect(subject['models']['MyAPI::Relation']).to eq(
+      'id' => 'MyAPI::Relation',
+      'properties' => {
+        'name' => { 'type' => 'string', 'description' => 'Name' }
       }
     )
   end


### PR DESCRIPTION
grape-entity's documentation specifies that `:using` may be a class or a string (https://github.com/intridea/grape-entity#exposing-with-a-presenter). Currently grape-swagger only supports classes; using strings raises an exception. I've added support for strings and a test.
