### PR TITLE
Default values specified with proc fail

### DIFF
--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -146,7 +146,7 @@ module GrapeSwagger
 
         parsed_params[:defaultValue] = example if example
         if default_value && example.blank?
-          parsed_params[:defaultValue] = default_value
+          parsed_params[:defaultValue] = default_value.respond_to?(:call) ? default_value.call : default_value
         end
 
         parsed_params.merge!(enum_or_range_values) if enum_or_range_values

--- a/spec/default_values_spec.rb
+++ b/spec/default_values_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+require 'grape_version'
+
+describe 'Parse default values' do
+  subject do
+    test_class = Class.new(Grape::API)
+    test_class.add_swagger_documentation
+  end
+
+  it 'parses immediate defaults' do
+    params = {
+      name: { type: 'String', default: 'default' }
+    }
+
+    value = subject.parse_params(params, '/', 'GET').first
+    expect(value[:defaultValue]).to eq('default')
+  end
+
+  it 'parses delayed defaults' do
+    params = {
+      name: { type: 'String', default: -> { 'default' } }
+    }
+
+    value = subject.parse_params(params, '/', 'GET').first
+    expect(value[:defaultValue]).to eq('default')
+  end
+end


### PR DESCRIPTION
Grape allows for default values to be delayed until execution time. This causes the proc itself to be rendered as the Swagger default
