### PR TITLE
Fix: un-pending-ify spec.

### DIFF
--- a/spec/markdown/kramdown_adapter_spec.rb
+++ b/spec/markdown/kramdown_adapter_spec.rb
@@ -17,7 +17,6 @@ describe GrapeSwagger::Markdown::KramdownAdapter do
     end
 
     it 'raises an GrapeSwagger::Errors::MarkdownDependencyMissingError if module can not be required' do
-      pending
       expect_any_instance_of(Kernel).to receive(:require).with('kramdown').and_raise(LoadError)
 
       expect { GrapeSwagger::Markdown::KramdownAdapter.new }.to raise_error(GrapeSwagger::Errors::MarkdownDependencyMissingError, 'Missing required dependency: kramdown')


### PR DESCRIPTION
Was marked pending in https://github.com/ruby-grape/grape-swagger/commit/55ceec689d5df6506704e6c04481148fbb45e404, but doesn't need to be.