### PR TITLE
Fixing the case when description has not been initialized until markd…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 n.n.n / 2016-03-16
 ==================
+[#365](https://github.com/ruby-grape/grape-swagger/pull/365)
+
+- fixes passing markdown with redcarpet even with nil description and detail
+
 [#358](https://github.com/ruby-grape/grape-swagger/pull/358)
 
 - removes `allowMultiple` property from params

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -118,7 +118,7 @@ module Grape
     def description_object(route, markdown)
       description = route.route_desc if route.route_desc.present?
       description = route.route_detail if route.route_detail.present?
-      description = markdown.markdown(description).chomp if markdown
+      description = markdown.markdown(description.to_s).chomp if markdown
       description
     end
 

--- a/spec/swagger_v2/description_not_initialized.rb
+++ b/spec/swagger_v2/description_not_initialized.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'details' do
+  describe 'details, pass markdown with redcarpet even with nil description and detail', unless: RUBY_PLATFORM.eql?('java') do
+    include_context "the api entities"
+
+    before :all do
+      module TheApi
+        class GfmRcDetailApi < Grape::API
+          format :json
+
+          desc nil,
+               detail: nil,
+               entity: Entities::UseResponse,
+               failure: [{code: 400, model: Entities::ApiError}]
+          get '/use_gfm_rc_detail' do
+            { "declared_params" => declared(params) }
+          end
+
+          add_swagger_documentation markdown: GrapeSwagger::Markdown::RedcarpetAdapter.new
+        end
+      end
+    end
+
+    def app
+      TheApi::GfmRcDetailApi
+    end
+
+    subject do
+      get '/swagger_doc'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/use_gfm_rc_detail']['get']).not_to include('description')
+      expect(subject['paths']['/use_gfm_rc_detail']['get']['description']).to eql(nil)
+    end
+  end
+end


### PR DESCRIPTION
…own.

Catched it analyzing this error:
```
TypeError (wrong argument type nil (expected String)):
  
/home/thunder/.rvm/gems/ruby-2.3.0/bundler/gems/grape-swagger-18401c8ce1b1/lib/grape-swagger/markdown/redcarpet_adapter.rb:55:in `render'
/home/thunder/.rvm/gems/ruby-2.3.0/bundler/gems/grape-swagger-18401c8ce1b1/lib/grape-swagger/markdown/redcarpet_adapter.rb:55:in `markdown'
/home/thunder/.rvm/gems/ruby-2.3.0/bundler/gems/grape-swagger-18401c8ce1b1/lib/grape-swagger/endpoint.rb:121:in `description_object'
```