### PR TITLE
adding entity property description when documentation desc option is present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 #### Features
 
+[#381](https://github.com/ruby-grape/grape-swagger/pull/381) 
+
+- adding entity property description when property documentation desc option is present [@elciok](https://github.com/elciok).
+
 [#371](https://github.com/ruby-grape/grape-swagger/pull/371)
 
   - adds param type `body` handling

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -270,6 +270,7 @@ module Grape
 
           memo[x.first][:enum] = x.last[:values] if x.last[:values] && x.last[:values].is_a?(Array)
         end
+        memo[x.first][:description] = x.last[:documentation][:desc] if x.last[:documentation] && x.last[:documentation][:desc]
       end
     end
 

--- a/spec/support/api_swagger_v2_result.rb
+++ b/spec/support/api_swagger_v2_result.rb
@@ -174,22 +174,22 @@ RSpec.shared_context "swagger example" do
       "definitions"=>{
         "QueryInput"=>{
           "type"=>"object",
-          "properties"=>{"elements"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/QueryInputElement"}}},
+          "properties"=>{"elements"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/QueryInputElement"}, "description"=>"Set of configuration"}},
           "description"=>"nested route inside namespace"},
         "QueryInputElement"=>{
           "type"=>"object",
-          "properties"=>{"key"=>{"type"=>"string"}, "value"=>{"type"=>"string"}}},
+          "properties"=>{"key"=>{"type"=>"string", "description"=>"Name of parameter"}, "value"=>{"type"=>"string", "description"=>"Value of parameter"}}},
         "Thing"=>{
           "type"=>"object",
           "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32"}, "text"=>{"type"=>"string"}, "links"=>{"type"=>"link"}, "others"=>{"type"=>"text"}},
           "description"=>"This gets Thing."},
         "ApiError"=>{
           "type"=>"object",
-          "properties"=>{"code"=>{"type"=>"integer", "format"=>"int32"}, "message"=>{"type"=>"string"}},
+          "properties"=>{"code"=>{"type"=>"integer", "format"=>"int32", "description"=>"status code"}, "message"=>{"type"=>"string", "description"=>"error message"}},
           "description"=>"This gets Things."},
         "Something"=>{
           "type"=>"object",
-          "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32"}, "text"=>{"type"=>"string"}, "links"=>{"type"=>"link"}, "others"=>{"type"=>"text"}},
+          "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32", "description"=>"Identity of Something"}, "text"=>{"type"=>"string", "description"=>"Content of something."}, "links"=>{"type"=>"link"}, "others"=>{"type"=>"text"}},
           "description"=>"This gets Things."
         }
       }

--- a/spec/swagger_v2/api_swagger_v2_type-format_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_type-format_spec.rb
@@ -24,20 +24,20 @@ describe 'type format settings' do
     module TheApi
       module Entities
         class TypedDefinition < Grape::Entity
-          expose :prop_integer,   documentation: { type: Integer, desc: 'prop_integer' }
-          expose :prop_long,      documentation: { type: Numeric, desc: 'prop_long' }
-          expose :prop_float,     documentation: { type: Float, desc: 'prop_float' }
-          expose :prop_double,    documentation: { type: BigDecimal, desc: 'prop_double' }
-          expose :prop_string,    documentation: { type: String, desc: 'prop_string' }
-          expose :prop_symbol,    documentation: { type: Symbol, desc: 'prop_symbol' }
-          expose :prop_date,      documentation: { type: Date, desc: 'prop_date' }
-          expose :prop_date_time, documentation: { type: DateTime, desc: 'prop_date_time' }
-          expose :prop_time,      documentation: { type: Time, desc: 'prop_time' }
-          expose :prop_password,  documentation: { type: 'password', desc: 'prop_password' }
-          expose :prop_email,     documentation: { type: 'email', desc: 'prop_email' }
-          expose :prop_boolean,   documentation: { type: Virtus::Attribute::Boolean, desc: 'prop_boolean' }
-          expose :prop_file,      documentation: { type: File, desc: 'prop_file' }
-          expose :prop_json,      documentation: { type: JSON, desc: 'prop_json' }
+          expose :prop_integer,   documentation: { type: Integer, desc: 'prop_integer description' }
+          expose :prop_long,      documentation: { type: Numeric, desc: 'prop_long description' }
+          expose :prop_float,     documentation: { type: Float, desc: 'prop_float description' }
+          expose :prop_double,    documentation: { type: BigDecimal, desc: 'prop_double description' }
+          expose :prop_string,    documentation: { type: String, desc: 'prop_string description' }
+          expose :prop_symbol,    documentation: { type: Symbol, desc: 'prop_symbol description' }
+          expose :prop_date,      documentation: { type: Date, desc: 'prop_date description' }
+          expose :prop_date_time, documentation: { type: DateTime, desc: 'prop_date_time description' }
+          expose :prop_time,      documentation: { type: Time, desc: 'prop_time description' }
+          expose :prop_password,  documentation: { type: 'password', desc: 'prop_password description' }
+          expose :prop_email,     documentation: { type: 'email', desc: 'prop_email description' }
+          expose :prop_boolean,   documentation: { type: Virtus::Attribute::Boolean, desc: 'prop_boolean description' }
+          expose :prop_file,      documentation: { type: File, desc: 'prop_file description' }
+          expose :prop_json,      documentation: { type: JSON, desc: 'prop_json description' }
         end
       end
 
@@ -102,20 +102,20 @@ describe 'type format settings' do
 
   specify do
     expect(subject['definitions']['TypedDefinition']['properties']).to eql({
-      "prop_integer"=>{"type"=>"integer", "format"=>"int32"},
-      "prop_long"=>{"type"=>"integer", "format"=>"int64"},
-      "prop_float"=>{"type"=>"number", "format"=>"float"},
-      "prop_double"=>{"type"=>"number", "format"=>"double"},
-      "prop_string"=>{"type"=>"string"},
-      "prop_symbol"=>{"type"=>"string"},
-      "prop_date"=>{"type"=>"string", "format"=>"date"},
-      "prop_date_time"=>{"type"=>"string", "format"=>"date-time"},
-      "prop_time"=>{"type"=>"string", "format"=>"date-time"},
-      "prop_password"=>{"type"=>"string", "format"=>"password"},
-      "prop_email"=>{"type"=>"string", "format"=>"email"},
-      "prop_boolean"=>{"type"=>"boolean"},
-      "prop_file"=>{"type"=>"file"},
-      "prop_json"=>{"type"=>"json"}
+      "prop_integer"=>{"type"=>"integer", "format"=>"int32", "description"=>"prop_integer description"},
+      "prop_long"=>{"type"=>"integer", "format"=>"int64", "description"=>"prop_long description"},
+      "prop_float"=>{"type"=>"number", "format"=>"float", "description"=>"prop_float description"},
+      "prop_double"=>{"type"=>"number", "format"=>"double", "description"=>"prop_double description"},
+      "prop_string"=>{"type"=>"string", "description"=>"prop_string description"},
+      "prop_symbol"=>{"type"=>"string", "description"=>"prop_symbol description"},
+      "prop_date"=>{"type"=>"string", "format"=>"date", "description"=>"prop_date description"},
+      "prop_date_time"=>{"type"=>"string", "format"=>"date-time", "description"=>"prop_date_time description"},
+      "prop_time"=>{"type"=>"string", "format"=>"date-time", "description"=>"prop_time description"},
+      "prop_password"=>{"type"=>"string", "format"=>"password", "description"=>"prop_password description"},
+      "prop_email"=>{"type"=>"string", "format"=>"email", "description"=>"prop_email description"},
+      "prop_boolean"=>{"type"=>"boolean", "description"=>"prop_boolean description"},
+      "prop_file"=>{"type"=>"file", "description"=>"prop_file description"},
+      "prop_json"=>{"type"=>"json", "description"=>"prop_json description"}
     })
   end
 end

--- a/spec/swagger_v2/response_model_spec.rb
+++ b/spec/swagger_v2/response_model_spec.rb
@@ -105,8 +105,8 @@ describe 'responseModel' do
         "type"=>"object",
         "description" => "This returns something or an error",
         "properties"=>{
-          "code"=>{"type"=>"string"},
-          "message"=>{"type"=>"string"}
+          "code"=>{"type"=>"string","description"=>"Error code"},
+          "message"=>{"type"=>"string","description"=>"Error message"}
       }}
     )
 
@@ -115,27 +115,27 @@ describe 'responseModel' do
     { "type"=>"object",
       "description" => "This returns something or an error",
       "properties"=>
-        { "text"=>{"type"=>"string"},
-          "kind"=>{"$ref"=>"#/definitions/Kind"},
-          "kind2"=>{"$ref"=>"#/definitions/Kind"},
-          "kind3"=>{"$ref"=>"#/definitions/Kind"},
-          "tags"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/Tag"}},
-          "relation"=>{"$ref"=>"#/definitions/Relation"}}}
+        { "text"=>{"type"=>"string","description"=>"Content of something."},
+          "kind"=>{"$ref"=>"#/definitions/Kind","description"=>"The kind of this something."},
+          "kind2"=>{"$ref"=>"#/definitions/Kind","description"=>"Secondary kind."},
+          "kind3"=>{"$ref"=>"#/definitions/Kind","description"=>"Tertiary kind."},
+          "tags"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/Tag"},"description"=>"Tags."},
+          "relation"=>{"$ref"=>"#/definitions/Relation","description"=>"A related model."}}}
     )
 
     expect(subject['definitions'].keys).to include 'Kind'
     expect(subject['definitions']['Kind']).to eq(
-      "type"=>"object", "properties"=>{"title"=>{"type"=>"string"}}
+      "type"=>"object", "properties"=>{"title"=>{"type"=>"string","description"=>"Title of the kind."}}
     )
 
     expect(subject['definitions'].keys).to include 'Relation'
     expect(subject['definitions']['Relation']).to eq(
-      "type"=>"object", "properties"=>{"name"=>{"type"=>"string"}}
+      "type"=>"object", "properties"=>{"name"=>{"type"=>"string","description"=>"Name"}}
     )
 
     expect(subject['definitions'].keys).to include 'Tag'
     expect(subject['definitions']['Tag']).to eq(
-      "type"=>"object", "properties"=>{"name"=>{"type"=>"string"}}
+      "type"=>"object", "properties"=>{"name"=>{"type"=>"string","description"=>"Name"}}
     )
   end
 end
@@ -193,18 +193,18 @@ describe 'should build definition from given entity' do
 
   it "it prefer entity over others" do
     expect(subject['definitions']).to eql({
-      "Kind"=>{"type"=>"object", "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32"}}},
-      "Tag"=>{"type"=>"object", "properties"=>{"name"=>{"type"=>"string"}}},
-      "Relation"=>{"type"=>"object", "properties"=>{"name"=>{"type"=>"string"}}},
+      "Kind"=>{"type"=>"object", "properties"=>{"id"=>{"type"=>"integer", "format"=>"int32", "description"=>"Title of the kind."}}},
+      "Tag"=>{"type"=>"object", "properties"=>{"name"=>{"type"=>"string", "description"=>"Name"}}},
+      "Relation"=>{"type"=>"object", "properties"=>{"name"=>{"type"=>"string", "description"=>"Name"}}},
       "SomeEntity"=>{
         "type"=>"object",
         "properties"=>{
-          "text"=>{"type"=>"string"},
-          "kind"=>{"$ref"=>"#/definitions/Kind"},
-          "kind2"=>{"$ref"=>"#/definitions/Kind"},
-          "kind3"=>{"$ref"=>"#/definitions/Kind"},
-          "tags"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/Tag"}},
-          "relation"=>{"$ref"=>"#/definitions/Relation"}
+          "text"=>{"type"=>"string", "description"=>"Content of something."},
+          "kind"=>{"$ref"=>"#/definitions/Kind", "description"=>"The kind of this something."},
+          "kind2"=>{"$ref"=>"#/definitions/Kind", "description"=>"Secondary kind."},
+          "kind3"=>{"$ref"=>"#/definitions/Kind", "description"=>"Tertiary kind."},
+          "tags"=>{"type"=>"array", "items"=>{"$ref"=>"#/definitions/Tag"}, "description"=>"Tags."},
+          "relation"=>{"$ref"=>"#/definitions/Relation", "description"=>"A related model."}
         },
         "description"=>"This returns something"
       }})


### PR DESCRIPTION
The swagger_doc json generated contains entity definitions, with property declarations, but if you set a "desc" option like this:

expose :name, documentation: {type: "String", desc: "Name of object"}

This gets ignored by grape-swagger. I've changed this.