### PR TITLE
Added feature to report header params in params block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 #### Fixes
 
 * [#389](https://github.com/ruby-grape/grape-swagger/pull/389): respect X-Forwarded-Host - [@edvakf](https://github.com/edvakf).
+* [#393](https://github.com/ruby-grape/grape-swagger/pull/393): properly handle header parameters- [@wleeper](https://github.com/wleeper).
 
 ### 0.20.1 / 2016-04-17
 

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -9,6 +9,7 @@ require 'grape-swagger/doc_methods/path_string'
 require 'grape-swagger/doc_methods/tag_name_description'
 require 'grape-swagger/doc_methods/parse_params'
 require 'grape-swagger/doc_methods/move_params'
+require 'grape-swagger/doc_methods/headers'
 
 module GrapeSwagger
   module DocMethods

--- a/lib/grape-swagger/doc_methods/headers.rb
+++ b/lib/grape-swagger/doc_methods/headers.rb
@@ -1,0 +1,18 @@
+module GrapeSwagger
+  module DocMethods
+    class Headers
+      class << self
+        def parse(route)
+          route.route_headers.to_a.map do |route_header|
+            route_header.tap do |header|
+              hash = header[1]
+              description = hash.delete('description')
+              hash[:documentation] = { desc: description, in: 'header' }
+              hash[:type] = hash['type'].titleize if hash['type']
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/swagger_v2/api_swagger_v2_headers_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_headers_spec.rb
@@ -36,9 +36,13 @@ describe 'headers' do
   end
 
   specify do
-    expect(subject['paths']['/use_headers']['get']).to include('headers')
-    expect(subject['paths']['/use_headers']['get']['headers']).to eql({
-      "X-Rate-Limit-Limit"=>{"description"=>"The number of allowed requests in the current period", "type"=>"integer"}
-    })
+    expect(subject['paths']['/use_headers']['get']['parameters']).to eql([
+      {"in"=>"header",
+       "name"=>"X-Rate-Limit-Limit",
+       "description"=>"The number of allowed requests in the current period",
+       "type"=>"integer",
+       "format" => "int32",
+       "required"=>false},
+    ])
   end
 end

--- a/spec/swagger_v2/param_type_spec.rb
+++ b/spec/swagger_v2/param_type_spec.rb
@@ -50,7 +50,7 @@ describe 'Params Types' do
 
     it 'has consistent types' do
       types = subject.map { |param| param['type'] }
-      expect(types).to eq(%w(string))
+      expect(types).to eq(%w(string string))
     end
   end
 end

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -97,10 +97,10 @@ describe 'a simple mounted api' do
           "/simple_with_headers"=>{
             "get"=>{
               "description"=>"this gets something else",
-              "headers"=>{
-                "XAuthToken"=>{"description"=>"A required header.", "required"=>true},
-                "XOtherHeader"=>{"description"=>"An optional header.", "required"=>false}},
               "produces"=>["application/json"],
+              "parameters"=>[
+                {"in"=>"header", "name"=>"XAuthToken", "description"=>"A required header.", "type"=>"string", "required"=>true},
+                {"in"=>"header", "name"=>"XOtherHeader", "description"=>"An optional header.", "type"=>"string", "required"=>false}],
               "tags"=>["simple_with_headers"],
               "operationId"=>"getSimpleWithHeaders",
               "responses"=>{
@@ -203,10 +203,10 @@ describe 'a simple mounted api' do
           "/simple_with_headers"=>{
             "get"=>{
               "description"=>"this gets something else",
-              "headers"=>{
-                "XAuthToken"=>{"description"=>"A required header.", "required"=>true},
-                "XOtherHeader"=>{"description"=>"An optional header.", "required"=>false}},
               "produces"=>["application/json"],
+              "parameters"=>[
+                {"in"=>"header", "name"=>"XAuthToken", "description"=>"A required header.", "type"=>"string", "required"=>true},
+                {"in"=>"header", "name"=>"XOtherHeader", "description"=>"An optional header.", "type"=>"string", "required"=>false}],
               "tags"=>["simple_with_headers"],
               "operationId"=>"getSimpleWithHeaders",
               "responses"=>{


### PR DESCRIPTION
#### What's this PR do, and where should I start?

This PR address [Issue #391](https://github.com/ruby-grape/grape-swagger/issues/391)

This PR changes the behavior by no longer output a header tag at the root level of an endpoint, and replaces that with parameters tagged with `"in": "header"`, which is the correct Swagger 2.0 method.

See changes to spec/swagger_v2/simple_mounted_api_spec.rb to see how the behavior changed.

#### How should this be manually tested?

Fire up the example app and add some header variables using the proper grape syntax (note the example below is <= 0.14, not what is in the docs for 0.16.2:

```
        desc 'This returns something',
          failure: [{code: 400, model: Entities::ApiError}],
          headers:  {
            "X-Rate-Limit-Limit" => {
              "description" => "The number of allowed requests in the current period",
              "type" => "integer"
          }}
        get '/use_headers' do
          { "declared_params" => declared(params) }
        end
```

#### Any background context you want to provide?

Ran into this issue when I tried to add header params to our app. 