### PR TITLE
replace request.env['HTTP_HOST'] with request.host_with_port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 #### Fixes
 
+* [#389](https://github.com/ruby-grape/grape-swagger/pull/389): respect X-Forwarded-Host - [@edvakf](https://github.com/edvakf).
+
 ### 0.20.1 / 2016-04-17
 
 #### Features

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -24,7 +24,7 @@ module Grape
         swagger:        '2.0',
         produces:       content_types_for(target_class),
         authorizations: options[:authorizations],
-        host:           GrapeSwagger::DocMethods::OptionalObject.build(:host, options, request.env['HTTP_HOST']),
+        host:           GrapeSwagger::DocMethods::OptionalObject.build(:host, options, request.host_with_port),
         basePath:       GrapeSwagger::DocMethods::OptionalObject.build(:base_path, options, request.env['SCRIPT_NAME']),
         tags:           GrapeSwagger::DocMethods::TagNameDescription.build(options),
         schemes:        options[:schemes].is_a?(String) ? [options[:schemes]] : options[:schemes]

--- a/spec/swagger_v2/host.rb
+++ b/spec/swagger_v2/host.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe 'host in the swagger_doc' do
+  include_context "the api entities"
+
+  before :all do
+    module TheApi
+      class EmptyApi < Grape::API
+        format :json
+
+        add_swagger_documentation
+      end
+    end
+  end
+
+  def app
+    TheApi::EmptyApi
+  end
+
+  describe 'host should include port' do
+    subject do
+      get 'http://example.com:8080/swagger_doc'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['host']).to eq 'example.com:8080'
+    end
+  end
+
+  describe 'respect X-Forwarded-Host over Host header' do
+    subject do
+      header 'Host', 'dummy.example.com'
+      header 'X-Forwarded-Host', 'real.example.com'
+      get '/swagger_doc'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['host']).to eq 'real.example.com'
+    end
+  end
+end


### PR DESCRIPTION
request.env['HTTP_HOST'] doesn't respect X-Forwarded-Host, whereas request.host does