### PR TITLE
Make default schemes undefined to match Swagger Spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+### (next)
+
+#### Fixes
+* [#382](https://github.com/ruby-grape/grape-swagger/pull/382): Make the schemes undefined by default to match Swagger 2.0 spec indicating that a blank schemes will use the scheme from the document - [@wleeper](https://github.com/wleeper).
+
 ### 0.20.0 / 2016-04-09
 
 #### Features

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -90,7 +90,6 @@ module GrapeSwagger
       {
         info: {},
         models: [],
-        schemes: %w( https http ),
         api_version: 'v1',
         target_class: nil,
         mount_path: '/swagger_doc',

--- a/spec/support/api_swagger_v2_result.rb
+++ b/spec/support/api_swagger_v2_result.rb
@@ -79,7 +79,6 @@ RSpec.shared_context "swagger example" do
         {"name"=>"thing2", "description"=>"Operations about thing2s"},
         {"name"=>"dummy", "description"=>"Operations about dummies"}
       ],
-      "schemes"=>["https", "http"],
       "paths"=>{
         "/v3/other_thing/{elements}"=>{
           "get"=>{

--- a/spec/swagger_v2/api_swagger_v2_response_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_spec.rb
@@ -55,7 +55,6 @@ describe 'response' do
           {"name"=>"entity_response", "description"=>"Operations about entity_responses"},
           {"name"=>"nested_type", "description"=>"Operations about nested_types"}
         ],
-        "schemes"=>["https", "http"],
         "paths"=>{
           "/nested_type"=>{
             "get"=>{
@@ -104,7 +103,6 @@ describe 'response' do
           {"name"=>"entity_response", "description"=>"Operations about entity_responses"},
           {"name"=>"nested_type", "description"=>"Operations about nested_types"}
         ],
-        "schemes"=>["https", "http"],
         "paths"=>{
           "/entity_response"=>{
             "get"=>{
@@ -150,7 +148,6 @@ describe 'response' do
           {"name"=>"entity_response", "description"=>"Operations about entity_responses"},
           {"name"=>"nested_type", "description"=>"Operations about nested_types"}
         ],
-        "schemes"=>["https", "http"],
         "paths"=>{
           "/params_response"=>{
             "post"=>{

--- a/spec/swagger_v2/default_api_spec.rb
+++ b/spec/swagger_v2/default_api_spec.rb
@@ -27,7 +27,6 @@ describe 'Default API' do
           "produces"=>["application/json"],
           "host"=>"example.org",
           "tags" => [{"name"=>"something", "description"=>"Operations about somethings"}],
-          "schemes" => ["https", "http"],
           "paths"=>{
             "/something"=>{
               "get"=>{
@@ -72,7 +71,6 @@ describe 'Default API' do
         "produces"=>["application/json"],
         "host"=>"example.org",
         "tags" => [{"name"=>"something", "description"=>"Operations about somethings"}],
-        "schemes" => ["https", "http"],
         "paths"=>{
           "/something"=>{
             "get"=>{

--- a/spec/swagger_v2/hide_api_spec.rb
+++ b/spec/swagger_v2/hide_api_spec.rb
@@ -41,7 +41,6 @@ describe 'a hide mounted api' do
       "produces"=>["application/xml", "application/json", "application/octet-stream", "text/plain"],
       "host"=>"example.org",
       "tags" => [{"name"=>"simple", "description"=>"Operations about simples"}, {"name"=>"lazy", "description"=>"Operations about lazies"}],
-      "schemes" => ["https", "http"],
       "paths"=>{
         "/simple"=>{
           "get"=>{
@@ -98,7 +97,6 @@ describe 'a hide mounted api with same namespace' do
       "produces"=>["application/xml", "application/json", "application/octet-stream", "text/plain"],
       "host"=>"example.org",
       "tags" => [{"name"=>"simple", "description"=>"Operations about simples"}],
-      "schemes" => ["https", "http"],
       "paths"=>{
         "/simple/show"=>{
           "get"=>{
@@ -117,7 +115,6 @@ describe 'a hide mounted api with same namespace' do
       "produces"=>["application/xml", "application/json", "application/octet-stream", "text/plain"],
       "host"=>"example.org",
       "tags" => [{"name"=>"simple", "description"=>"Operations about simples"}],
-      "schemes" => ["https", "http"],
       "paths"=>{
         "/simple/show"=>{
           "get"=>{

--- a/spec/swagger_v2/mounted_target_class_spec.rb
+++ b/spec/swagger_v2/mounted_target_class_spec.rb
@@ -34,7 +34,6 @@ describe 'docs mounted separately from api' do
       "produces"=>["application/xml", "application/json", "application/octet-stream", "text/plain"],
       "host"=>"example.org",
       "tags"=>[{"name"=>"simple", "description"=>"Operations about simples"}],
-      "schemes"=>["https", "http"],
       "paths"=>{
         "/simple"=>{
           "get"=>{
@@ -57,7 +56,6 @@ describe 'docs mounted separately from api' do
       "tags" => [{"name"=>"simple", "description"=>"Operations about simples"}],
       "produces"=>["application/xml", "application/json", "application/octet-stream", "text/plain"],
       "host"=>"example.org",
-      "schemes" => ["https", "http"],
       "paths" => {
         "/simple"=>{
           "get"=>{

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -79,7 +79,6 @@ describe 'a simple mounted api' do
         "produces"=>["application/xml", "application/json", "application/octet-stream", "text/plain"],
         "host"=>"example.org",
         "tags" => [{"name"=>"simple", "description"=>"Operations about simples"}, {"name"=>"simple-test", "description"=>"Operations about simple-tests"}, {"name"=>"simple_with_headers", "description"=>"Operations about simple_with_headers"}, {"name"=>"items", "description"=>"Operations about items"}, {"name"=>"custom", "description"=>"Operations about customs"}],
-        "schemes"=>["https", "http"],
         "paths"=>{
           "/simple"=>{
             "get"=>{
@@ -155,7 +154,6 @@ describe 'a simple mounted api' do
         "produces"=>["application/xml", "application/json", "application/octet-stream", "text/plain"],
         "host"=>"example.org",
         "tags" => [{"name"=>"simple", "description"=>"Operations about simples"}, {"name"=>"simple-test", "description"=>"Operations about simple-tests"}, {"name"=>"simple_with_headers", "description"=>"Operations about simple_with_headers"}, {"name"=>"items", "description"=>"Operations about items"}, {"name"=>"custom", "description"=>"Operations about customs"}],
-        "schemes"=>["https", "http"],
         "paths"=>{
           "/simple"=>{
             "get"=>{
@@ -182,7 +180,6 @@ describe 'a simple mounted api' do
           "produces"=>["application/xml", "application/json", "application/octet-stream", "text/plain"],
           "host"=>"example.org",
           "tags" => [{"name"=>"simple", "description"=>"Operations about simples"}, {"name"=>"simple-test", "description"=>"Operations about simple-tests"}, {"name"=>"simple_with_headers", "description"=>"Operations about simple_with_headers"}, {"name"=>"items", "description"=>"Operations about items"}, {"name"=>"custom", "description"=>"Operations about customs"}],
-          "schemes"=>["https", "http"],
           "paths"=>{
             "/simple-test"=>{
               "get"=>{


### PR DESCRIPTION
#### What's this PR do, and where should I start?

This PR takes out the default value for schemes.  This brings the generator in line with Swagger Spec 2.0 which indicates that schemes is an optional parameter and default behavior is to assume the same scheme as the scheme of the document.

#### How should this be manually tested?

Can be tested using the example (which did not work prior to this change) by running:

```
bundle exec rackup
```

From the examples directory.  This will start the example up on http://localhost:9292.  Drop the `http://localhost:9292/swagger_doc` into `http://petstore.swagger.io` and choose one of the methods to 'try'. It should successfully hit the back end.

#### Any background context you want to provide?

Ran into this problem because we run our app in development on http only and the default value of `['https', 'http']` failed to work.  It also failed as noted to work with the example if started per the README.

* Tests were updated to reflect the lack of schemes tag in the default.  There was already code to override this value with custom options, those tests were not changed and still pass as expected.