### PR TITLE
Generate default API base path

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -12,7 +12,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 397
+  Max: 401
 
 # Offense count: 5
 Metrics/CyclomaticComplexity:
@@ -26,7 +26,7 @@ Metrics/LineLength:
 # Offense count: 13
 # Configuration parameters: CountComments.
 Metrics/MethodLength:
-  Max: 359
+  Max: 362
 
 # Offense count: 4
 Metrics/PerceivedComplexity:

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -316,6 +316,16 @@ module Grape
               end
             end
 
+            def generate_default_base_path
+              lambda do |request|
+                if %w(development test).include?(ENV['RAILS_ENV'] || ENV['RACK_ENV'])
+                  request.base_url
+                else
+                  "#{request.scheme}://#{request.host}"
+                end
+              end
+            end
+
             def hide_documentation_path
               @@hide_documentation_path
             end
@@ -328,7 +338,7 @@ module Grape
               defaults = {
                 target_class: nil,
                 mount_path: '/swagger_doc',
-                base_path: nil,
+                base_path: generate_default_base_path,
                 api_version: '0.1',
                 markdown: nil,
                 hide_documentation_path: false,

--- a/spec/non_default_api_spec.rb
+++ b/spec/non_default_api_spec.rb
@@ -495,9 +495,22 @@ describe 'options: ' do
     #   JSON.parse(last_response.body)["basePath"].should == "https://example.org:80"
     # end
 
-    it 'uses https schema in endpoint doc' do
-      get '/swagger_doc/something.json', {}, 'rack.url_scheme' => 'https'
-      expect(JSON.parse(last_response.body)['basePath']).to eq 'https://example.org:80'
+    context 'when in development environment' do
+      before { ENV['RAILS_ENV'] = 'development' }
+
+      it 'uses https schema with base_url in endpoint doc' do
+        get '/swagger_doc/something.json', {}, 'rack.url_scheme' => 'https'
+        expect(JSON.parse(last_response.body)['basePath']).to eq 'https://example.org:80'
+      end
+    end
+
+    context 'when in production environment' do
+      before { ENV['RAILS_ENV'] = 'production' }
+
+      it 'uses https schema with host only in endpoint doc' do
+        get '/swagger_doc/something.json', {}, 'rack.url_scheme' => 'https'
+        expect(JSON.parse(last_response.body)['basePath']).to eq 'https://example.org'
+      end
     end
   end
 


### PR DESCRIPTION
This generates the default API `basePath`, so that even when url scheme and port are in direct conflict in `production` or `staging` environment (in fact those, that differ from `development` and `test`), it works as expected. Resolves #107. Sorry it took so long. @dblock?