### PR TITLE
Speedup by parsing models smarter, not harder

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -8,7 +8,7 @@
 
 # Offense count: 10
 Metrics/AbcSize:
-  Max: 213
+  Max: 214
 
 # Offense count: 1
 # Configuration parameters: CountComments.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 * [#292](https://github.com/ruby-grape/grape-swagger/pull/292): Support i18n - [@calfzhou](https://github.com/calfzhou).
 * [#297](https://github.com/ruby-grape/grape-swagger/pull/297): Correct use of documentation param_type - [@fab-girard](https://github.com/fab-girard).
+* [#305](https://github.com/ruby-grape/grape-swagger/pull/305): Speedup by parsing models smarter, not harder - [@jhollinger](https://github.com/jhollinger).
 * Your contribution here.
 
 ### 0.10.2 (August 19, 2015)


### PR DESCRIPTION
We have one namespace with Very Large entities in its responses, and that swagger doc endpoint began timing out behind our gateway, breaking Swagger UI.

I tracked it down to one line being run in a loop that (seemingly) didn't need to be. Moving it to _after_ the loop brought it down from ~49 sec to ~4 sec on my laptop. Changing the `models` array from an `Array` to a `Set` brought it down to ~3 sec.

Existing tests pass, but I'm not sure of a great way to write one for this since the behavior remains the same. Well, functionally the same. The resulting JSON has the models in a different order, but I don't think that matters.