### PR TITLE
handling of body params

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,14 @@ rvm:
   - 2.3.0
   - 2.2.3
   - 2.1.7
-  - rbx-2
   - jruby-19mode
+  - jruby-9.0.5.0
+  - rbx-2
 
 matrix:
   allow_failures:
     - rvm: rbx-2
+    - rvm: jruby-19mode
 env:
   - GRAPE_VERSION=0.12.0
   - GRAPE_VERSION=0.13.0

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -1,3 +1,5 @@
+require 'grape-swagger/doc_methods/status_codes'
+
 require 'grape-swagger/doc_methods/produces_consumes'
 require 'grape-swagger/doc_methods/data_type'
 require 'grape-swagger/doc_methods/extensions'
@@ -6,7 +8,7 @@ require 'grape-swagger/doc_methods/optional_object'
 require 'grape-swagger/doc_methods/path_string'
 require 'grape-swagger/doc_methods/tag_name_description'
 require 'grape-swagger/doc_methods/parse_params'
-# require 'grape-swagger/doc_methods/move_params'
+require 'grape-swagger/doc_methods/move_params'
 
 module GrapeSwagger
   module DocMethods

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -1,0 +1,119 @@
+module GrapeSwagger
+  module DocMethods
+    class MoveParams
+      class << self
+        def to_definition(paths, definitions)
+          @definitions = definitions
+          find_post_put(paths) do |path|
+            find_definition_and_parameters(path)
+          end
+        end
+
+        def find_post_put(paths)
+          paths.each do |x|
+            found = x.last.select { |y| move_methods.include?(y) }
+            yield found unless found.empty?
+          end
+        end
+
+        def find_definition_and_parameters(path)
+          path.keys.each do |verb|
+            parameters = path[verb][:parameters]
+
+            next if parameters.nil?
+            next unless should_move?(parameters)
+
+            unify!(parameters)
+
+            status_code = GrapeSwagger::DocMethods::StatusCodes.get[verb.to_sym][:code]
+            response = path[verb][:responses][status_code]
+            referenced_definition = parse_model(response[:schema]['$ref'])
+
+            name = build_definition(verb, referenced_definition)
+
+            move_params_to_new(verb, name, parameters)
+            @definitions[name].delete(:required) if @definitions[name][:required].empty?
+            path[verb][:parameters] << build_body_parameter(response.dup, name)
+          end
+        end
+
+        def build_definition(verb, name)
+          name = "#{verb}Request#{name}".to_sym
+          @definitions[name] = { type: 'object', properties: {}, required: [] }
+
+          name
+        end
+
+        def move_params_to_new(_, name, parameters)
+          properties = {}
+          definition = @definitions[name]
+          request_parameters = parameters.dup
+
+          request_parameters.each do |param|
+            next unless movable?(param)
+            name = param[:name].to_sym
+            properties[name] = {}
+
+            properties[name].tap do |x|
+              property_keys.each do |attribute|
+                x[attribute] = param[attribute] unless param[attribute].nil?
+              end
+            end
+
+            properties[name][:readOnly] = true unless deletable?(param)
+            parameters.delete(param) if deletable?(param)
+            definition[:required] << name if deletable?(param) && param[:required]
+          end
+
+          definition[:properties] = properties
+        end
+
+        def build_body_parameter(response, name = false)
+          body_param = {}
+          body_param.tap do |x|
+            x[:name] = parse_model(response[:schema]['$ref'])
+            x[:in] = 'body'
+            x[:required] = true
+            x[:schema] = { '$ref' => response[:schema]['$ref'] } unless name
+            x[:schema] = { '$ref' => "#/definitions/#{name}" } if name
+          end
+        end
+
+        private
+
+        def unify!(params)
+          params.each do |param|
+            param[:in] = param.delete(:param_type) if param.key?(:param_type)
+            param[:in] = 'body' if param[:in] == 'formData'
+          end
+        end
+
+        def parse_model(ref)
+          ref.split('/').last
+        end
+
+        def move_methods
+          [:post, :put, :patch]
+        end
+
+        def property_keys
+          [:type, :format, :description, :minimum, :maximum, :items]
+        end
+
+        def movable?(param)
+          return true if param[:in] == 'body' || param[:in] == 'path'
+          false
+        end
+
+        def deletable?(param)
+          return true if movable?(param) && param[:in] == 'body'
+          false
+        end
+
+        def should_move?(parameters)
+          !parameters.select { |x| x[:in] == 'body' || x[:param_type] == 'body' }.empty?
+        end
+      end
+    end
+  end
+end

--- a/lib/grape-swagger/doc_methods/operation_id.rb
+++ b/lib/grape-swagger/doc_methods/operation_id.rb
@@ -2,20 +2,24 @@ module GrapeSwagger
   module DocMethods
     class OperationId
       class << self
-        def build(method, path = nil)
+        def build(method = nil, path = nil)
           verb = method.to_s.downcase
 
-          unless path.nil?
-            operation = path.split('/').map(&:capitalize).join
-            operation.gsub!(/\-(\w)/, &:upcase).delete!('-') if operation.include?('-')
-            operation.gsub!(/\_(\w)/, &:upcase).delete!('_') if operation.include?('_')
-            if path.include?('{')
-              operation.gsub!(/\{(\w)/, &:upcase)
-              operation.delete!('{').delete!('}')
-            end
-          end
+          operation = manipulate(path) unless path.nil?
 
           "#{verb}#{operation}"
+        end
+
+        def manipulate(path)
+          operation = path.split('/').map(&:capitalize).join
+          operation.gsub!(/\-(\w)/, &:upcase).delete!('-') if operation.include?('-')
+          operation.gsub!(/\_(\w)/, &:upcase).delete!('_') if operation.include?('_')
+          if path.include?('{')
+            operation.gsub!(/\{(\w)/, &:upcase)
+            operation.delete!('{').delete!('}')
+          end
+
+          operation
         end
       end
     end

--- a/lib/grape-swagger/doc_methods/status_codes.rb
+++ b/lib/grape-swagger/doc_methods/status_codes.rb
@@ -1,0 +1,17 @@
+module GrapeSwagger
+  module DocMethods
+    class StatusCodes
+      class << self
+        def get
+          {
+            get: { code: 200, message: 'get {item}(s)' },
+            post: { code: 201, message: 'created {item}' },
+            put: { code: 200, message: 'updated {item}' },
+            patch: { code: 200, message: 'patched {item}' },
+            delete: { code: 200, message: 'deleted {item}' }
+          }
+        end
+      end
+    end
+  end
+end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -109,7 +109,7 @@ module Grape
       method[:produces]    = produces_object(route, options[:produces] || options[:format])
       method[:consumes]    = consumes_object(route, options[:format])
       method[:parameters]  = params_object(route)
-      method[:responses]   = response_object(route)
+      method[:responses]   = response_object(route, options[:markdown])
       method[:tags]        = tag_object(route, options[:version])
       method[:operationId] = GrapeSwagger::DocMethods::OperationId.build(route.route_method, path)
       method.delete_if { |_, value| value.blank? }
@@ -117,8 +117,11 @@ module Grape
 
     def description_object(route, markdown)
       description = route.route_desc if route.route_desc.present?
-      description = route.route_detail if route.route_detail.present?
+      description = route.route_description if route.route_description.present?
+      description = "# #{description} " if markdown
+      description += "\n #{route.route_detail}" if route.route_detail
       description = markdown.markdown(description.to_s).chomp if markdown
+
       description
     end
 
@@ -149,7 +152,7 @@ module Grape
       end
     end
 
-    def response_object(route)
+    def response_object(route, markdown)
       default_code = GrapeSwagger::DocMethods::StatusCodes.get[route.route_method.downcase.to_sym]
       default_code[:model] = @entity if @entity
       default_code[:message] = route.route_description || default_code[:message].sub('{item}', @item)
@@ -168,9 +171,11 @@ module Grape
           value[:code] = 204
         end
 
+        next if memo.key?(204)
         next unless !response_model.start_with?('Swagger_doc') &&
                     ((@definitions[response_model] && value[:code].to_s.start_with?('2')) || value[:model])
 
+        @definitions[response_model][:description] = description_object(route, markdown)
         # TODO: proof that the definition exist, if model isn't specified
         memo[value[:code]][:schema] = if route.route_is_array
                                         { 'type' => 'array', 'items' => { '$ref' => "#/definitions/#{response_model}" } }

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -71,8 +71,7 @@ module Grape
       end
 
       add_definitions_from options[:models]
-
-      # GrapeSwagger::DocMethods::MoveParams.to_definition(@paths, @definitions)
+      GrapeSwagger::DocMethods::MoveParams.to_definition(@paths, @definitions)
       [@paths, @definitions]
     end
 
@@ -151,7 +150,7 @@ module Grape
     end
 
     def response_object(route)
-      default_code = default_status_codes[route.route_method.downcase.to_sym]
+      default_code = GrapeSwagger::DocMethods::StatusCodes.get[route.route_method.downcase.to_sym]
       default_code[:model] = @entity if @entity
       default_code[:message] = route.route_description || default_code[:message].sub('{item}', @item)
 
@@ -289,16 +288,6 @@ module Grape
 
     def model_name(name)
       name.respond_to?(:name) ? name.name.demodulize.camelize : name.split('::').last
-    end
-
-    def default_status_codes
-      {
-        get: { code: 200, message: 'get {item}(s)' },
-        post: { code: 201, message: 'created {item}' },
-        put: { code: 200, message: 'updated {item}' },
-        patch: { code: 200, message: 'patched {item}' },
-        delete: { code: 200, message: 'deleted {item}' }
-      }
     end
 
     def could_it_be_a_model?(value)

--- a/spec/lib/move_params_spec.rb
+++ b/spec/lib/move_params_spec.rb
@@ -1,0 +1,250 @@
+require 'spec_helper'
+
+describe GrapeSwagger::DocMethods::MoveParams do
+  include_context "the api paths/defs"
+
+  subject { described_class }
+
+  it { expect(subject.to_s).to eql 'GrapeSwagger::DocMethods::MoveParams' }
+
+  describe 'find_post_put' do
+    let(:paths) { {} }
+
+    describe 'paths empty' do
+      specify { expect { |b| subject.find_post_put(paths, &b) }.not_to yield_control }
+    end
+
+    describe 'no post/put given' do
+      let(:paths) {{
+        :'/foo'=> { get: {}, delete: {}},
+        :'/bar/{key}'=> { get: {}, delete: {}},
+      }}
+      specify { expect { |b| subject.find_post_put(paths, &b) }.not_to yield_control }
+    end
+
+    describe 'no post/put given' do
+      let(:paths) {{
+        :'/foo'=> { get: {}, delete: {}, post: {}, put: {}, patch: {} },
+        :'/bar/{key}'=> { get: {}, delete: {}, post: {}, put: {}, patch: {}},
+      }}
+      let(:expected) {[
+        { post: {}, put: {}, patch: {}},
+        { post: {}, put: {}, patch: {}},
+      ]}
+      specify { expect { |b| subject.find_post_put(paths, &b) }.to yield_control.twice }
+      specify { expect { |b| subject.find_post_put(paths, &b) }.to yield_successive_args *expected }
+    end
+  end
+
+  describe 'build_definition' do
+    let(:verb) { 'post' }
+    let(:name) { 'Foo' }
+    let(:definitions) {{}}
+
+    specify do
+      subject.instance_variable_set(:@definitions, definitions)
+      subject.build_definition(verb, name)
+
+      definition = definitions.to_a.first
+      expect(definition.first).to eql :postRequestFoo
+      expect(definition.last).to eql({ type: 'object', properties: {}, required: [] })
+    end
+  end
+
+  describe 'move_params_to_new definition' do
+    let(:name) { 'Foo' }
+    let(:definitions) {{}}
+
+    describe 'post request' do
+      let(:verb) { 'post' }
+      let(:params) { paths["/in_body"][:post][:parameters] }
+
+      specify do
+        subject.instance_variable_set(:@definitions, definitions)
+        name = subject.build_definition(verb, name)
+        subject.move_params_to_new(verb, name, params)
+
+        expect(definitions[name]).to eql expected_post_defs
+        expect(params).to be_empty
+      end
+    end
+
+    describe 'put request' do
+      let(:verb) { 'put' }
+      let(:params) { paths["/in_body/{key}"][:put][:parameters] }
+
+      specify do
+        subject.instance_variable_set(:@definitions, definitions)
+        name, definition = subject.build_definition(verb, name)
+        subject.move_params_to_new(verb, name, params)
+
+        expect(definitions[name]).to eql expected_put_defs
+        expect(params.length).to be 1
+      end
+    end
+  end
+
+  describe 'find_definition' do
+    specify do
+      subject.instance_variable_set(:@definitions, definitions)
+      subject.find_definition_and_parameters(found_path)
+
+      expect(definitions.keys).to include 'InBody', :postRequestInBody
+    end
+  end
+
+  describe 'build_body_parameter' do
+    let(:response) {{ schema: { '$ref' => '#/definitions/Somewhere'} }}
+
+    describe 'no name given' do
+      let(:expected_param) {
+        {:name=>"Somewhere", :in=>"body", :required=>true, :schema=>{'$ref' => "#/definitions/Somewhere"}}
+      }
+      specify do
+        parameter = subject.build_body_parameter(response)
+        expect(parameter).to eql expected_param
+      end
+    end
+
+    describe 'name given' do
+      let(:name) { 'Foo' }
+      let(:expected_param) {
+        {:name=>"Somewhere", :in=>"body", :required=>true, :schema=>{'$ref' => "#/definitions/#{name}"}}
+      }
+      specify do
+        parameter = subject.build_body_parameter(response, name)
+        expect(parameter).to eql expected_param
+      end
+    end
+  end
+
+  describe 'private methods' do
+    describe 'parse_model' do
+      let(:ref) { '#/definitions/InBody' }
+      subject(:object) { described_class.send(:parse_model, ref) }
+
+      specify { expect(object).to eql 'InBody' }
+    end
+
+    describe 'movable' do
+      describe 'path' do
+        let(:param) {{ in: "path", name: "key", description: nil, type: "integer", format: "int32", required: true }}
+        it { expect(subject.send(:movable?, param)).to be true }
+      end
+
+      describe 'body' do
+        let(:param) {{ in: "body", name: "in_body", description: "in_body", type: "integer", format: "int32", required: true }}
+        it { expect(subject.send(:movable?, param)).to be true }
+      end
+
+      describe 'query' do
+        let(:param) {{ in: "query", name: "in_query", description: "in_query", type: "integer", format: "int32", required: true }}
+        it { expect(subject.send(:movable?, param)).to be false }
+      end
+
+      describe 'header' do
+        let(:param) {{ in: "header", name: "in_header", description: "in_header", type: "integer", format: "int32", required: true }}
+        it { expect(subject.send(:movable?, param)).to be false }
+      end
+    end
+
+    describe 'deletable' do
+      describe 'path' do
+        let(:param) {{ in: "path", name: "key", description: nil, type: "integer", format: "int32", required: true }}
+        it { expect(subject.send(:deletable?, param)).to be false }
+      end
+
+      describe 'body' do
+        let(:param) {{ in: "body", name: "in_body_1", description: "in_body_1", type: "integer", format: "int32", required: true }}
+        it { expect(subject.send(:deletable?, param)).to be true }
+      end
+
+      describe 'query' do
+        let(:param) {{ in: "query", name: "in_query_1", description: "in_query_1", type: "integer", format: "int32", required: true }}
+        it { expect(subject.send(:deletable?, param)).to be false }
+      end
+
+      describe 'header' do
+        let(:param) {{ in: "header", name: "in_header_1", description: "in_header_1", type: "integer", format: "int32", required: true }}
+        it { expect(subject.send(:deletable?, param)).to be false }
+      end
+    end
+
+    describe 'should move' do
+      describe 'no move' do
+        let(:params) {[
+          { in: "path", name: "key", description: nil, type: "integer", format: "int32", required: true },
+          { in: "formData", name: "in_form_data", description: "in_form_data", type: "integer", format: "int32", required: true }
+        ]}
+        it { expect(subject.send(:should_move?, params)).to be false }
+      end
+
+      describe 'move' do
+        let(:params) {[
+          { in: "path", name: "key", description: nil, type: "integer", format: "int32", required: true },
+          { in: "body", name: "in_bosy", description: "in_bosy", type: "integer", format: "int32", required: true },
+          { in: "formData", name: "in_form_data", description: "in_form_data", type: "integer", format: "int32", required: true }
+        ]}
+        it { expect(subject.send(:should_move?, params)).to be true }
+      end
+    end
+
+    describe 'unify' do
+      before do
+        subject.send(:unify!, params) if subject.send(:should_move?, params)
+      end
+      describe 'param type with `:in` given' do
+        let(:params) {[
+          { in: "path", name: "key", description: nil, type: "integer", format: "int32", required: true },
+          { in: "body", name: "in_body", description: "in_body", type: "integer", format: "int32", required: true },
+          { in: "query", name: "in_query", description: "in_query", type: "integer", format: "int32", required: true },
+          { in: "header", name: "in_header", description: "in_header", type: "integer", format: "int32", required: true },
+          { in: "formData", name: "in_form_data", description: "in_form_data", type: "integer", format: "int32", required: true }
+        ]}
+
+        let(:expected_params) {[
+          { in: "path", name: "key", description: nil, type: "integer", format: "int32", required: true },
+          { in: "body", name: "in_body", description: "in_body", type: "integer", format: "int32", required: true },
+          { in: "query", name: "in_query", description: "in_query", type: "integer", format: "int32", required: true },
+          { in: "header", name: "in_header", description: "in_header", type: "integer", format: "int32", required: true },
+          { in: "body", name: "in_form_data", description: "in_form_data", type: "integer", format: "int32", required: true }
+        ]}
+        it { expect(params).to eql expected_params }
+      end
+
+      describe 'let it as is' do
+        let(:params) {[
+          { in: "path", name: "key", description: nil, type: "integer", format: "int32", required: true },
+          { in: "formData", name: "in_form_data", description: "in_form_data", type: "integer", format: "int32", required: true }
+        ]}
+
+        let(:expected_params) {[
+          { in: "path", name: "key", description: nil, type: "integer", format: "int32", required: true },
+          { in: "formData", name: "in_form_data", description: "in_form_data", type: "integer", format: "int32", required: true }
+        ]}
+        it { expect(params).to eql expected_params }
+
+      end
+
+      describe 'param type with `:param_type` given' do
+        let(:params) {[
+          { param_type: "path", name: "key", description: nil, type: "integer", format: "int32", required: true },
+          { param_type: "body", name: "in_body", description: "in_body", type: "integer", format: "int32", required: true },
+          { param_type: "query", name: "in_query", description: "in_query", type: "integer", format: "int32", required: true },
+          { param_type: "header", name: "in_header", description: "in_header", type: "integer", format: "int32", required: true },
+          { param_type: "formData", name: "in_form_data", description: "in_form_data", type: "integer", format: "int32", required: true }
+        ]}
+
+        let(:expected_params) {[
+          { name: "key", description: nil, type: "integer", format: "int32", required: true, in: "path" },
+          { name: "in_body", description: "in_body", type: "integer", format: "int32", required: true, in: "body" },
+          { name: "in_query", description: "in_query", type: "integer", format: "int32", required: true, in: "query" },
+          { name: "in_header", description: "in_header", type: "integer", format: "int32", required: true, in: "header" },
+          { name: "in_form_data", description: "in_form_data", type: "integer", format: "int32", required: true, in: "body" }
+        ]}
+        it { expect(params).to eql expected_params }
+      end
+    end
+
+  end
+end

--- a/spec/support/api_swagger_v2_result.rb
+++ b/spec/support/api_swagger_v2_result.rb
@@ -67,101 +67,133 @@ RSpec.shared_context "swagger example" do
         "termsOfServiceUrl"=>"www.The-URL-of-the-terms-and-service.com",
         "contact"=>{"name"=>"Contact name", "email"=>"Contact@email.com", "url"=>"Contact URL"},
         "license"=>{"name"=>"The name of the license.", "url"=>"www.The-URL-of-the-license.org"},
-        "version"=>"v1"},
-        "swagger"=>"2.0",
-        "produces"=>["application/json"],
-        "host"=>"example.org",
-        "basePath"=>"/api",
-        "tags"=>[
-          {"name"=>"other_thing", "description"=>"Operations about other_things"},
-          {"name"=>"thing", "description"=>"Operations about things"},
-          {"name"=>"thing2", "description"=>"Operations about thing2s"},
-          {"name"=>"dummy", "description"=>"Operations about dummies"}
-        ],
-        "schemes"=>["https", "http"],
-        "paths"=>{
-          "/v3/other_thing/{elements}"=>{
-            "get"=>{
-              "produces"=>["application/json"],
-              "parameters"=>[{"in"=>"body", "name"=>"elements", "description"=>"Set of configuration", "required"=>true, "type"=>"array", "items"=>{"type"=>"string"}}],
-              "responses"=>{"200"=>{"description"=>"nested route inside namespace", "schema"=>{"$ref"=>"#/definitions/QueryInput"}}},
-              "tags"=>["other_thing"],
-              "operationId"=>"getV3OtherThingElements",
-              "x-amazon-apigateway-auth"=>{"type"=>"none"},
-              "x-amazon-apigateway-integration"=>{"type"=>"aws", "uri"=>"foo_bar_uri", "httpMethod"=>"get"}}
+        "version"=>"v1"
+      },
+      "swagger"=>"2.0",
+      "produces"=>["application/json"],
+      "host"=>"example.org",
+      "basePath"=>"/api",
+      "tags"=>[
+        {"name"=>"other_thing", "description"=>"Operations about other_things"},
+        {"name"=>"thing", "description"=>"Operations about things"},
+        {"name"=>"thing2", "description"=>"Operations about thing2s"},
+        {"name"=>"dummy", "description"=>"Operations about dummies"}
+      ],
+      "schemes"=>["https", "http"],
+      "paths"=>{
+        "/v3/other_thing/{elements}"=>{
+          "get"=>{
+            "description"=>"nested route inside namespace",
+            "produces"=>["application/json"],
+            "parameters"=>[{"in"=>"body", "name"=>"elements", "description"=>"Set of configuration", "type"=>"array", "items"=>{"type"=>"string"}, "required"=>true}],
+            "responses"=>{"200"=>{"description"=>"nested route inside namespace", "schema"=>{"$ref"=>"#/definitions/QueryInput"}}},
+            "tags"=>["other_thing"],
+            "operationId"=>"getV3OtherThingElements",
+            "x-amazon-apigateway-auth"=>{"type"=>"none"},
+            "x-amazon-apigateway-integration"=>{"type"=>"aws", "uri"=>"foo_bar_uri", "httpMethod"=>"get"}
+          }
+        },
+        "/thing"=>{
+          "get"=>{
+            "description"=>"This gets Things.",
+            "produces"=>["application/json"],
+            "parameters"=>[
+              {"in"=>"query", "name"=>"id", "description"=>"Identity of Something", "type"=>"integer", "format"=>"int32", "required"=>false},
+              {"in"=>"query", "name"=>"text", "description"=>"Content of something.", "type"=>"string", "required"=>false},
+              {"in"=>"formData", "name"=>"links", "description"=>nil, "type"=>"array", "items"=>{"type"=>"link"}, "required"=>false},
+              {"in"=>"query", "name"=>"others", "description"=>nil, "type"=>"text", "required"=>false}
+            ],
+            "responses"=>{"200"=>{"description"=>"This gets Things.", "schema"=>{"$ref"=>"#/definitions/Thing"}}, "401"=>{"description"=>"Unauthorized", "schema"=>{"$ref"=>"#/definitions/ApiError"}}},
+            "tags"=>["thing"],
+            "operationId"=>"getThing"
           },
-          "/thing"=>{
-            "get"=>{
-              "produces"=>["application/json"],
-              "parameters"=>[
-                {"in"=>"query", "name"=>"id", "description"=>"Identity of Something", "required"=>false, "type"=>"integer", "format"=>"int32"},
-                {"in"=>"query", "name"=>"text", "description"=>"Content of something.", "required"=>false, "type"=>"string"},
-                {"in"=>"formData", "name"=>"links", "description"=>nil, "required"=>false, "type"=>"array", "items"=>{"type"=>"link"}},
-                {"in"=>"query", "name"=>"others", "description"=>nil, "required"=>false, "type"=>"text"}
-              ],
-              "responses"=>{"200"=>{"description"=>"This gets Things.", "schema"=>{"$ref"=>"#/definitions/Thing"}}, "401"=>{"description"=>"Unauthorized", "schema"=>{"$ref"=>"#/definitions/ApiError"}}},
-              "tags"=>["thing"],
-              "operationId"=>"getThing"},
-            "post"=>{
-              "produces"=>["application/json"],
-              "consumes"=>["application/json"],
-              "parameters"=>[
-                {"in"=>"formData", "name"=>"text", "description"=>"Content of something.", "required"=>true, "type"=>"string"},
-                {"in"=>"formData", "name"=>"links", "description"=>nil, "required"=>true, "type"=>"array", "items"=>{"type"=>"string"}}
-              ],
-              "responses"=>{"201"=>{"description"=>"This creates Thing.", "schema"=>{"$ref"=>"#/definitions/Something"}}, "422"=>{"description"=>"Unprocessible Entity"}},
-              "tags"=>["thing"],
-              "operationId"=>"postThing"
-          }},
-          "/thing/{id}"=>{
-            "get"=>{
-              "produces"=>["application/json"],
-              "parameters"=>[{"in"=>"path", "name"=>"id", "description"=>nil, "required"=>true, "type"=>"integer", "format"=>"int32"}],
-              "responses"=>{"200"=>{"description"=>"getting a single thing", "schema"=>{"$ref"=>"#/definitions/Thing"}}, "401"=>{"description"=>"Unauthorized"}},
-              "tags"=>["thing"],
-              "operationId"=>"getThingId"
-            },
-            "put"=>{
-              "produces"=>["application/json"],
-              "consumes"=>["application/json"],
-              "parameters"=>[
-                {"in"=>"path", "name"=>"id", "description"=>nil, "required"=>true, "type"=>"integer", "format"=>"int32"},
-                {"in"=>"formData", "name"=>"text", "description"=>"Content of something.", "required"=>false, "type"=>"string"},
-                {"in"=>"formData", "name"=>"links", "description"=>nil, "required"=>false, "type"=>"array", "items"=>{"type"=>"string"}}
-              ],
-              "responses"=>{"200"=>{"description"=>"This updates Thing.", "schema"=>{"$ref"=>"#/definitions/Something"}}},
-              "tags"=>["thing"],
-              "operationId"=>"putThingId"
-            },
-            "delete"=>{
-              "produces"=>["application/json"],
-              "parameters"=>[{"in"=>"path", "name"=>"id", "description"=>nil, "required"=>true, "type"=>"integer", "format"=>"int32"}],
-              "responses"=>{"200"=>{"description"=>"This deletes Thing.", "schema"=>{"$ref"=>"#/definitions/Something"}}},
-              "tags"=>["thing"],
-              "operationId"=>"deleteThingId"
-          }},
-          "/thing2"=>{
-            "get"=>{
-              "produces"=>["application/json"],
-              "responses"=>{"200"=>{"description"=>"get Horses", "schema"=>{"$ref"=>"#/definitions/Something"}}, "401"=>{"description"=>"HorsesOutError", "schema"=>{"$ref"=>"#/definitions/ApiError"}}},
-              "tags"=>["thing2"],
-              "operationId"=>"getThing2"
-          }},
-          "/dummy/{id}"=>{
-            "delete"=>{
-              "produces"=>["application/json"],
-              "parameters"=>[{"in"=>"path", "name"=>"id", "description"=>nil, "required"=>true, "type"=>"integer", "format"=>"int32"}],
-              "responses"=>{"204"=>{"description"=>"dummy route."}, "401"=>{"description"=>"Unauthorized"}},
-              "tags"=>["dummy"],
-              "operationId"=>"deleteDummyId"
-        }}},
-        "definitions"=>{
-          "QueryInput"=>{"type"=>"object", "properties"=>{"elements"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/QueryInputElement"}}}},
-          "QueryInputElement"=>{"type"=>"object", "properties"=>{"key"=>{"type"=>"string"}, "value"=>{"type"=>"string"}}},
-          "Thing"=>{"type"=>"object", "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32"}, "text"=>{"type"=>"string"}, "links"=>{"type"=>"link"}, "others"=>{"type"=>"text"}}},
-          "ApiError"=>{"type"=>"object", "properties"=>{"code"=>{"type"=>"integer", "format"=>"int32"}, "message"=>{"type"=>"string"}}},
-          "Something"=>{"type"=>"object", "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32"}, "text"=>{"type"=>"string"}, "links"=>{"type"=>"link"}, "others"=>{"type"=>"text"}}}
-    }}
+          "post"=>{
+            "description"=>"This creates Thing.",
+            "produces"=>["application/json"],
+            "consumes"=>["application/json"],
+            "parameters"=>[
+              {"in"=>"formData", "name"=>"text", "description"=>"Content of something.", "type"=>"string", "required"=>true},
+              {"in"=>"formData", "name"=>"links", "description"=>nil, "type"=>"array", "items"=>{"type"=>"string"}, "required"=>true}
+            ],
+            "responses"=>{"201"=>{"description"=>"This creates Thing.", "schema"=>{"$ref"=>"#/definitions/Something"}}, "422"=>{"description"=>"Unprocessible Entity"}},
+            "tags"=>["thing"],
+            "operationId"=>"postThing"
+          }
+        },
+        "/thing/{id}"=>{
+          "get"=>{
+            "description"=>"This gets Thing.",
+            "produces"=>["application/json"],
+            "parameters"=>[{"in"=>"path", "name"=>"id", "description"=>nil, "type"=>"integer", "format"=>"int32", "required"=>true}],
+            "responses"=>{"200"=>{"description"=>"getting a single thing", "schema"=>{"$ref"=>"#/definitions/Thing"}}, "401"=>{"description"=>"Unauthorized"}},
+            "tags"=>["thing"],
+            "operationId"=>"getThingId"
+          },
+          "put"=>{
+            "description"=>"This updates Thing.",
+            "produces"=>["application/json"],
+            "consumes"=>["application/json"],
+            "parameters"=>[
+              {"in"=>"path", "name"=>"id", "description"=>nil, "type"=>"integer", "format"=>"int32", "required"=>true},
+              {"in"=>"formData", "name"=>"text", "description"=>"Content of something.", "type"=>"string", "required"=>false},
+              {"in"=>"formData", "name"=>"links", "description"=>nil, "type"=>"array", "items"=>{"type"=>"string"}, "required"=>false}
+            ],
+            "responses"=>{"200"=>{"description"=>"This updates Thing.", "schema"=>{"$ref"=>"#/definitions/Something"}}},
+            "tags"=>["thing"],
+            "operationId"=>"putThingId"
+          },
+          "delete"=>{
+            "description"=>"This deletes Thing.",
+            "produces"=>["application/json"],
+            "parameters"=>[{"in"=>"path", "name"=>"id", "description"=>nil, "type"=>"integer", "format"=>"int32", "required"=>true}],
+            "responses"=>{"200"=>{"description"=>"This deletes Thing.", "schema"=>{"$ref"=>"#/definitions/Something"}}},
+            "tags"=>["thing"],
+            "operationId"=>"deleteThingId"
+          }
+        },
+        "/thing2"=>{
+          "get"=>{
+            "description"=>"This gets Things.",
+            "produces"=>["application/json"],
+            "responses"=>{"200"=>{"description"=>"get Horses", "schema"=>{"$ref"=>"#/definitions/Something"}}, "401"=>{"description"=>"HorsesOutError", "schema"=>{"$ref"=>"#/definitions/ApiError"}}},
+            "tags"=>["thing2"],
+            "operationId"=>"getThing2"
+          }
+        },
+        "/dummy/{id}"=>{
+          "delete"=>{
+            "description"=>"dummy route.",
+            "produces"=>["application/json"],
+            "parameters"=>[{"in"=>"path", "name"=>"id", "description"=>nil, "type"=>"integer", "format"=>"int32", "required"=>true}],
+            "responses"=>{"204"=>{"description"=>"dummy route."}, "401"=>{"description"=>"Unauthorized"}},
+            "tags"=>["dummy"],
+            "operationId"=>"deleteDummyId"
+          }
+        }
+      },
+      "definitions"=>{
+        "QueryInput"=>{
+          "type"=>"object",
+          "properties"=>{"elements"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/QueryInputElement"}}},
+          "description"=>"nested route inside namespace"},
+        "QueryInputElement"=>{
+          "type"=>"object",
+          "properties"=>{"key"=>{"type"=>"string"}, "value"=>{"type"=>"string"}}},
+        "Thing"=>{
+          "type"=>"object",
+          "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32"}, "text"=>{"type"=>"string"}, "links"=>{"type"=>"link"}, "others"=>{"type"=>"text"}},
+          "description"=>"This gets Thing."},
+        "ApiError"=>{
+          "type"=>"object",
+          "properties"=>{"code"=>{"type"=>"integer", "format"=>"int32"}, "message"=>{"type"=>"string"}},
+          "description"=>"This gets Things."},
+        "Something"=>{
+          "type"=>"object",
+          "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32"}, "text"=>{"type"=>"string"}, "links"=>{"type"=>"link"}, "others"=>{"type"=>"text"}},
+          "description"=>"This gets Things."
+        }
+      }
+    }
   end
 
   let(:http_verbs) { %w[get post put delete]}

--- a/spec/support/the_api_entities.rb
+++ b/spec/support/the_api_entities.rb
@@ -28,9 +28,21 @@ RSpec.shared_context "the api entities" do
           expose :items, as: '$responses', using: Entities::ResponseItem, documentation: { is_array: true }
         end
 
-        class UseTemResponseAsType < Grape::Entity
+        class UseItemResponseAsType < Grape::Entity
           expose :description, documentation: { type: String }
           expose :responses, documentation: { type: Entities::ResponseItem, is_array: false }
+        end
+
+        class UseAddress < Grape::Entity
+          expose :street, documentation: { type: String, desc: 'street' }
+          expose :postcode, documentation: { type: String, desc: 'postcode' }
+          expose :city, documentation: { type: String, desc: 'city' }
+          expose :country, documentation: { type: String, desc: 'country' }
+        end
+
+        class UseNestedWithAddress < Grape::Entity
+          expose :name, documentation: { type: String }
+          expose :address, using: Entities::UseAddress
         end
       end
     end

--- a/spec/support/the_paths_definitions.rb
+++ b/spec/support/the_paths_definitions.rb
@@ -1,0 +1,94 @@
+RSpec.shared_context "the api paths/defs" do
+  let(:paths) {{
+    "/in_body" => {
+      post: {
+        produces: ["application/json"],
+        consumes: ["application/json"],
+        parameters: [
+          {in: "body", name: "in_body_1", description: "in_body_1", type: "integer", format: "int32", required: true},
+          {in: "body", name: "in_body_2", description: "in_body_2", type: "string", required: false},
+          {in: "body", name: "in_body_3", description: "in_body_3", type: "string", required: false}
+        ],
+        responses: {201 => {description: "post in body /wo entity", schema: {"$ref" => "#/definitions/InBody"}}},
+        tags: ["in_body"],
+        operationId: "postInBody"
+      },
+      get: {
+        produces: ["application/json"],
+        responses: {200 => {description: "get in path /wo entity", schema: {"$ref" => "#/definitions/InBody"}}},
+        tags: ["in_body"],
+        operationId: "getInBody"
+      }
+    },
+    "/in_body/{key}" => {
+      put: {
+        produces: ["application/json"],
+        consumes: ["application/json"],
+        parameters: [
+          {in: "path", name: "key", description: nil, type: "integer", format: "int32", required: true},
+          {in: "body", name: "in_body_1", description: "in_body_1", type: "integer", format: "int32", required: true},
+          {in: "body", name: "in_body_2", description: "in_body_2", type: "string", required: false},
+          {in: "body", name: "in_body_3", description: "in_body_3", type: "string", required: false}
+        ],
+        responses: {200 => {description: "put in body /wo entity", schema: {"$ref" => "#/definitions/InBody"}}},
+        tags: ["in_body"],
+        operationId: "putInBodyKey"
+      },
+      get: {
+        produces: ["application/json"],
+        parameters: [
+          {in: "path", name: "key", description: nil, type: "integer", format: "int32", required: true}
+        ],
+        responses: {200 => {description: "get in path /wo entity", schema: {"$ref" => "#/definitions/InBody"}}},
+        tags: ["in_body"],
+        operationId: "getInBodyKey"
+    }}
+  }}
+
+  let(:found_path) {{
+    post: {
+      produces: ["application/json"],
+      consumes: ["application/json"],
+      parameters: [
+        {in: "body", name: "in_body_1", description: "in_body_1", type: "integer", format: "int32", required: true},
+        {in: "body", name: "in_body_2", description: "in_body_2", type: "string", required: false},
+        {in: "body", name: "in_body_3", description: "in_body_3", type: "string", required: false}
+      ],
+      responses: {201 =>  {description: "post in body /wo entity", schema: {"$ref"=>"#/definitions/InBody"}}},
+      tags: ["in_body"],
+      operationId: "postInBody"
+  }}}
+
+  let(:definitions) {{
+    "InBody" => {
+      type: "object",
+      properties: {
+        in_body_1: {type: "integer", format: "int32"},
+        in_body_2: {type: "string"},
+        in_body_3: {type: "string"},
+        key: {type: "integer", format: "int32"}
+  }}}}
+
+  let(:expected_post_defs) {{
+    type: "object",
+    properties: {
+      in_body_1: {type: "integer", format: "int32", description: "in_body_1"},
+      in_body_2: {type: "string", description: "in_body_2"},
+      in_body_3: {type: "string", description: "in_body_3"}
+    },
+    :required=>[:in_body_1]
+  }}
+
+  let(:expected_put_defs) {{
+    type: "object",
+    properties: {
+      in_body_1: {type: "integer", format: "int32", description: "in_body_1"},
+      in_body_2: {type: "string", description: "in_body_2"},
+      in_body_3: {type: "string", description: "in_body_3"},
+      key: {type: "integer", format: "int32", readOnly: true}
+    },
+    :required=>[:in_body_1]
+  }}
+
+  let(:expected_path) {[]}
+end

--- a/spec/swagger_v2/api_swagger_v2_detail_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_detail_spec.rb
@@ -64,12 +64,12 @@ describe 'details' do
 
     specify do
       expect(subject['paths']['/use_detail']['get']).to include('description')
-      expect(subject['paths']['/use_detail']['get']['description']).to eql 'detailed description of the route'
+      expect(subject['paths']['/use_detail']['get']['description']).to eql "This returns something\n detailed description of the route"
     end
 
     specify do
       expect(subject['paths']['/use_detail_block']['get']).to include('description')
-      expect(subject['paths']['/use_detail_block']['get']['description']).to eql 'detailed description of the route inside the `desc` block'
+      expect(subject['paths']['/use_detail_block']['get']['description']).to eql "This returns something\n detailed description of the route inside the `desc` block"
     end
   end
 
@@ -106,7 +106,7 @@ describe 'details' do
     specify do
       expect(subject['paths']['/use_gfm_detail']['get']).to include('description')
       expect(subject['paths']['/use_gfm_detail']['get']['description']).to eql(
-        "<h1 id=\"burgers-in-heaven\">Burgers in Heaven</h1>\n\n<blockquote>\n  <p>A burger doesn’t come for free</p>\n</blockquote>\n\n<p>If you want to reserve a burger in heaven, you have to do<br />\nsome crazy stuff on earth.</p>\n\n<pre><code>def do_good\nputs 'help people'\nend\n</code></pre>\n\n<ul>\n  <li><em>Will go to Heaven:</em> Probably</li>\n  <li><em>Will go to Hell:</em> Probably not</li>\n</ul>"
+        "<h1 id=\"this-returns-something\">This returns something</h1>\n<p># Burgers in Heaven</p>\n\n<blockquote>\n  <p>A burger doesn’t come for free</p>\n</blockquote>\n\n<p>If you want to reserve a burger in heaven, you have to do<br />\nsome crazy stuff on earth.</p>\n\n<pre><code>def do_good\nputs 'help people'\nend\n</code></pre>\n\n<ul>\n  <li><em>Will go to Heaven:</em> Probably</li>\n  <li><em>Will go to Hell:</em> Probably not</li>\n</ul>"
       )
     end
   end
@@ -144,7 +144,7 @@ describe 'details' do
     specify do
       expect(subject['paths']['/use_gfm_rc_detail']['get']).to include('description')
       expect(subject['paths']['/use_gfm_rc_detail']['get']['description']).to eql(
-        "<h1>Burgers in Heaven</h1>\n\n<blockquote>\n<p>A burger doesn&#39;t come for free</p>\n</blockquote>\n\n<p>If you want to reserve a burger in heaven, you have to do\nsome crazy stuff on earth.</p>\n<pre class=\"highlight plaintext\"><code>def do_good\nputs 'help people'\nend\n</code></pre>\n\n<ul>\n<li><em>Will go to Heaven:</em> Probably</li>\n<li><em>Will go to Hell:</em> Probably not</li>\n</ul>"
+        "<h1>This returns something</h1>\n\n<p># Burgers in Heaven</p>\n\n<blockquote>\n<p>A burger doesn&#39;t come for free</p>\n</blockquote>\n\n<p>If you want to reserve a burger in heaven, you have to do\nsome crazy stuff on earth.</p>\n<pre class=\"highlight plaintext\"><code>def do_good\nputs 'help people'\nend\n</code></pre>\n\n<ul>\n<li><em>Will go to Heaven:</em> Probably</li>\n<li><em>Will go to Hell:</em> Probably not</li>\n</ul>"
       )
     end
   end

--- a/spec/swagger_v2/api_swagger_v2_param_type_body_nested_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_param_type_body_nested_spec.rb
@@ -1,0 +1,192 @@
+require 'spec_helper'
+
+describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `header`' do
+  include_context "the api entities"
+
+  before :all do
+    module TheApi
+      class NestedBodyParamTypeApi < Grape::API
+        namespace :simple_nested_params do
+          desc 'post in body with nested parameters',
+            detail: 'more details description',
+            success: TheApi::Entities::UseNestedWithAddress
+          params do
+            requires :name, type: String, documentation: { desc: 'name', in: 'body' }
+            optional :address, type: Hash do
+              requires :street, type: String, documentation: { desc: 'street', in: 'body' }
+              requires :postcode, type: String, documentation: { desc: 'postcode', in: 'body' }
+              requires :city, type: String, documentation: { desc: 'city', in: 'body' }
+              optional :country, type: String, documentation: { desc: 'country', in: 'body' }
+            end
+          end
+
+          post '/in_body' do
+            { "declared_params" => declared(params) }
+          end
+
+          desc 'put in body with nested parameters',
+            detail: 'more details description',
+            success: TheApi::Entities::UseNestedWithAddress
+          params do
+            requires :id, type: Integer
+            optional :name, type: String, documentation: { desc: 'name', in: 'body' }
+            optional :address, type: Hash do
+              optional :street, type: String, documentation: { desc: 'street', in: 'body' }
+              optional :postcode, type: String, documentation: { desc: 'postcode', in: 'formData' }
+              optional :city, type: String, documentation: { desc: 'city', in: 'body' }
+              optional :country, type: String, documentation: { desc: 'country', in: 'body' }
+            end
+          end
+
+          put '/in_body/:id' do
+            { "declared_params" => declared(params) }
+          end
+        end
+
+        namespace :multiple_nested_params do
+          desc 'put in body with multiple nested parameters',
+            success: TheApi::Entities::UseNestedWithAddress
+          params do
+            requires :id, type: Integer
+            optional :name, type: String, documentation: { desc: 'name', in: 'body' }
+            optional :address, type: Hash do
+              optional :street, type: String, documentation: { desc: 'street', in: 'body' }
+              requires :postcode, type: String, documentation: { desc: 'postcode', in: 'formData' }
+              optional :city, type: String, documentation: { desc: 'city', in: 'body' }
+              optional :country, type: String, documentation: { desc: 'country', in: 'body' }
+            end
+            optional :delivery_address, type: Hash do
+              optional :street, type: String, documentation: { desc: 'street', in: 'body' }
+              optional :postcode, type: String, documentation: { desc: 'postcode', in: 'formData' }
+              optional :city, type: String, documentation: { desc: 'city', in: 'body' }
+              optional :country, type: String, documentation: { desc: 'country', in: 'body' }
+            end
+          end
+
+          put '/in_body/:id' do
+            { "declared_params" => declared(params) }
+          end
+        end
+
+        add_swagger_documentation
+      end
+    end
+  end
+
+  def app
+    TheApi::NestedBodyParamTypeApi
+  end
+
+  describe 'nested body parameters given' do
+    subject do
+      get '/swagger_doc/simple_nested_params'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/simple_nested_params/in_body']['post']['parameters']).to eql([{
+        "name"=>"UseNestedWithAddress",
+        "in"=>"body",
+        "required"=>true,
+        "schema"=>{"$ref"=>"#/definitions/postRequestUseNestedWithAddress"}
+      }])
+    end
+
+    specify do
+      expect(subject['definitions']['postRequestUseNestedWithAddress']).to eql({
+        "description" => "post in body with nested parameters\n more details description",
+        "type"=>"object",
+        "properties"=>{
+          "address"=>{"$ref"=>"#/definitions/postRequestUseNestedWithAddressAddress"},
+          "name"=>{"type"=>"string", "description"=>"name"}
+        },
+        "required"=>["name"]
+      })
+      expect(subject['definitions']['postRequestUseNestedWithAddressAddress']).to eql({
+        "type"=>"object",
+        "properties"=>{
+          "street"=>{"type"=>"string", "description"=>"street"},
+          "postcode"=>{"type"=>"string", "description"=>"postcode"},
+          "city"=>{"type"=>"string", "description"=>"city"},
+          "country"=>{"type"=>"string", "description"=>"country"}
+        },
+        "required"=>["street", "postcode", "city"]
+      })
+    end
+
+    specify do
+      expect(subject['paths']['/simple_nested_params/in_body/{id}']['put']['parameters']).to eql([
+        {"in"=>"path", "name"=>"id", "description"=>nil, "type"=>"integer", "format"=>"int32", "required"=>true},
+        {
+          "name"=>"UseNestedWithAddress",
+          "in"=>"body",
+          "required"=>true,
+          "schema"=>{"$ref"=>"#/definitions/putRequestUseNestedWithAddress"}
+        }
+      ])
+    end
+
+    specify do
+      expect(subject['definitions']['putRequestUseNestedWithAddress']).to eql({
+        "description" => "put in body with nested parameters\n more details description",
+        "type"=>"object",
+        "properties"=>{
+          "address"=>{"$ref"=>"#/definitions/putRequestUseNestedWithAddressAddress"},
+          "id"=>{"type"=>"integer", "format"=>"int32", "readOnly"=>true},
+          "name"=>{"type"=>"string", "description"=>"name"}
+      }})
+      expect(subject['definitions']['putRequestUseNestedWithAddressAddress']).to eql({
+        "type"=>"object",
+        "properties"=>{
+          "street"=>{"type"=>"string", "description"=>"street"},
+          "postcode"=>{"type"=>"string", "description"=>"postcode"},
+          "city"=>{"type"=>"string", "description"=>"city"},
+          "country"=>{"type"=>"string", "description"=>"country"}
+      }})
+    end
+  end
+
+  describe 'multiple nested body parameters given' do
+    subject do
+      get '/swagger_doc/multiple_nested_params'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/multiple_nested_params/in_body/{id}']['put']['parameters']).to eql([
+        {"in"=>"path", "name"=>"id", "description"=>nil, "type"=>"integer", "format"=>"int32", "required"=>true},
+        {"name"=>"UseNestedWithAddress", "in"=>"body", "required"=>true, "schema"=>{"$ref"=>"#/definitions/putRequestUseNestedWithAddress"}}
+      ])
+    end
+
+    specify do
+      expect(subject['definitions']['putRequestUseNestedWithAddress']).to eql({
+        "description" => "put in body with multiple nested parameters",
+        "type"=>"object",
+        "properties"=>{
+          "address"=>{"$ref"=>"#/definitions/putRequestUseNestedWithAddressAddress"},
+          "delivery_address"=>{"$ref"=>"#/definitions/putRequestUseNestedWithAddressDeliveryAddress"},
+          "id"=>{"type"=>"integer", "format"=>"int32", "readOnly"=>true},
+          "name"=>{"type"=>"string", "description"=>"name"}
+      }})
+      expect(subject['definitions']['putRequestUseNestedWithAddressAddress']).to eql({
+        "type"=>"object",
+        "properties"=>{
+          "street"=>{"type"=>"string", "description"=>"street"},
+          "postcode"=>{"type"=>"string", "description"=>"postcode"},
+          "city"=>{"type"=>"string", "description"=>"city"},
+          "country"=>{"type"=>"string", "description"=>"country"}
+        },
+        "required"=>["postcode"]
+      })
+      expect(subject['definitions']['putRequestUseNestedWithAddressDeliveryAddress']).to eql({
+        "type"=>"object",
+        "properties"=>{
+          "street"=>{"type"=>"string", "description"=>"street"},
+          "postcode"=>{"type"=>"string", "description"=>"postcode"},
+          "city"=>{"type"=>"string", "description"=>"city"},
+          "country"=>{"type"=>"string", "description"=>"country"}
+      }})
+    end
+  end
+end

--- a/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
@@ -1,0 +1,193 @@
+require 'spec_helper'
+
+describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `header`' do
+  include_context "the api entities"
+
+  before :all do
+    module TheApi
+      class BodyParamTypeApi < Grape::API
+        namespace :wo_entities do
+          desc 'post in body /wo entity'
+          params do
+            requires :in_body_1, type: Integer, documentation: { desc: 'in_body_1', param_type: 'body' }
+            optional :in_body_2, type: String, documentation: { desc: 'in_body_2', param_type: 'body' }
+            optional :in_body_3, type: String, documentation: { desc: 'in_body_3', param_type: 'body' }
+          end
+
+          post '/in_body' do
+            { "declared_params" => declared(params) }
+          end
+
+          desc 'put in body /wo entity'
+          params do
+            requires :key, type: Integer
+            optional :in_body_1, type: Integer, documentation: { desc: 'in_body_1', param_type: 'body' }
+            optional :in_body_2, type: String, documentation: { desc: 'in_body_2', param_type: 'body' }
+            optional :in_body_3, type: String, documentation: { desc: 'in_body_3', param_type: 'body' }
+          end
+
+          put '/in_body/:key' do
+            { "declared_params" => declared(params) }
+          end
+        end
+
+        namespace :with_entities do
+          desc 'post in body with entity',
+            success: TheApi::Entities::ResponseItem
+          params do
+            requires :name, type: String, documentation: { desc: 'name', param_type: 'body' }
+          end
+
+          post '/in_body' do
+            { "declared_params" => declared(params) }
+          end
+
+          desc 'put in body with entity',
+            success: TheApi::Entities::ResponseItem
+          params do
+            requires :id, type: Integer
+            optional :name, type: String, documentation: { desc: 'name', param_type: 'body' }
+          end
+
+          put '/in_body/:id' do
+            { "declared_params" => declared(params) }
+          end
+        end
+
+        # namespace :nested_params do
+        #   desc 'post in body with entity',
+        #     success: TheApi::Entities::UseNestedWithAddress
+        #   params do
+        #     requires :name, type: String, documentation: { desc: 'name', in: 'body' }
+        #     optional :address, type: Hash do
+        #       requires :street, type: String, documentation: { desc: 'street', in: 'body' }
+        #       requires :postcode, type: String, documentation: { desc: 'postcode', in: 'body' }
+        #       requires :city, type: String, documentation: { desc: 'city', in: 'body' }
+        #       optional :country, type: String, documentation: { desc: 'country', in: 'body' }
+        #     end
+        #   end
+        #
+        #   post '/in_body' do
+        #     { "declared_params" => declared(params) }
+        #   end
+        #
+        #   desc 'put in body with entity',
+        #     success: TheApi::Entities::UseNestedWithAddress
+        #   params do
+        #     requires :id, type: Integer
+        #     optional :name, type: String, documentation: { desc: 'name', in: 'body' }
+        #     optional :address, type: Hash do
+        #       optional :street, type: String, documentation: { desc: 'street', in: 'body' }
+        #       optional :postcode, type: String, documentation: { desc: 'postcode', in: 'formData' }
+        #       optional :city, type: String, documentation: { desc: 'city', in: 'body' }
+        #       optional :country, type: String, documentation: { desc: 'country', in: 'body' }
+        #     end
+        #   end
+        #
+        #   put '/in_body/:id' do
+        #     { "declared_params" => declared(params) }
+        #   end
+        # end
+
+        add_swagger_documentation
+      end
+    end
+  end
+
+  def app
+    TheApi::BodyParamTypeApi
+  end
+
+  describe 'no entity given' do
+    subject do
+      get '/swagger_doc/wo_entities'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/wo_entities/in_body']['post']['parameters']).to eql([
+        {"name"=>"InBody", "in"=>"body", "required"=>true, "schema"=>{"$ref"=>"#/definitions/postRequestInBody"}}
+      ])
+    end
+
+    specify do
+      expect(subject['definitions']['postRequestInBody']).to eql({
+        "type"=>"object",
+        "properties"=>{
+          "in_body_1"=>{"type"=>"integer", "format"=>"int32", "description"=>"in_body_1"},
+          "in_body_2"=>{"type"=>"string", "description"=>"in_body_2"},
+          "in_body_3"=>{"type"=>"string", "description"=>"in_body_3"}
+        },
+        "required"=>["in_body_1"]
+      })
+    end
+
+    specify do
+      expect(subject['paths']['/wo_entities/in_body/{key}']['put']['parameters']).to eql([
+        {"in"=>"path", "name"=>"key", "description"=>nil, "type"=>"integer", "format"=>"int32", "required"=>true},
+        {"name"=>"InBody", "in"=>"body", "required"=>true, "schema"=>{"$ref"=>"#/definitions/putRequestInBody"}}
+      ])
+    end
+
+    specify do
+      expect(subject['definitions']['putRequestInBody']).to eql({
+        "type"=>"object",
+        "properties"=>{
+          "key"=>{"type"=>"integer", "format"=>"int32", "readOnly"=>true},
+          "in_body_1"=>{"type"=>"integer", "format"=>"int32", "description"=>"in_body_1"},
+          "in_body_2"=>{"type"=>"string", "description"=>"in_body_2"},
+          "in_body_3"=>{"type"=>"string", "description"=>"in_body_3"}
+        }
+      })
+    end
+  end
+
+  describe 'entity given' do
+    subject do
+      get '/swagger_doc/with_entities'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/with_entities/in_body']['post']['parameters']).to eql([
+        {"name"=>"ResponseItem", "in"=>"body", "required"=>true, "schema"=>{"$ref"=>"#/definitions/postRequestResponseItem"}}
+      ])
+    end
+
+    specify do
+      expect(subject['definitions']['postRequestResponseItem']).to eql({
+        "type"=>"object",
+        "properties"=>{
+          "name"=>{"type"=>"string", "description"=>"name"}},
+          "required"=>["name"]
+      })
+    end
+
+    specify do
+      expect(subject['paths']['/with_entities/in_body/{id}']['put']['parameters']).to eql([
+        {"in"=>"path", "name"=>"id", "description"=>nil, "type"=>"integer", "format"=>"int32", "required"=>true},
+        {"name"=>"ResponseItem", "in"=>"body", "required"=>true, "schema"=>{"$ref"=>"#/definitions/putRequestResponseItem"}}
+      ])
+    end
+
+    specify do
+      expect(subject['definitions']['putRequestResponseItem']).to eql({
+        "type"=>"object",
+        "properties"=>{
+          "id"=>{"type"=>"integer", "format"=>"int32", "readOnly"=>true},
+          "name"=>{"type"=>"string", "description"=>"name"}}
+      })
+    end
+  end
+
+  # describe 'nested body parameters given' do
+  #   subject do
+  #     get '/swagger_doc/nested_params'
+  #     JSON.parse(last_response.body)
+  #   end
+  #
+  #   specify do
+  #     # ap subject
+  #   end
+  # end
+end

--- a/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
@@ -54,41 +54,6 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
           end
         end
 
-        # namespace :nested_params do
-        #   desc 'post in body with entity',
-        #     success: TheApi::Entities::UseNestedWithAddress
-        #   params do
-        #     requires :name, type: String, documentation: { desc: 'name', in: 'body' }
-        #     optional :address, type: Hash do
-        #       requires :street, type: String, documentation: { desc: 'street', in: 'body' }
-        #       requires :postcode, type: String, documentation: { desc: 'postcode', in: 'body' }
-        #       requires :city, type: String, documentation: { desc: 'city', in: 'body' }
-        #       optional :country, type: String, documentation: { desc: 'country', in: 'body' }
-        #     end
-        #   end
-        #
-        #   post '/in_body' do
-        #     { "declared_params" => declared(params) }
-        #   end
-        #
-        #   desc 'put in body with entity',
-        #     success: TheApi::Entities::UseNestedWithAddress
-        #   params do
-        #     requires :id, type: Integer
-        #     optional :name, type: String, documentation: { desc: 'name', in: 'body' }
-        #     optional :address, type: Hash do
-        #       optional :street, type: String, documentation: { desc: 'street', in: 'body' }
-        #       optional :postcode, type: String, documentation: { desc: 'postcode', in: 'formData' }
-        #       optional :city, type: String, documentation: { desc: 'city', in: 'body' }
-        #       optional :country, type: String, documentation: { desc: 'country', in: 'body' }
-        #     end
-        #   end
-        #
-        #   put '/in_body/:id' do
-        #     { "declared_params" => declared(params) }
-        #   end
-        # end
-
         add_swagger_documentation
       end
     end
@@ -112,6 +77,7 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
 
     specify do
       expect(subject['definitions']['postRequestInBody']).to eql({
+        "description" => "post in body /wo entity",
         "type"=>"object",
         "properties"=>{
           "in_body_1"=>{"type"=>"integer", "format"=>"int32", "description"=>"in_body_1"},
@@ -131,6 +97,7 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
 
     specify do
       expect(subject['definitions']['putRequestInBody']).to eql({
+        "description" => "put in body /wo entity",
         "type"=>"object",
         "properties"=>{
           "key"=>{"type"=>"integer", "format"=>"int32", "readOnly"=>true},
@@ -156,6 +123,7 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
 
     specify do
       expect(subject['definitions']['postRequestResponseItem']).to eql({
+        "description" => "post in body with entity",
         "type"=>"object",
         "properties"=>{
           "name"=>{"type"=>"string", "description"=>"name"}},
@@ -172,6 +140,7 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
 
     specify do
       expect(subject['definitions']['putRequestResponseItem']).to eql({
+        "description" => "put in body with entity",
         "type"=>"object",
         "properties"=>{
           "id"=>{"type"=>"integer", "format"=>"int32", "readOnly"=>true},
@@ -179,15 +148,4 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
       })
     end
   end
-
-  # describe 'nested body parameters given' do
-  #   subject do
-  #     get '/swagger_doc/nested_params'
-  #     JSON.parse(last_response.body)
-  #   end
-  #
-  #   specify do
-  #     # ap subject
-  #   end
-  # end
 end

--- a/spec/swagger_v2/api_swagger_v2_response_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_spec.rb
@@ -59,6 +59,7 @@ describe 'response' do
         "paths"=>{
           "/nested_type"=>{
             "get"=>{
+              "description"=>"This returns something",
               "produces"=>["application/json"],
               "responses"=>{
                 "200"=>{"description"=>"This returns something", "schema"=>{"$ref"=>"#/definitions/UseItemResponseAsType"}},
@@ -68,10 +69,21 @@ describe 'response' do
               "operationId"=>"getNestedType"
         }}},
         "definitions"=>{
-          "ResponseItem"=>{"type"=>"object", "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32"}, "name"=>{"type"=>"string"}}},
-          "UseItemResponseAsType"=>{"type"=>"object", "properties"=>{"description"=>{"type"=>"string"}, "responses"=>{"$ref"=>"#/definitions/ResponseItem"}}},
-          "ApiError"=>{"type"=>"object", "properties"=>{"code"=>{"type"=>"integer", "format"=>"int32"}, "message"=>{"type"=>"string"}}}
-      }})
+          "ResponseItem"=>{
+            "type"=>"object",
+            "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32"}, "name"=>{"type"=>"string"}}
+          },
+          "UseItemResponseAsType"=>{
+            "type"=>"object",
+            "properties"=>{"description"=>{"type"=>"string"}, "responses"=>{"$ref"=>"#/definitions/ResponseItem"}},
+            "description"=>"This returns something"
+          },
+          "ApiError"=>{
+            "type"=>"object",
+            "properties"=>{"code"=>{"type"=>"integer", "format"=>"int32"}, "message"=>{"type"=>"string"}},
+            "description"=>"This returns something"
+          }}
+        })
     end
   end
 
@@ -96,6 +108,7 @@ describe 'response' do
         "paths"=>{
           "/entity_response"=>{
             "get"=>{
+              "description"=>"This returns something",
               "produces"=>["application/json"],
               "tags"=>["entity_response"],
               "operationId"=>"getEntityResponse",
@@ -108,10 +121,14 @@ describe 'response' do
             "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32"}, "name"=>{"type"=>"string"}}},
           "UseResponse"=>{
             "type"=>"object",
-            "properties"=>{"description"=>{"type"=>"string"}, "$responses"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/ResponseItem"}}}},
+            "properties"=>{"description"=>{"type"=>"string"}, "$responses"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/ResponseItem"}}},
+            "description"=>"This returns something"
+          },
           "ApiError"=>{
             "type"=>"object",
-            "properties"=>{"code"=>{"type"=>"integer", "format"=>"int32"}, "message"=>{"type"=>"string"}}}
+            "properties"=>{"code"=>{"type"=>"integer", "format"=>"int32"}, "message"=>{"type"=>"string"}},
+            "description"=>"This returns something"
+          }
       }})
     end
   end
@@ -137,6 +154,7 @@ describe 'response' do
         "paths"=>{
           "/params_response"=>{
             "post"=>{
+              "description"=>"This returns something",
               "produces"=>["application/json"],
               "consumes"=>["application/json"],
               "parameters"=>[
@@ -149,8 +167,16 @@ describe 'response' do
                 "400"=>{"description"=>"NotFound", "schema"=>{"$ref"=>"#/definitions/ApiError"}}}
         }}},
         "definitions"=>{
-          "ParamsResponse"=>{"type"=>"object", "properties"=>{"description"=>{"type"=>"string"}, "$responses"=>{"type"=>"string"}}},
-          "ApiError"=>{"type"=>"object", "properties"=>{"code"=>{"type"=>"integer", "format"=>"int32"}, "message"=>{"type"=>"string"}}}
+          "ParamsResponse"=>{
+            "type"=>"object",
+            "properties"=>{"description"=>{"type"=>"string"}, "$responses"=>{"type"=>"string"}},
+            "description"=>"This returns something"
+          },
+          "ApiError"=>{
+            "type"=>"object",
+            "properties"=>{"code"=>{"type"=>"integer", "format"=>"int32"}, "message"=>{"type"=>"string"}},
+            "description"=>"This returns something"
+          }
       }})
     end
   end

--- a/spec/swagger_v2/api_swagger_v2_response_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_spec.rb
@@ -23,7 +23,7 @@ describe 'response' do
         end
 
         desc 'This returns something',
-          entity: Entities::UseTemResponseAsType,
+          entity: Entities::UseItemResponseAsType,
           failure: [{code: 400, message: 'NotFound', model: Entities::ApiError}]
         get '/nested_type' do
           { "declared_params" => declared(params) }
@@ -61,7 +61,7 @@ describe 'response' do
             "get"=>{
               "produces"=>["application/json"],
               "responses"=>{
-                "200"=>{"description"=>"This returns something", "schema"=>{"$ref"=>"#/definitions/UseTemResponseAsType"}},
+                "200"=>{"description"=>"This returns something", "schema"=>{"$ref"=>"#/definitions/UseItemResponseAsType"}},
                 "400"=>{"description"=>"NotFound", "schema"=>{"$ref"=>"#/definitions/ApiError"}}
               },
               "tags"=>["nested_type"],
@@ -69,7 +69,7 @@ describe 'response' do
         }}},
         "definitions"=>{
           "ResponseItem"=>{"type"=>"object", "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32"}, "name"=>{"type"=>"string"}}},
-          "UseTemResponseAsType"=>{"type"=>"object", "properties"=>{"description"=>{"type"=>"string"}, "responses"=>{"$ref"=>"#/definitions/ResponseItem"}}},
+          "UseItemResponseAsType"=>{"type"=>"object", "properties"=>{"description"=>{"type"=>"string"}, "responses"=>{"$ref"=>"#/definitions/ResponseItem"}}},
           "ApiError"=>{"type"=>"object", "properties"=>{"code"=>{"type"=>"integer", "format"=>"int32"}, "message"=>{"type"=>"string"}}}
       }})
     end

--- a/spec/swagger_v2/default_api_spec.rb
+++ b/spec/swagger_v2/default_api_spec.rb
@@ -31,6 +31,7 @@ describe 'Default API' do
           "paths"=>{
             "/something"=>{
               "get"=>{
+                "description"=>"This gets something.",
                 "produces"=>["application/json"],
                 "tags"=>["something"],
                 "operationId"=>"getSomething",
@@ -75,6 +76,7 @@ describe 'Default API' do
         "paths"=>{
           "/something"=>{
             "get"=>{
+              "description"=>"This gets something.",
               "produces"=>["application/json"],
               "tags"=>["something"],
               "operationId"=>"getSomething",

--- a/spec/swagger_v2/hide_api_spec.rb
+++ b/spec/swagger_v2/hide_api_spec.rb
@@ -45,12 +45,14 @@ describe 'a hide mounted api' do
       "paths"=>{
         "/simple"=>{
           "get"=>{
+            "description"=>"Show this endpoint",
             "produces"=>["application/json"],
             "tags"=>["simple"],
             "operationId"=>"getSimple",
             "responses"=>{"200"=>{"description"=>"Show this endpoint"}}}},
         "/lazy"=>{
           "get"=>{
+            "description"=>"Lazily show endpoint",
             "produces"=>["application/json"],
             "tags"=>["lazy"],
             "operationId"=>"getLazy",
@@ -100,6 +102,7 @@ describe 'a hide mounted api with same namespace' do
       "paths"=>{
         "/simple/show"=>{
           "get"=>{
+            "description"=>"Show this endpoint",
             "produces"=>["application/json"],
             "operationId"=>"getSimpleShow",
             "tags"=>["simple"], "responses"=>{"200"=>{"description"=>"Show this endpoint"}}}}}
@@ -118,6 +121,7 @@ describe 'a hide mounted api with same namespace' do
       "paths"=>{
         "/simple/show"=>{
           "get"=>{
+            "description"=>"Show this endpoint",
             "produces"=>["application/json"],
             "tags"=>["simple"],
             "operationId"=>"getSimpleShow",

--- a/spec/swagger_v2/mounted_target_class_spec.rb
+++ b/spec/swagger_v2/mounted_target_class_spec.rb
@@ -31,17 +31,21 @@ describe 'docs mounted separately from api' do
     expect(JSON.parse(last_response.body)).to eq({
       "info"=>{"title"=>"API title", "version"=>"v1"},
       "swagger"=>"2.0",
-      "tags" => [{"name"=>"simple", "description"=>"Operations about simples"}],
       "produces"=>["application/xml", "application/json", "application/octet-stream", "text/plain"],
       "host"=>"example.org",
-      "schemes" => ["https", "http"],
-      "paths" => {
+      "tags"=>[{"name"=>"simple", "description"=>"Operations about simples"}],
+      "schemes"=>["https", "http"],
+      "paths"=>{
         "/simple"=>{
           "get"=>{
+            "description"=>"This gets something.",
             "produces"=>["application/json"],
+            "responses"=>{"200"=>{"description"=>"This gets something."}},
             "tags"=>["simple"],
-            "operationId"=>"getSimple",
-            "responses"=>{"200"=>{"description"=>"This gets something."}}}}}
+            "operationId"=>"getSimple"
+          }
+        }
+      }
     })
   end
 
@@ -57,10 +61,16 @@ describe 'docs mounted separately from api' do
       "paths" => {
         "/simple"=>{
           "get"=>{
+            "description"=>"This gets something.",
             "produces"=>["application/json"],
+            "responses"=>{
+              "200"=>{"description"=>"This gets something."}
+            },
             "tags"=>["simple"],
-            "operationId"=>"getSimple",
-            "responses"=>{"200"=>{"description"=>"This gets something."}}}}}
+            "operationId"=>"getSimple"
+          }
+        }
+      }
     })
   end
 end

--- a/spec/swagger_v2/response_model_spec.rb
+++ b/spec/swagger_v2/response_model_spec.rb
@@ -103,6 +103,7 @@ describe 'responseModel' do
     expect(subject['definitions']['Error']).to eq(
       {
         "type"=>"object",
+        "description" => "This returns something or an error",
         "properties"=>{
           "code"=>{"type"=>"string"},
           "message"=>{"type"=>"string"}
@@ -112,6 +113,7 @@ describe 'responseModel' do
     expect(subject['definitions'].keys).to include 'Something'
     expect(subject['definitions']['Something']).to eq(
     { "type"=>"object",
+      "description" => "This returns something or an error",
       "properties"=>
         { "text"=>{"type"=>"string"},
           "kind"=>{"$ref"=>"#/definitions/Kind"},
@@ -203,6 +205,8 @@ describe 'should build definition from given entity' do
           "kind3"=>{"$ref"=>"#/definitions/Kind"},
           "tags"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/Tag"}},
           "relation"=>{"$ref"=>"#/definitions/Relation"}
-    }}})
+        },
+        "description"=>"This returns something"
+      }})
   end
 end

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -83,18 +83,21 @@ describe 'a simple mounted api' do
         "paths"=>{
           "/simple"=>{
             "get"=>{
+              "description"=>"This gets something.",
               "produces"=>["application/json"],
               "tags"=>["simple"],
               "operationId"=>"getSimple",
               "responses"=>{"200"=>{"description"=>"This gets something."}}}},
           "/simple-test"=>{
             "get"=>{
+              "description"=>"This gets something for URL using - separator.",
               "produces"=>["application/json"],
               "tags"=>["simple-test"],
               "operationId"=>"getSimpleTest",
               "responses"=>{"200"=>{"description"=>"This gets something for URL using - separator."}}}},
           "/simple_with_headers"=>{
             "get"=>{
+              "description"=>"this gets something else",
               "headers"=>{
                 "XAuthToken"=>{"description"=>"A required header.", "required"=>true},
                 "XOtherHeader"=>{"description"=>"An optional header.", "required"=>false}},
@@ -108,6 +111,7 @@ describe 'a simple mounted api' do
           }},
           "/items"=>{
             "post"=>{
+              "description"=>"this takes an array of parameters",
               "produces"=>["application/json"],
               "consumes"=>["application/json"],
               "parameters"=>[{"in"=>"formData", "name"=>"items[]", "description"=>"array of items", "required"=>false, "type"=>"array", "items"=>{"type"=>"string"}}],
@@ -117,13 +121,24 @@ describe 'a simple mounted api' do
           }},
           "/custom"=>{
             "get"=>{
+              "description"=>"this uses a custom parameter",
               "produces"=>["application/json"],
               "parameters"=>[{"in"=>"formData", "name"=>"custom", "description"=>"array of items", "required"=>false, "type"=>"array", "items"=>{"type"=>"CustomType"}}],
               "tags"=>["custom"],
               "operationId"=>"getCustom",
               "responses"=>{"200"=>{"description"=>"this uses a custom parameter", "schema"=>{"$ref"=>"#/definitions/Custom"}}}}
       }},
-      "definitions"=>{"Item"=>{"type"=>"object", "properties"=>{"items[]"=>{"type"=>"string"}}}, "Custom"=>{"type"=>"object", "properties"=>{"custom"=>{"type"=>"CustomType"}}}}})
+      "definitions"=>{
+        "Item"=>{
+          "type"=>"object",
+          "properties"=>{"items[]"=>{"type"=>"string"}},
+          "description"=>"this takes an array of parameters"
+        },
+        "Custom"=>{
+          "type"=>"object",
+          "properties"=>{"custom"=>{"type"=>"CustomType"}},
+          "description"=>"this uses a custom parameter"
+        }}})
     end
   end
 
@@ -144,6 +159,7 @@ describe 'a simple mounted api' do
         "paths"=>{
           "/simple"=>{
             "get"=>{
+              "description"=>"This gets something.",
               "produces"=>["application/json"],
               "tags"=>["simple"],
               "operationId"=>"getSimple",
@@ -170,6 +186,7 @@ describe 'a simple mounted api' do
           "paths"=>{
             "/simple-test"=>{
               "get"=>{
+                "description"=>"This gets something for URL using - separator.",
                 "produces"=>["application/json"],
                 "tags"=>["simple-test"],
                 "operationId"=>"getSimpleTest",
@@ -188,6 +205,7 @@ describe 'a simple mounted api' do
         expect(subject['paths']).to eq({
           "/simple_with_headers"=>{
             "get"=>{
+              "description"=>"this gets something else",
               "headers"=>{
                 "XAuthToken"=>{"description"=>"A required header.", "required"=>true},
                 "XOtherHeader"=>{"description"=>"An optional header.", "required"=>false}},
@@ -212,6 +230,7 @@ describe 'a simple mounted api' do
         expect(subject['paths']).to eq({
           "/items"=>{
             "post"=>{
+              "description"=>"this takes an array of parameters",
               "produces"=>["application/json"],
               "consumes"=>["application/json"],
               "parameters"=>[{"in"=>"formData", "name"=>"items[]", "description"=>"array of items", "required"=>false, "type"=>"array", "items"=>{"type"=>"string"}}],
@@ -232,6 +251,7 @@ describe 'a simple mounted api' do
         expect(subject['paths']).to eq({
           "/custom"=>{
             "get"=>{
+              "description"=>"this uses a custom parameter",
               "produces"=>["application/json"],
               "parameters"=>[{"in"=>"formData", "name"=>"custom", "description"=>"array of items", "required"=>false, "type"=>"array", "items"=>{"type"=>"CustomType"}}],
               "tags"=>["custom"],


### PR DESCRIPTION
introducing handling of params with in `body`, these params should be referenced to a definition object,
and if one given, no `formData` param is allowed → this would also be handled in the same manner as in  body (see: [#parameter-object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#parameter-object))

* [x] simple params [type_body_spec](spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb)
* [x] nested params [type_body_nested_spec](spec/swagger_v2/api_swagger_v2_param_type_body_nested_spec.rb)