### PR TITLE
Re-add Rubinius and set to allow failures on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ rvm:
   - 2.1
   - 2.0
   - jruby-19mode
+  - rbx-2
 
 env:
   - GRAPE_VERSION=0.8.0
@@ -18,3 +19,7 @@ env:
   - GRAPE_VERSION=0.13.0
   - GRAPE_VERSION=0.14.0
   - GRAPE_VERSION=HEAD
+
+matrix:
+  allow_failures:
+    - rvm: rbx-2


### PR DESCRIPTION
There are many reasons that a build can fail on Travis. In the case of Rubinius, two of the most common have historically been RVM failing to install correctly and general stability issues in Rubinius. However, stability issues are not unique to Rubinius. I have had many builds segfault on MRI as well.

Travis provides the ability to allow failures in selected matrix entries without failing the overall build. This gives visibility without impacting workflow.

Finally, Rubinius development moves very fast and we repeatedly encouraged using 'rbx-2' in .travis.yml to pick up the newest release. When issues are fixed, the new Rubinius release runs and the results are visible.