### PR TITLE
Fix typeref

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -32,7 +32,7 @@ Metrics/MethodLength:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 471
+  Max: 472
 
 # Offense count: 5
 Metrics/PerceivedComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### 0.10.5 (Next)
 
 * [#338](https://github.com/ruby-grape/grape-swagger/pull/338): Fixed handling of nested Array parameters - [@itoufo](https://github.com/itoufo).
+* [#347](https://github.com/ruby-grape/grape-swagger/pull/347): Fixed typeref when both :using and :as are provided in exposure but no :type in documentation - [@c910335](https://github.com/c910335).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -252,16 +252,17 @@ module GrapeSwagger
         end
         i18n_keys << :default
 
-        model.documentation.each do |property_name, property_info|
-          p = property_info.dup
+        model.exposures.each do |property_name, property_info|
+          next unless property_info.key? :documentation
+          property_name = property_info[:as] if property_info.key? :as
+          p = property_info[:documentation].dup
 
           required << property_name.to_s if p.delete(:required)
 
           type = if p[:type]
                    p.delete(:type)
                  else
-                   exposure = model.exposures[property_name]
-                   parse_entity_name(exposure[:using]) if exposure
+                   parse_entity_name(property_info[:using])
                  end
 
           if p.delete(:is_array)


### PR DESCRIPTION
Fixed: empty type reference when both :using and :as are provided in exposure but no :type in documentation