### PR TITLE
more robust logic for cleaning out the format suffix when hide_format is specified

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,9 @@ test/dummy/tmp/
 test/dummy/.sass-cache
 Gemfile.lock
 
+# rubymine
+.idea
+
 # Have editor/IDE/OS specific files you need to ignore? Consider using a global gitignore:
 #
 # * Create a file at ~/.gitignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 #### Fixes
 
+* [#256](https://github.com/tim-vandecasteele/grape-swagger/pull/256): More robust logic for cleaning out the format suffix when hide_format is specified - [@mzruya](https://github.com/mzruya).
 * [#252](https://github.com/tim-vandecasteele/grape-swagger/pull/252): Allow docs to mounted in separate class than target - [@iangreenleaf](https://github.com/iangreenleaf).
 * [#251](https://github.com/tim-vandecasteele/grape-swagger/pull/251): Fixed model id equal to model name when root existing in entities - [@aitortomas](https://github.com/aitortomas).
 * [#232](https://github.com/tim-vandecasteele/grape-swagger/pull/232): Fixed missing raw array params - [@u2](https://github.com/u2).

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -147,7 +147,13 @@ module GrapeSwagger
 
     def parse_path(path, version)
       # adapt format to swagger format
-      parsed_path = path.gsub('(.:format)', @@hide_format ? '' : '.{format}')
+      if @@hide_format
+        suffix = (path.match(/\(.*\)\z/) || [''])[0]
+        parsed_path = path.gsub(suffix, '')
+      else
+        parsed_path = path.gsub('(.:format)', '.{format}')
+      end
+
       # This is attempting to emulate the behavior of
       # Rack::Mount::Strexp. We cannot use Strexp directly because
       # all it does is generate regular expressions for parsing URLs.

--- a/spec/non_default_api_spec.rb
+++ b/spec/non_default_api_spec.rb
@@ -504,22 +504,40 @@ describe 'options: ' do
           { bla: 'something' }
         end
       end
+    end
 
-      class SimpleApiWithHiddenPaths < Grape::API
-        mount ProtectedApi
-        add_swagger_documentation hide_format: true
+    shared_examples_for 'an api path without a format suffix' do |options = {}|
+      let(:app) do
+        Class.new(Grape::API) do
+          mount ProtectedApi
+          add_swagger_documentation({ hide_format: true }.merge(options))
+        end
+      end
+
+      it 'has no formats' do
+        get '/swagger_doc/something.json'
+        apis = JSON.parse(last_response.body)['apis']
+        expect(apis.length).to eq 1
+        expect(apis.first['path']).to eq '/something'
       end
     end
 
-    def app
-      SimpleApiWithHiddenPaths
+    it_behaves_like 'an api path without a format suffix'
+
+    context ':format' do
+      it_behaves_like('an api path without a format suffix', format: :json)
     end
 
-    it 'has no formats' do
-      get '/swagger_doc/something.json'
-      JSON.parse(last_response.body)['apis'].each do |api|
-        expect(api['path']).to_not end_with '.{format}'
-      end
+    context ':base_path' do
+      it_behaves_like('an api path without a format suffix', base_path: '/api')
+    end
+
+    context ':api_version' do
+      it_behaves_like('an api path without a format suffix', api_version: 'v1')
+    end
+
+    context 'all settings' do
+      it_behaves_like('an api path without a format suffix', api_version: 'v1', base_path: '/api', format: :json)
     end
   end
 


### PR DESCRIPTION
`hide_format: true` only works in a specific case
the suffix of the path could be one of three options (one of which depends on the actual format)

`grape/path.rb:39`
```ruby
if uses_specific_format?
  "(.#{settings[:format]})"
elsif !uses_path_versioning? || (has_namespace? || has_path?)
  '(.:format)'
else
  '(/.:format)'
end
```

Since we only have the already interpolated path string, we can figure out which option was the one using a regex.
