### PR TITLE
Moving documented headers into the `parameters` object

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 333
+  Max: 340
 
 # Offense count: 6
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ n.n.n / 2016-02-05
 
 ### 0.10.3 (Next)
 
+* [#345](https://github.com/ruby-grape/grape-swagger/pull/345): Moving documented headers into the `parameters` object - [@daveWid](https://github.com/daveWid).
+
 [#336](https://github.com/ruby-grape/grape-swagger/pull/336) changes of swagger-2.0 fork, to support it
 
 * updates gems, corrects parameter, which is in array, make rubocop happy

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -127,11 +127,12 @@ module Grape
     def method_object(route, options)
       methods = {}
       methods[:description] = description_object(route, options[:markdown])
-      methods[:headers] = route.route_headers if route.route_headers
 
       methods[:produces] = produces_object(route, options)
 
       methods[:parameters] = params_object(route)
+      methods[:parameters].concat(parse_header_params(route)) if route.route_headers
+
       methods[:responses] = response_object(route)
 
       if route.route_aws
@@ -235,6 +236,12 @@ module Grape
         else
           memo[x] = required.assoc(x.to_s).last
         end
+      end
+    end
+
+    def parse_header_params(route)
+      route.route_headers.map do |param, value|
+        { in: 'header', name: param, type: 'string' }.merge(value)
       end
     end
 

--- a/spec/swagger_v2/api_swagger_v2_headers_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_headers_spec.rb
@@ -36,9 +36,7 @@ describe 'headers' do
   end
 
   specify do
-    expect(subject['paths']['/use_headers']['get']).to include('headers')
-    expect(subject['paths']['/use_headers']['get']['headers']).to eql({
-      "X-Rate-Limit-Limit"=>{"description"=>"The number of allowed requests in the current period", "type"=>"integer"}
-    })
+    expect(subject['paths']['/use_headers']['get']['parameters'][0]['in']).to eq('header')
+    expect(subject['paths']['/use_headers']['get']['parameters'][0]).to eql({"description"=>"The number of allowed requests in the current period", "type"=>"integer", "in"=>"header", "name"=>"X-Rate-Limit-Limit"})
   end
 end

--- a/spec/swagger_v2/param_type_spec.rb
+++ b/spec/swagger_v2/param_type_spec.rb
@@ -51,7 +51,7 @@ describe 'Params Types' do
 
     it 'has consistent types' do
       types = subject.map { |param| param['type'] }
-      expect(types).to eq(%w(string))
+      expect(types).to eq(%w(string string))
     end
   end
 end

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -84,9 +84,9 @@ describe 'a simple mounted api' do
           "/simple-test"=>{"get"=>{"produces"=>["application/json"], "responses"=>{"200"=>{"description"=>"This gets something for URL using - separator."}}}},
           "/simple_with_headers"=>{
             "get"=>{
-              "headers"=>{
-                "XAuthToken"=>{"description"=>"A required header.", "required"=>true},
-                "XOtherHeader"=>{"description"=>"An optional header.", "required"=>false}},
+              "parameters"=>[{"in"=>"header", "name"=>"XAuthToken", "description"=>"A required header.", "required"=>true, "type"=>"string"},
+                {"in"=>"header", "name"=>"XOtherHeader", "description"=>"An optional header.", "required"=>false, "type"=>"string"}
+              ],
               "produces"=>["application/json"],
               "responses"=>{
                 "200"=>{"description"=>"this gets something else"},
@@ -161,9 +161,9 @@ describe 'a simple mounted api' do
         expect(subject['paths']).to eq({
           "/simple_with_headers"=>{
             "get"=>{
-              "headers"=>{
-                "XAuthToken"=>{"description"=>"A required header.", "required"=>true},
-                "XOtherHeader"=>{"description"=>"An optional header.", "required"=>false}},
+              "parameters"=>[{"in"=>"header", "name"=>"XAuthToken", "description"=>"A required header.", "required"=>true, "type"=>"string"},
+                {"in"=>"header", "name"=>"XOtherHeader", "description"=>"An optional header.", "required"=>false, "type"=>"string"}
+              ],
               "produces"=>["application/json"],
               "responses"=>{
                 "200"=>{"description"=>"this gets something else"},


### PR DESCRIPTION
The documented headers in the description block describing the request headers. To have them picked up in the SwaggerUI they need to be in the parameters object with in: 'header' instead of a headers object, which used to document the response headers.