### PR TITLE
Add fixed fields

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,7 +28,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 201
+  Max: 206
 
 # Offense count: 10
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,7 +28,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 206
+  Max: 210
 
 # Offense count: 10
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,9 @@
 
 #### Features
 
-* Your contribution here.
+* [#431](https://github.com/ruby-grape/grape-swagger/pull/431): Add summary and deprecated to the operation object generator to be more compliant with [OpenAPI v2](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operation-object) - [@aschuster3](https://github.com/aschuster3).
 
 #### Fixes
-
-* Your contribution here.
 
 ### 0.20.4 (May 16, 2016)
 

--- a/README.md
+++ b/README.md
@@ -442,6 +442,52 @@ end
 ```
 
 
+#### Overriding the route summary
+
+By default, the route summary is filled with the value supplied to `desc`.
+
+```ruby
+namespace 'order' do
+  desc 'This will be your summary'
+  get :order_id do
+    ...
+  end
+end
+```
+
+To override the summary, add `summary: '[string]'` after the description.
+
+```ruby
+namespace 'order' do
+  desc 'This will be your summary',
+    summary: 'Now this is your summary!'
+  get :order_id do
+    ...
+  end
+end
+```
+
+
+#### Deprecate routes
+
+For route deprecation, add `deprecated: true` after your description.
+
+```ruby
+namespace 'order' do
+  desc 'Old way to do things',
+    deprecated: true
+  get :old do
+    ...
+  end
+
+  desc 'New way to do things'
+  get :new do
+    ...
+  end
+end
+```
+
+
 #### Expose nested namespace as standalone route
 
 Use the `nested: false` property in the `swagger` option to make nested namespaces appear as standalone resources.

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -102,7 +102,9 @@ module Grape
     end
 
     def method_object(route, options, path)
+      puts "lib/grape-swagger/endpoint.rb:105 DEBUG OUTPUT FOR GRAPE-SWAGGER: #{route.options}"
       method = {}
+      method[:summary]     = summary_object(route)
       method[:description] = description_object(route, options[:markdown])
       method[:produces]    = produces_object(route, options[:produces] || options[:format])
       method[:consumes]    = consumes_object(route, options[:format])
@@ -113,6 +115,14 @@ module Grape
       method.delete_if { |_, value| value.blank? }
 
       [route.request_method.downcase.to_sym, method]
+    end
+
+    def summary_object(route)
+      summary = route.options[:desc] if route.options.key?(:desc)
+      summary = route.description if route.description.present?
+      summary = route.options[:summary] if route.options.key?(:summary)
+
+      summary
     end
 
     def description_object(route, markdown)
@@ -237,9 +247,7 @@ module Grape
 
       GrapeSwagger.model_parsers.each do |klass, ancestor|
         next unless model.ancestors.map(&:to_s).include?(ancestor)
-
         parser = klass.new(model, self)
-
         break
       end
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -102,7 +102,6 @@ module Grape
     end
 
     def method_object(route, options, path)
-      puts "lib/grape-swagger/endpoint.rb:105 DEBUG OUTPUT FOR GRAPE-SWAGGER: #{route.options}"
       method = {}
       method[:summary]     = summary_object(route)
       method[:description] = description_object(route, options[:markdown])
@@ -111,6 +110,7 @@ module Grape
       method[:parameters]  = params_object(route)
       method[:responses]   = response_object(route, options[:markdown])
       method[:tags]        = tag_object(route, options[:version].to_s)
+      method[:deprecated]  = deprecated_object(route)
       method[:operationId] = GrapeSwagger::DocMethods::OperationId.build(route, path)
       method.delete_if { |_, value| value.blank? }
 
@@ -197,6 +197,10 @@ module Grape
 
     def tag_object(route, version)
       Array(route.path.split('{')[0].split('/').reject(&:empty?).delete_if { |i| ((i == route.prefix.to_s) || (i == version)) }.first)
+    end
+
+    def deprecated_object(route)
+      route.options.key?(:deprecated) && route.options[:deprecated]
     end
 
     private

--- a/spec/issues/403_versions_spec.rb
+++ b/spec/issues/403_versions_spec.rb
@@ -29,6 +29,7 @@ describe 'describing versions' do
         paths: {
           :'/nothings' => {
             get: {
+              summary: 'no versions given',
               description: 'no versions given',
               produces: ['application/json'],
               responses: {
@@ -71,6 +72,7 @@ describe 'describing versions' do
         paths: {
           :'/v2/api_version' => {
             get: {
+              summary: 'api versions given',
               description: 'api versions given',
               produces: ['application/json'],
               responses: {
@@ -112,6 +114,7 @@ describe 'describing versions' do
         paths: {
           :'/doc_version' => {
             get: {
+              summary: 'doc versions given',
               description: 'doc versions given',
               produces: ['application/json'],
               responses: {
@@ -154,6 +157,7 @@ describe 'describing versions' do
         paths: {
           :'/v2/both_versions' => {
             get: {
+              summary: 'both versions given',
               description: 'both versions given',
               produces: ['application/json'],
               responses: {

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -192,6 +192,7 @@ RSpec.shared_context 'entity swagger example' do
       'paths' => {
         '/v3/other_thing/{elements}' => {
           'get' => {
+            'summary' => 'nested route inside namespace',
             'description' => 'nested route inside namespace',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'body', 'name' => 'elements', 'description' => 'Set of configuration', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true }],
@@ -204,6 +205,7 @@ RSpec.shared_context 'entity swagger example' do
         },
         '/thing' => {
           'get' => {
+            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'parameters' => [
@@ -217,6 +219,7 @@ RSpec.shared_context 'entity swagger example' do
             'operationId' => 'getThing'
           },
           'post' => {
+            'summary' => 'This creates Thing.',
             'description' => 'This creates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -231,6 +234,7 @@ RSpec.shared_context 'entity swagger example' do
         },
         '/thing/{id}' => {
           'get' => {
+            'summary' => 'This gets Thing.',
             'description' => 'This gets Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -239,6 +243,7 @@ RSpec.shared_context 'entity swagger example' do
             'operationId' => 'getThingId'
           },
           'put' => {
+            'summary' => 'This updates Thing.',
             'description' => 'This updates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -252,6 +257,7 @@ RSpec.shared_context 'entity swagger example' do
             'operationId' => 'putThingId'
           },
           'delete' => {
+            'summary' => 'This deletes Thing.',
             'description' => 'This deletes Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -262,6 +268,7 @@ RSpec.shared_context 'entity swagger example' do
         },
         '/thing2' => {
           'get' => {
+            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
@@ -271,6 +278,7 @@ RSpec.shared_context 'entity swagger example' do
         },
         '/dummy/{id}' => {
           'delete' => {
+            'summary' => 'dummy route.',
             'description' => 'dummy route.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -284,6 +292,7 @@ RSpec.shared_context 'entity swagger example' do
         'QueryInput' => {
           'type' => 'object',
           'properties' => { 'elements' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/QueryInputElement' }, 'description' => 'Set of configuration' } },
+          'summary' => 'nested route inside namespace',
           'description' => 'nested route inside namespace'
         },
         'QueryInputElement' => {
@@ -293,6 +302,7 @@ RSpec.shared_context 'entity swagger example' do
         'ApiError' => {
           'type' => 'object',
           'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } },
+          'summary' => 'This gets Things.',
           'description' => 'This gets Things.'
         },
         'Something' => {
@@ -303,6 +313,7 @@ RSpec.shared_context 'entity swagger example' do
             'links' => { 'type' => 'link' },
             'others' => { 'type' => 'text' }
           },
+          'summary' => 'This gets Things.',
           'description' => 'This gets Things.'
         }
       }

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -292,7 +292,6 @@ RSpec.shared_context 'entity swagger example' do
         'QueryInput' => {
           'type' => 'object',
           'properties' => { 'elements' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/QueryInputElement' }, 'description' => 'Set of configuration' } },
-          'summary' => 'nested route inside namespace',
           'description' => 'nested route inside namespace'
         },
         'QueryInputElement' => {
@@ -302,7 +301,6 @@ RSpec.shared_context 'entity swagger example' do
         'ApiError' => {
           'type' => 'object',
           'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } },
-          'summary' => 'This gets Things.',
           'description' => 'This gets Things.'
         },
         'Something' => {
@@ -313,7 +311,6 @@ RSpec.shared_context 'entity swagger example' do
             'links' => { 'type' => 'link' },
             'others' => { 'type' => 'text' }
           },
-          'summary' => 'This gets Things.',
           'description' => 'This gets Things.'
         }
       }

--- a/spec/support/model_parsers/mock_parser.rb
+++ b/spec/support/model_parsers/mock_parser.rb
@@ -184,6 +184,7 @@ RSpec.shared_context 'mock swagger example' do
       'paths' => {
         '/v3/other_thing/{elements}' => {
           'get' => {
+            'summary' => 'nested route inside namespace',
             'description' => 'nested route inside namespace',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'body', 'name' => 'elements', 'description' => 'Set of configuration', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true }],
@@ -196,6 +197,7 @@ RSpec.shared_context 'mock swagger example' do
         },
         '/thing' => {
           'get' => {
+            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'parameters' => [
@@ -209,6 +211,7 @@ RSpec.shared_context 'mock swagger example' do
             'operationId' => 'getThing'
           },
           'post' => {
+            'summary' => 'This creates Thing.',
             'description' => 'This creates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -223,6 +226,7 @@ RSpec.shared_context 'mock swagger example' do
         },
         '/thing/{id}' => {
           'get' => {
+            'summary' => 'This gets Thing.',
             'description' => 'This gets Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -231,6 +235,7 @@ RSpec.shared_context 'mock swagger example' do
             'operationId' => 'getThingId'
           },
           'put' => {
+            'summary' => 'This updates Thing.',
             'description' => 'This updates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -244,6 +249,7 @@ RSpec.shared_context 'mock swagger example' do
             'operationId' => 'putThingId'
           },
           'delete' => {
+            'summary' => 'This deletes Thing.',
             'description' => 'This deletes Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -254,6 +260,7 @@ RSpec.shared_context 'mock swagger example' do
         },
         '/thing2' => {
           'get' => {
+            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
@@ -263,6 +270,7 @@ RSpec.shared_context 'mock swagger example' do
         },
         '/dummy/{id}' => {
           'delete' => {
+            'summary' => 'dummy route.',
             'description' => 'dummy route.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],

--- a/spec/support/model_parsers/representable_parser.rb
+++ b/spec/support/model_parsers/representable_parser.rb
@@ -361,7 +361,6 @@ RSpec.shared_context 'representable swagger example' do
         'QueryInput' => {
           'type' => 'object',
           'properties' => { 'elements' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/QueryInputElement' }, 'description' => 'Set of configuration' } },
-          'summary' => 'nested route inside namespace',
           'description' => 'nested route inside namespace'
         },
         'QueryInputElement' => {
@@ -371,7 +370,6 @@ RSpec.shared_context 'representable swagger example' do
         'ApiError' => {
           'type' => 'object',
           'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } },
-          'summary' => 'This gets Things.',
           'description' => 'This gets Things.'
         },
         'Something' => {
@@ -382,7 +380,6 @@ RSpec.shared_context 'representable swagger example' do
             'links' => { 'type' => 'array', 'items' => { 'description' => '', 'type' => 'link' } },
             'others' => { 'description' => '', 'type' => 'text' }
           },
-          'summary' => 'This gets Things.',
           'description' => 'This gets Things.'
         }
       }

--- a/spec/support/model_parsers/representable_parser.rb
+++ b/spec/support/model_parsers/representable_parser.rb
@@ -261,6 +261,7 @@ RSpec.shared_context 'representable swagger example' do
       'paths' => {
         '/v3/other_thing/{elements}' => {
           'get' => {
+            'summary' => 'nested route inside namespace',
             'description' => 'nested route inside namespace',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'body', 'name' => 'elements', 'description' => 'Set of configuration', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true }],
@@ -273,6 +274,7 @@ RSpec.shared_context 'representable swagger example' do
         },
         '/thing' => {
           'get' => {
+            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'parameters' => [
@@ -286,6 +288,7 @@ RSpec.shared_context 'representable swagger example' do
             'operationId' => 'getThing'
           },
           'post' => {
+            'summary' => 'This creates Thing.',
             'description' => 'This creates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -300,6 +303,7 @@ RSpec.shared_context 'representable swagger example' do
         },
         '/thing/{id}' => {
           'get' => {
+            'summary' => 'This gets Thing.',
             'description' => 'This gets Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -308,6 +312,7 @@ RSpec.shared_context 'representable swagger example' do
             'operationId' => 'getThingId'
           },
           'put' => {
+            'summary' => 'This updates Thing.',
             'description' => 'This updates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -321,6 +326,7 @@ RSpec.shared_context 'representable swagger example' do
             'operationId' => 'putThingId'
           },
           'delete' => {
+            'summary' => 'This deletes Thing.',
             'description' => 'This deletes Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -331,6 +337,7 @@ RSpec.shared_context 'representable swagger example' do
         },
         '/thing2' => {
           'get' => {
+            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
@@ -340,6 +347,7 @@ RSpec.shared_context 'representable swagger example' do
         },
         '/dummy/{id}' => {
           'delete' => {
+            'summary' => 'dummy route.',
             'description' => 'dummy route.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -353,6 +361,7 @@ RSpec.shared_context 'representable swagger example' do
         'QueryInput' => {
           'type' => 'object',
           'properties' => { 'elements' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/QueryInputElement' }, 'description' => 'Set of configuration' } },
+          'summary' => 'nested route inside namespace',
           'description' => 'nested route inside namespace'
         },
         'QueryInputElement' => {
@@ -362,6 +371,7 @@ RSpec.shared_context 'representable swagger example' do
         'ApiError' => {
           'type' => 'object',
           'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } },
+          'summary' => 'This gets Things.',
           'description' => 'This gets Things.'
         },
         'Something' => {
@@ -372,6 +382,7 @@ RSpec.shared_context 'representable swagger example' do
             'links' => { 'type' => 'array', 'items' => { 'description' => '', 'type' => 'link' } },
             'others' => { 'description' => '', 'type' => 'text' }
           },
+          'summary' => 'This gets Things.',
           'description' => 'This gets Things.'
         }
       }

--- a/spec/swagger_v2/api_swagger_v2_deprecation_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_deprecation_spec.rb
@@ -1,0 +1,46 @@
+require 'spec_helper'
+
+describe 'swagger spec v2.0 deprecation' do
+  include_context "#{MODEL_PARSER} swagger example"
+
+  def app
+    Class.new(Grape::API) do
+      format :json
+
+      desc 'This is a test sample', deprecated: true
+      get '/old' do
+        present true
+      end
+
+      desc 'This is another test sample', deprecated: false
+      get '/new' do
+        present true
+      end
+
+      version 'v1', using: :path
+      add_swagger_documentation api_version: 'v1',
+                                base_path: '/api',
+                                info: {
+                                  title: 'The API title to be displayed on the API homepage.',
+                                  description: 'A description of the API.',
+                                  contact_name: 'Contact name',
+                                  contact_email: 'Contact@email.com',
+                                  contact_url: 'Contact URL',
+                                  license: 'The name of the license.',
+                                  license_url: 'www.The-URL-of-the-license.org',
+                                  terms_of_service_url: 'www.The-URL-of-the-terms-and-service.com'
+                                }
+    end
+  end
+
+  before do
+    get '/v1/swagger_doc'
+  end
+
+  let(:json) { JSON.parse(last_response.body) }
+
+  describe 'deprecation' do
+    it { expect(json['paths']['/old']['get']['deprecated']).to eql true }
+    it { expect(json['paths']['/new']['get']).to_not include 'deprecated' }
+  end
+end

--- a/spec/swagger_v2/api_swagger_v2_response_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_spec.rb
@@ -45,6 +45,7 @@ describe 'response' do
     end
     specify do
       expect(subject['paths']['/nested_type']['get']).to eql(
+        'summary' => 'This returns something',
         'description' => 'This returns something',
         'produces' => ['application/json'],
         'responses' => {
@@ -66,6 +67,7 @@ describe 'response' do
 
     specify do
       expect(subject['paths']['/entity_response']['get']).to eql(
+        'summary' => 'This returns something',
         'description' => 'This returns something',
         'produces' => ['application/json'],
         'responses' => {
@@ -87,6 +89,7 @@ describe 'response' do
 
     specify do
       expect(subject['paths']['/params_response']['post']).to eql(
+        'summary' => 'This returns something',
         'description' => 'This returns something',
         'produces' => ['application/json'],
         'consumes' => ['application/json'],

--- a/spec/swagger_v2/default_api_spec.rb
+++ b/spec/swagger_v2/default_api_spec.rb
@@ -29,6 +29,7 @@ describe 'Default API' do
         'paths' => {
           '/something' => {
             'get' => {
+              'summary' => 'This gets something.',
               'description' => 'This gets something.',
               'produces' => ['application/json'],
               'tags' => ['something'],
@@ -75,6 +76,7 @@ describe 'Default API' do
                             'paths' => {
                               '/something' => {
                                 'get' => {
+                                  'summary' => 'This gets something.',
                                   'description' => 'This gets something.',
                                   'produces' => ['application/json'],
                                   'tags' => ['something'],

--- a/spec/swagger_v2/hide_api_spec.rb
+++ b/spec/swagger_v2/hide_api_spec.rb
@@ -44,6 +44,7 @@ describe 'a hide mounted api' do
       'paths' => {
         '/simple' => {
           'get' => {
+            'summary' => 'Show this endpoint',
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
             'tags' => ['simple'],
@@ -53,6 +54,7 @@ describe 'a hide mounted api' do
         },
         '/lazy' => {
           'get' => {
+            'summary' => 'Lazily show endpoint',
             'description' => 'Lazily show endpoint',
             'produces' => ['application/json'],
             'tags' => ['lazy'],
@@ -105,6 +107,7 @@ describe 'a hide mounted api with same namespace' do
       'paths' => {
         '/simple/show' => {
           'get' => {
+            'summary' => 'Show this endpoint',
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
             'operationId' => 'getSimpleShow',
@@ -126,6 +129,7 @@ describe 'a hide mounted api with same namespace' do
       'paths' => {
         '/simple/show' => {
           'get' => {
+            'summary' => 'Show this endpoint',
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
             'tags' => ['simple'],

--- a/spec/swagger_v2/mounted_target_class_spec.rb
+++ b/spec/swagger_v2/mounted_target_class_spec.rb
@@ -37,6 +37,7 @@ describe 'docs mounted separately from api' do
       'paths' => {
         '/simple' => {
           'get' => {
+            'summary' => 'This gets something.',
             'description' => 'This gets something.',
             'produces' => ['application/json'],
             'responses' => { '200' => { 'description' => 'This gets something.' } },
@@ -59,6 +60,7 @@ describe 'docs mounted separately from api' do
       'paths' => {
         '/simple' => {
           'get' => {
+            'summary' => 'This gets something.',
             'description' => 'This gets something.',
             'produces' => ['application/json'],
             'responses' => {

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -100,6 +100,7 @@ describe 'a simple mounted api' do
         'paths' => {
           '/simple' => {
             'get' => {
+              'summary' => 'This gets something.',
               'description' => 'This gets something.',
               'produces' => ['application/json'],
               'tags' => ['simple'],
@@ -109,6 +110,7 @@ describe 'a simple mounted api' do
           },
           '/simple-test' => {
             'get' => {
+              'summary' => 'This gets something for URL using - separator.',
               'description' => 'This gets something for URL using - separator.',
               'produces' => ['application/json'],
               'tags' => ['simple-test'],
@@ -134,6 +136,7 @@ describe 'a simple mounted api' do
           },
           '/simple_with_headers' => {
             'get' => {
+              'summary' => 'this gets something else',
               'description' => 'this gets something else',
               'produces' => ['application/json'],
               'parameters' => [
@@ -151,6 +154,7 @@ describe 'a simple mounted api' do
           },
           '/items' => {
             'post' => {
+              'summary' => 'this takes an array of parameters',
               'description' => 'this takes an array of parameters',
               'produces' => ['application/json'],
               'consumes' => ['application/json'],
@@ -162,6 +166,7 @@ describe 'a simple mounted api' do
           },
           '/custom' => {
             'get' => {
+              'summary' => 'this uses a custom parameter',
               'description' => 'this uses a custom parameter',
               'produces' => ['application/json'],
               'parameters' => [{ 'in' => 'formData', 'name' => 'custom', 'description' => 'array of items', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'CustomType' } }],
@@ -199,6 +204,7 @@ describe 'a simple mounted api' do
         'paths' => {
           '/simple' => {
             'get' => {
+              'summary' => 'This gets something.',
               'description' => 'This gets something.',
               'produces' => ['application/json'],
               'tags' => ['simple'],
@@ -236,6 +242,7 @@ describe 'a simple mounted api' do
           'paths' => {
             '/simple-test' => {
               'get' => {
+                'summary' => 'This gets something for URL using - separator.',
                 'description' => 'This gets something for URL using - separator.',
                 'produces' => ['application/json'],
                 'tags' => ['simple-test'],
@@ -258,6 +265,7 @@ describe 'a simple mounted api' do
         expect(subject['paths']).to eq(
           '/simple_with_headers' => {
             'get' => {
+              'summary' => 'this gets something else',
               'description' => 'this gets something else',
               'produces' => ['application/json'],
               'parameters' => [
@@ -287,6 +295,7 @@ describe 'a simple mounted api' do
         expect(subject['paths']).to eq(
           '/items' => {
             'post' => {
+              'summary' => 'this takes an array of parameters',
               'description' => 'this takes an array of parameters',
               'produces' => ['application/json'],
               'consumes' => ['application/json'],
@@ -310,6 +319,7 @@ describe 'a simple mounted api' do
         expect(subject['paths']).to eq(
           '/custom' => {
             'get' => {
+              'summary' => 'this uses a custom parameter',
               'description' => 'this uses a custom parameter',
               'produces' => ['application/json'],
               'parameters' => [{ 'in' => 'formData', 'name' => 'custom', 'description' => 'array of items', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'CustomType' } }],


### PR DESCRIPTION
Between Swagger v1.2 and v2, the `description` took a slightly different meaning and `summary` took it's place. I had to re-work a handful of tests so that summary was accepted and in order to be somewhat forward compatible, I made the string passed to `desc` on paths fill in the value for the summary by default with the option to override it.

While I was at it, I also added `deprecated` and built tests around that logic.

I based my additions on [this resource](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#operation-object)

I tested and confirmed that these changes reflect on SwaggerUI appropriately.