### PR TITLE
Fix: Allow is_array for nested entities with with documentation

### DIFF
--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -245,7 +245,11 @@ module Grape
         x[0] = x.last[:as] if x.last[:as]
         if x.last[:using].present? || could_it_be_a_model?(x.last)
           name = expose_params_from_model(x.last[:using] || x.last[:type])
-          memo[x.first] = { '$ref' => "#/definitions/#{name}" }
+          memo[x.first] = if x.last[:documentation] && x.last[:documentation][:is_array]
+                            { 'type' => 'array', 'items' => { '$ref' => "#/definitions/#{name}" } }
+                          else
+                            { '$ref' => "#/definitions/#{name}" }
+                          end
         else
           memo[x.first] = { type: data_type(x.last[:documentation] || x.last) }
           memo[x.first][:enum] = x.last[:values] if x.last[:values] && x.last[:values].is_a?(Array)

--- a/spec/support/api_swagger_v2_result.rb
+++ b/spec/support/api_swagger_v2_result.rb
@@ -137,7 +137,7 @@ RSpec.shared_context "swagger example" do
       }}},
       "definitions"=>{
         "QueryInputElement"=>{"type"=>"object", "properties"=>{"key"=>{"type"=>"string"}, "value"=>{"type"=>"string"}}},
-        "QueryInput"=>{"type"=>"object", "properties"=>{"elements"=>{"$ref"=>"#/definitions/QueryInputElement"}}},
+        "QueryInput"=>{"type"=>"object", "properties"=>{"elements"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/QueryInputElement"}}}},
         "Thing"=>{"properties"=>{"id"=>{"type"=>"integer"}, "text"=>{"type"=>"string"}, "links"=>{"type"=>"link"}, "others"=>{"type"=>"text"}}},
         "ApiError"=>{"type"=>"object", "properties"=>{"code"=>{"type"=>"integer"}, "message"=>{"type"=>"string"}}},
         "Something"=>{"type"=>"object", "properties"=>{"id"=>{"type"=>"integer"}, "text"=>{"type"=>"string"}, "links"=>{"type"=>"link"}, "others"=>{"type"=>"text"}}}

--- a/spec/swagger_v2/api_swagger_v2_response_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_spec.rb
@@ -57,7 +57,7 @@ describe 'exposing' do
             "properties"=>{"id"=>{"type"=>"integer"}, "name"=>{"type"=>"string"}}},
           "UseResponse"=>{
             "type"=>"object",
-            "properties"=>{"description"=>{"type"=>"string"}, "$responses"=>{"$ref"=>"#/definitions/ResponseItem"}}},
+            "properties"=>{"description"=>{"type"=>"string"}, "$responses"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/ResponseItem"}}}},
           "ApiError"=>{
             "type"=>"object",
             "properties"=>{"code"=>{"type"=>"integer"}, "message"=>{"type"=>"string"}}}

--- a/spec/swagger_v2/response_model_spec.rb
+++ b/spec/swagger_v2/response_model_spec.rb
@@ -117,7 +117,7 @@ describe 'responseModel' do
           "kind"=>{"$ref"=>"#/definitions/Kind"},
           "kind2"=>{"$ref"=>"#/definitions/Kind"},
           "kind3"=>{"$ref"=>"#/definitions/Kind"},
-          "tags"=>{"$ref"=>"#/definitions/Tag"},
+          "tags"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/Tag"}},
           "relation"=>{"$ref"=>"#/definitions/Relation"}}}
     )
 
@@ -201,7 +201,7 @@ describe 'should build definition from given entity' do
           "kind"=>{"$ref"=>"#/definitions/Kind"},
           "kind2"=>{"$ref"=>"#/definitions/Kind"},
           "kind3"=>{"$ref"=>"#/definitions/Kind"},
-          "tags"=>{"$ref"=>"#/definitions/Tag"},
+          "tags"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/Tag"}},
           "relation"=>{"$ref"=>"#/definitions/Relation"}}}
     })
 


### PR DESCRIPTION
Previously an endpoint which returned the `MyEntity` entity (below):

```ruby
module Entities
  class SubEntity < Grape::Entity
    expose :some_value, documentation: { type: "String" }
  end
  class MyEntity < Grape::Entity
    expose :sub_entities, using: Entities::SubEntity, documentation: { is_array: true }
  end
end
```

Would generate this documentation:

```javascript
{
  ...
  definitions: {
    MyEntity: {
      type: "object",
      properties: {
        sub_entities: {
          $ref: "#/definitions/SubEntity"
        }
      }
    },
    SubEntity: {
      type: "object",
      properties: {
        some_value: {
          type: "string"
        }
      }
    }
  }
}
```

With the changes it will now produce:

```javascript
{
  ...
  definitions: {
    MyEntity: {
      type: "object",
      properties: {
        sub_entities: {
          type: "array",
          items: {
            $ref: "#/definitions/SubEntity"
          }
        }
      }
    },
    SubEntity: {
      type: "object",
      properties: {
        some_value: {
          type: "string"
        }
      }
    }
  }
}
```

Which better represents the structure and follows the same output standard as if `in_array` was specified on the actual endpoint.
