### PR TITLE
Remove extra dependency

### DIFF
--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -12,7 +12,6 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.add_runtime_dependency 'grape', '>= 0.12.0'
-  s.add_runtime_dependency 'awesome_print'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'shoulda'

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -12,8 +12,6 @@ require 'grape-swagger/model_parsers'
 require 'grape-swagger/markdown/kramdown_adapter'
 require 'grape-swagger/markdown/redcarpet_adapter'
 
-require 'awesome_print'
-
 module GrapeSwagger
   class << self
     def model_parsers


### PR DESCRIPTION
`awesome_print` gem is not used in the code and should not be a runtime dependency.

Initially, it was added as a development dependency in e406abfe3c5344b60c90e41eac16d1e73b46dc9e. It was used to output debug information in specs.

But later, it was changed to be a runtime dependency in 05a0085155e75909f2ab23906134e0b7091e2144 for no particular reason.