### PR TITLE
Correct use of documentation param_type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.10.3 (Next)
 
 * [#292](https://github.com/ruby-grape/grape-swagger/pull/292): Support i18n - [@calfzhou](https://github.com/calfzhou).
+* [#297](https://github.com/ruby-grape/grape-swagger/pull/297): Correct use of documentation param_type - [@fab-girard](https://github.com/fab-girard).
 * Your contribution here.
 
 ### 0.10.2 (August 19, 2015)

--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Grape uses the option `default` to set a default value for optional parameters. 
 
 ## Grape Entities
 
-Add the [grape-entity](https://github.com/agileanimal/grape-entity) gem to our Gemfile.
+Add the [grape-entity](https://github.com/ruby-grape/grape-entity) gem to our Gemfile.
 
 The following example exposes statuses. And exposes statuses documentation adding :type and :desc.
 

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -103,8 +103,8 @@ module GrapeSwagger
         values               = value.is_a?(Hash) ? value[:values] : nil
         enum_or_range_values = parse_enum_or_range_values(values)
 
-        if value.is_a?(Hash) && value.key?(:documentation) && value[:documentation].key?(:param_type)
-          param_type = value[:documentation][:param_type]
+        if value.is_a?(Hash) && value.key?(:param_type)
+          param_type = value[:param_type]
           if is_array
             items     = { '$ref' => data_type }
             data_type = 'array'

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -133,7 +133,7 @@ module GrapeSwagger
           description:   as_markdown(description),
           type:          data_type,
           required:      required,
-          allowMultiple: is_array
+          allowMultiple: is_array && data_type != 'array' && %w(query header path).include?(param_type)
         }
 
         if PRIMITIVE_MAPPINGS.key?(data_type)

--- a/spec/array_params_spec.rb
+++ b/spec/array_params_spec.rb
@@ -21,7 +21,7 @@ describe 'Array Params' do
       end
 
       params do
-        optional :raw_array, type: Array[Integer]
+        optional :raw_array, type: Array[Integer], documentation: { is_array: true }
       end
       get :raw_array_integers do
       end

--- a/spec/param_type_spec.rb
+++ b/spec/param_type_spec.rb
@@ -5,8 +5,9 @@ describe 'Params Types' do
     Class.new(Grape::API) do
       format :json
 
+      desc 'description', nickname: 'desc', params: { input1: { type: Integer, param_type: 'query' } }
       params do
-        requires :input, type: String, documentation: { param_type: 'query' }
+        requires :input2, type: String, documentation: { param_type: 'query' }
       end
       post :action do
       end
@@ -19,12 +20,13 @@ describe 'Params Types' do
     get '/swagger_doc/action'
     expect(last_response.status).to eq 200
     body = JSON.parse last_response.body
-    body['apis'].first['operations'].first['parameters']
+    body['apis'].first['operations'].flat_map { |o| o['parameters'] }
   end
 
   it 'reads param type correctly' do
-    expect(subject).to eq [
-      { 'paramType' => 'query', 'name' => 'input', 'description' => '', 'type' => 'string', 'required' => true, 'allowMultiple' => false }
+    expect(subject).to match_array [
+      { 'paramType' => 'query', 'name' => 'input1', 'description' => '', 'type' => 'integer', 'required' => false, 'allowMultiple' => false, 'format' => 'int32' },
+      { 'paramType' => 'query', 'name' => 'input2', 'description' => '', 'type' => 'string', 'required' => true, 'allowMultiple' => false }
     ]
   end
 


### PR DESCRIPTION
Hello,
when params are defined using an existing grape entity documentation, param_type was not taken into account. I've commited a first modification for that issue.

But the correction has shown another issue : with a param_type now added, and if param is an array, data_type is now set to "array". I think this is inconsitant with allowMultiple parameter... In addition, according to swagger-spec 1.2 allowMultiple is valid only for some param_type ("query", "header" or "path"). Reason of the second commit.

Fab