### PR TITLE
options[:version] missing, changed to route.version.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 #### Fixes
 
+* [#438](https://github.com/ruby-grape/grape-swagger/pull/438): Route version was missing in :options passed to PathString, so Endpoint.path_and_definitions_objects wasn't returning a versioned path when required - [@texpert](https://github.com/texpert).
+
 * Your contribution here.
 
 ### 0.20.4 (May 16, 2016)

--- a/lib/grape-swagger/doc_methods/path_string.rb
+++ b/lib/grape-swagger/doc_methods/path_string.rb
@@ -13,8 +13,8 @@ module GrapeSwagger
           # set item from path, this could be used for the definitions object
           item = route.path.gsub(%r{/{(.+?)}}, '').split('/').last.singularize.underscore.camelize || 'Item'
 
-          if route.options[:version] && options[:add_version]
-            route.path.sub!('{version}', route.options[:version].to_s)
+          if route.version && options[:add_version]
+            route.path.sub!('{version}', route.version.to_s)
           else
             route.path.sub!('/{version}', '')
           end

--- a/lib/grape-swagger/doc_methods/path_string.rb
+++ b/lib/grape-swagger/doc_methods/path_string.rb
@@ -2,7 +2,8 @@ module GrapeSwagger
   module DocMethods
     class PathString
       class << self
-        def build(path, route_version, options = {})
+        def build(route, options = {})
+          path = route.path
           # always removing format
           path.sub!(/\(\.\w+?\)$/, '')
           path.sub!('(.:format)', '')
@@ -13,8 +14,8 @@ module GrapeSwagger
           # set item from path, this could be used for the definitions object
           item = path.gsub(%r{/{(.+?)}}, '').split('/').last.singularize.underscore.camelize || 'Item'
 
-          if route_version && options[:add_version]
-            path.sub!('{version}', route_version.to_s)
+          if route.version && options[:add_version]
+            path.sub!('{version}', route.version.to_s)
           else
             path.sub!('/{version}', '')
           end

--- a/lib/grape-swagger/doc_methods/path_string.rb
+++ b/lib/grape-swagger/doc_methods/path_string.rb
@@ -2,8 +2,7 @@ module GrapeSwagger
   module DocMethods
     class PathString
       class << self
-        def build(route, options = {})
-          path = route.path
+        def build(path, route_version, options = {})
           # always removing format
           path.sub!(/\(\.\w+?\)$/, '')
           path.sub!('(.:format)', '')
@@ -14,8 +13,8 @@ module GrapeSwagger
           # set item from path, this could be used for the definitions object
           item = path.gsub(%r{/{(.+?)}}, '').split('/').last.singularize.underscore.camelize || 'Item'
 
-          if route.version && options[:add_version]
-            path.sub!('{version}', route.version.to_s)
+          if route_version && options[:add_version]
+            path.sub!('{version}', route_version.to_s)
           else
             path.sub!('/{version}', '')
           end

--- a/lib/grape-swagger/doc_methods/path_string.rb
+++ b/lib/grape-swagger/doc_methods/path_string.rb
@@ -19,7 +19,7 @@ module GrapeSwagger
             route.path.sub!('/{version}', '')
           end
 
-          route.path = "#{GrapeSwagger::DocMethods::OptionalObject.build(:base_path, options)}#{route.path}" if options[:add_base_path]
+          route.path.prepend(GrapeSwagger::DocMethods::OptionalObject.build(:base_path, options)) if options[:add_base_path]
 
           [item, route.path.start_with?('/') ? route.path : "/#{route.path}"]
         end

--- a/lib/grape-swagger/doc_methods/path_string.rb
+++ b/lib/grape-swagger/doc_methods/path_string.rb
@@ -2,26 +2,26 @@ module GrapeSwagger
   module DocMethods
     class PathString
       class << self
-        def build(path, options = {})
+        def build(route, options = {})
           # always removing format
-          path.sub!(/\(\.\w+?\)$/, '')
-          path.sub!('(.:format)', '')
+          route.path.sub!(/\(\.\w+?\)$/, '')
+          route.path.sub!('(.:format)', '')
 
           # ... format path params
-          path.gsub!(/:(\w+)/, '{\1}')
+          route.path.gsub!(/:(\w+)/, '{\1}')
 
           # set item from path, this could be used for the definitions object
-          item = path.gsub(%r{/{(.+?)}}, '').split('/').last.singularize.underscore.camelize || 'Item'
+          item = route.path.gsub(%r{/{(.+?)}}, '').split('/').last.singularize.underscore.camelize || 'Item'
 
-          if options[:version] && options[:add_version]
-            path.sub!('{version}', options[:version].to_s)
+          if route.options[:version] && options[:add_version]
+            route.path.sub!('{version}', route.options[:version].to_s)
           else
-            path.sub!('/{version}', '')
+            route.path.sub!('/{version}', '')
           end
 
-          path = "#{GrapeSwagger::DocMethods::OptionalObject.build(:base_path, options)}#{path}" if options[:add_base_path]
+          route.path = "#{GrapeSwagger::DocMethods::OptionalObject.build(:base_path, options)}#{route.path}" if options[:add_base_path]
 
-          [item, path.start_with?('/') ? path : "/#{path}"]
+          [item, route.path.start_with?('/') ? route.path : "/#{route.path}"]
         end
       end
     end

--- a/lib/grape-swagger/doc_methods/path_string.rb
+++ b/lib/grape-swagger/doc_methods/path_string.rb
@@ -3,25 +3,26 @@ module GrapeSwagger
     class PathString
       class << self
         def build(route, options = {})
+          path = route.path
           # always removing format
-          route.path.sub!(/\(\.\w+?\)$/, '')
-          route.path.sub!('(.:format)', '')
+          path.sub!(/\(\.\w+?\)$/, '')
+          path.sub!('(.:format)', '')
 
           # ... format path params
-          route.path.gsub!(/:(\w+)/, '{\1}')
+          path.gsub!(/:(\w+)/, '{\1}')
 
           # set item from path, this could be used for the definitions object
-          item = route.path.gsub(%r{/{(.+?)}}, '').split('/').last.singularize.underscore.camelize || 'Item'
+          item = path.gsub(%r{/{(.+?)}}, '').split('/').last.singularize.underscore.camelize || 'Item'
 
           if route.version && options[:add_version]
-            route.path.sub!('{version}', route.version.to_s)
+            path.sub!('{version}', route.version.to_s)
           else
-            route.path.sub!('/{version}', '')
+            path.sub!('/{version}', '')
           end
 
-          route.path.prepend(GrapeSwagger::DocMethods::OptionalObject.build(:base_path, options)) if options[:add_base_path]
+          path = "#{GrapeSwagger::DocMethods::OptionalObject.build(:base_path, options)}#{path}" if options[:add_base_path]
 
-          [item, route.path.start_with?('/') ? route.path : "/#{route.path}"]
+          [item, path.start_with?('/') ? path : "/#{path}"]
         end
       end
     end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -86,7 +86,7 @@ module Grape
       routes.each do |route|
         next if hidden?(route)
 
-        @item, path = GrapeSwagger::DocMethods::PathString.build(route, options)
+        @item, path = GrapeSwagger::DocMethods::PathString.build(route.path, route.version, options)
         @entity = route.entity || route.options[:success]
 
         verb, method_object = method_object(route, options, path)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -86,7 +86,7 @@ module Grape
       routes.each do |route|
         next if hidden?(route)
 
-        @item, path = GrapeSwagger::DocMethods::PathString.build(route.path, route.version, options)
+        @item, path = GrapeSwagger::DocMethods::PathString.build(route, options)
         @entity = route.entity || route.options[:success]
 
         verb, method_object = method_object(route, options, path)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -86,7 +86,7 @@ module Grape
       routes.each do |route|
         next if hidden?(route)
 
-        @item, path = GrapeSwagger::DocMethods::PathString.build(route.path, options)
+        @item, path = GrapeSwagger::DocMethods::PathString.build(route, options)
         @entity = route.entity || route.options[:success]
 
         verb, method_object = method_object(route, options, path)

--- a/lib/grape-swagger/grape/route.rb
+++ b/lib/grape-swagger/grape/route.rb
@@ -1,7 +1,8 @@
 # backwards compatibility for Grape < 0.16.0
 module Grape
   class Route
-    [:path, :prefix, :entity, :description, :settings, :params, :headers, :http_codes].each do |m|
+    [:path, :prefix, :entity, :description, :settings, :params, :headers, :http_codes, :version]
+      .each do |m|
       define_method m do
         send "route_#{m}"
       end

--- a/spec/lib/path_string_spec.rb
+++ b/spec/lib/path_string_spec.rb
@@ -8,29 +8,59 @@ describe GrapeSwagger::DocMethods::PathString do
 
   describe 'operation_id_object' do
     describe 'version' do
-      describe 'defaults: not given, false' do
-        let(:options) { { add_version: false } }
+      describe 'defaults: given, true' do
+        let(:options) { { add_version: true } }
+        let(:version) { 'v1' }
 
-        specify do
-          expect(subject.build('/thing(.json)', options)).to eql ['Thing', '/thing']
-          expect(subject.build('/thing/foo(.json)', options)).to eql ['Foo', '/thing/foo']
-          expect(subject.build('/thing(.:format)', options)).to eql ['Thing', '/thing']
-          expect(subject.build('/thing/foo(.:format)', options)).to eql ['Foo', '/thing/foo']
-          expect(subject.build('/thing/:id', options)).to eql ['Thing', '/thing/{id}']
-          expect(subject.build('/thing/foo/:id', options)).to eql ['Foo', '/thing/foo/{id}']
+        specify 'The returned path includes version' do
+          expect(subject.build('/{version}/thing(.json)', version, options)).to eql ['Thing', '/v1/thing']
+          expect(subject.build('/{version}/thing/foo(.json)', version, options)).to eql ['Foo', '/v1/thing/foo']
+          expect(subject.build('/{version}/thing(.:format)', version, options)).to eql ['Thing', '/v1/thing']
+          expect(subject.build('/{version}/thing/foo(.:format)', version, options)).to eql ['Foo', '/v1/thing/foo']
+          expect(subject.build('/{version}/thing/:id', version, options)).to eql ['Thing', '/v1/thing/{id}']
+          expect(subject.build('/{version}/thing/foo/:id', version, options)).to eql ['Foo', '/v1/thing/foo/{id}']
         end
       end
 
-      describe 'defaults: given, true' do
-        let(:options) { { version: 'v1', add_version: true } }
+      describe 'defaults: not given, both false' do
+        let(:options) { { add_version: false } }
+        let(:version) { nil }
 
-        specify do
-          expect(subject.build('/{version}/thing(.json)', options)).to eql ['Thing', '/v1/thing']
-          expect(subject.build('/{version}/thing/foo(.json)', options)).to eql ['Foo', '/v1/thing/foo']
-          expect(subject.build('/{version}/thing(.:format)', options)).to eql ['Thing', '/v1/thing']
-          expect(subject.build('/{version}/thing/foo(.:format)', options)).to eql ['Foo', '/v1/thing/foo']
-          expect(subject.build('/{version}/thing/:id', options)).to eql ['Thing', '/v1/thing/{id}']
-          expect(subject.build('/{version}/thing/foo/:id', options)).to eql ['Foo', '/v1/thing/foo/{id}']
+        specify 'The returned path does not include version' do
+          expect(subject.build('/thing(.json)', version, options)).to eql ['Thing', '/thing']
+          expect(subject.build('/thing/foo(.json)', version, options)).to eql ['Foo', '/thing/foo']
+          expect(subject.build('/thing(.:format)', version, options)).to eql ['Thing', '/thing']
+          expect(subject.build('/thing/foo(.:format)', version, options)).to eql ['Foo', '/thing/foo']
+          expect(subject.build('/thing/:id', version, options)).to eql ['Thing', '/thing/{id}']
+          expect(subject.build('/thing/foo/:id', version, options)).to eql ['Foo', '/thing/foo/{id}']
+        end
+      end
+
+      describe 'defaults: add_version false' do
+        let(:options) { { add_version: false } }
+        let(:version) { 'v1' }
+
+        specify 'The returned path does not include version' do
+          expect(subject.build('/thing(.json)', version, options)).to eql ['Thing', '/thing']
+          expect(subject.build('/thing/foo(.json)', version, options)).to eql ['Foo', '/thing/foo']
+          expect(subject.build('/thing(.:format)', version, options)).to eql ['Thing', '/thing']
+          expect(subject.build('/thing/foo(.:format)', version, options)).to eql ['Foo', '/thing/foo']
+          expect(subject.build('/thing/:id', version, options)).to eql ['Thing', '/thing/{id}']
+          expect(subject.build('/thing/foo/:id', version, options)).to eql ['Foo', '/thing/foo/{id}']
+        end
+      end
+
+      describe 'defaults: root_version nil' do
+        let(:options) { { add_version: true } }
+        let(:version) { nil }
+
+        specify 'The returned path does not include version' do
+          expect(subject.build('/thing(.json)', version, options)).to eql ['Thing', '/thing']
+          expect(subject.build('/thing/foo(.json)', version, options)).to eql ['Foo', '/thing/foo']
+          expect(subject.build('/thing(.:format)', version, options)).to eql ['Thing', '/thing']
+          expect(subject.build('/thing/foo(.:format)', version, options)).to eql ['Foo', '/thing/foo']
+          expect(subject.build('/thing/:id', version, options)).to eql ['Thing', '/thing/{id}']
+          expect(subject.build('/thing/foo/:id', version, options)).to eql ['Foo', '/thing/foo/{id}']
         end
       end
     end

--- a/spec/lib/path_string_spec.rb
+++ b/spec/lib/path_string_spec.rb
@@ -10,57 +10,81 @@ describe GrapeSwagger::DocMethods::PathString do
     describe 'version' do
       describe 'defaults: given, true' do
         let(:options) { { add_version: true } }
-        let(:version) { 'v1' }
+        let(:route) { Struct.new(:version, :path).new('v1') }
 
         specify 'The returned path includes version' do
-          expect(subject.build('/{version}/thing(.json)', version, options)).to eql ['Thing', '/v1/thing']
-          expect(subject.build('/{version}/thing/foo(.json)', version, options)).to eql ['Foo', '/v1/thing/foo']
-          expect(subject.build('/{version}/thing(.:format)', version, options)).to eql ['Thing', '/v1/thing']
-          expect(subject.build('/{version}/thing/foo(.:format)', version, options)).to eql ['Foo', '/v1/thing/foo']
-          expect(subject.build('/{version}/thing/:id', version, options)).to eql ['Thing', '/v1/thing/{id}']
-          expect(subject.build('/{version}/thing/foo/:id', version, options)).to eql ['Foo', '/v1/thing/foo/{id}']
+          route.path = '/{version}/thing(.json)'
+          expect(subject.build(route, options)).to eql ['Thing', '/v1/thing']
+          route.path = '/{version}/thing/foo(.json)'
+          expect(subject.build(route, options)).to eql ['Foo', '/v1/thing/foo']
+          route.path = '/{version}/thing(.:format)'
+          expect(subject.build(route, options)).to eql ['Thing', '/v1/thing']
+          route.path = '/{version}/thing/foo(.:format)'
+          expect(subject.build(route, options)).to eql ['Foo', '/v1/thing/foo']
+          route.path = '/{version}/thing/:id'
+          expect(subject.build(route, options)).to eql ['Thing', '/v1/thing/{id}']
+          route.path = '/{version}/thing/foo/:id'
+          expect(subject.build(route, options)).to eql ['Foo', '/v1/thing/foo/{id}']
         end
       end
 
       describe 'defaults: not given, both false' do
         let(:options) { { add_version: false } }
-        let(:version) { nil }
+        let(:route) { Struct.new(:version, :path).new }
 
         specify 'The returned path does not include version' do
-          expect(subject.build('/thing(.json)', version, options)).to eql ['Thing', '/thing']
-          expect(subject.build('/thing/foo(.json)', version, options)).to eql ['Foo', '/thing/foo']
-          expect(subject.build('/thing(.:format)', version, options)).to eql ['Thing', '/thing']
-          expect(subject.build('/thing/foo(.:format)', version, options)).to eql ['Foo', '/thing/foo']
-          expect(subject.build('/thing/:id', version, options)).to eql ['Thing', '/thing/{id}']
-          expect(subject.build('/thing/foo/:id', version, options)).to eql ['Foo', '/thing/foo/{id}']
+          route.path = '/{version}/thing(.json)'
+          expect(subject.build(route, options)).to eql ['Thing', '/thing']
+          route.path = '/{version}/thing/foo(.json)'
+          expect(subject.build(route, options)).to eql ['Foo', '/thing/foo']
+          route.path = '/{version}/thing(.:format)'
+          expect(subject.build(route, options)).to eql ['Thing', '/thing']
+          route.path = '/{version}/thing/foo(.:format)'
+          expect(subject.build(route, options)).to eql ['Foo', '/thing/foo']
+          route.path = '/{version}/thing/:id'
+          expect(subject.build(route, options)).to eql ['Thing', '/thing/{id}']
+          route.path = '/{version}/thing/foo/:id'
+          expect(subject.build(route, options)).to eql ['Foo', '/thing/foo/{id}']
         end
       end
 
       describe 'defaults: add_version false' do
         let(:options) { { add_version: false } }
-        let(:version) { 'v1' }
+        let(:route) { Struct.new(:version, :path).new('v1') }
 
         specify 'The returned path does not include version' do
-          expect(subject.build('/thing(.json)', version, options)).to eql ['Thing', '/thing']
-          expect(subject.build('/thing/foo(.json)', version, options)).to eql ['Foo', '/thing/foo']
-          expect(subject.build('/thing(.:format)', version, options)).to eql ['Thing', '/thing']
-          expect(subject.build('/thing/foo(.:format)', version, options)).to eql ['Foo', '/thing/foo']
-          expect(subject.build('/thing/:id', version, options)).to eql ['Thing', '/thing/{id}']
-          expect(subject.build('/thing/foo/:id', version, options)).to eql ['Foo', '/thing/foo/{id}']
+          route.path = '/{version}/thing(.json)'
+          expect(subject.build(route, options)).to eql ['Thing', '/thing']
+          route.path = '/{version}/thing/foo(.json)'
+          expect(subject.build(route, options)).to eql ['Foo', '/thing/foo']
+          route.path = '/{version}/thing(.:format)'
+          expect(subject.build(route, options)).to eql ['Thing', '/thing']
+          route.path = '/{version}/thing/foo(.:format)'
+          expect(subject.build(route, options)).to eql ['Foo', '/thing/foo']
+          route.path = '/{version}/thing/:id'
+          expect(subject.build(route, options)).to eql ['Thing', '/thing/{id}']
+          route.path = '/{version}/thing/foo/:id'
+          expect(subject.build(route, options)).to eql ['Foo', '/thing/foo/{id}']
         end
       end
 
       describe 'defaults: root_version nil' do
         let(:options) { { add_version: true } }
-        let(:version) { nil }
+        let(:route) { Struct.new(:version, :path).new }
 
         specify 'The returned path does not include version' do
-          expect(subject.build('/thing(.json)', version, options)).to eql ['Thing', '/thing']
-          expect(subject.build('/thing/foo(.json)', version, options)).to eql ['Foo', '/thing/foo']
-          expect(subject.build('/thing(.:format)', version, options)).to eql ['Thing', '/thing']
-          expect(subject.build('/thing/foo(.:format)', version, options)).to eql ['Foo', '/thing/foo']
-          expect(subject.build('/thing/:id', version, options)).to eql ['Thing', '/thing/{id}']
-          expect(subject.build('/thing/foo/:id', version, options)).to eql ['Foo', '/thing/foo/{id}']
+          route.path = '/{version}/thing(.json)'
+          expect(subject.build(route, options)).to eql ['Thing', '/thing']
+          route.path = '/{version}/thing/foo(.json)'
+          expect(subject.build(route, options)).to eql ['Foo', '/thing/foo']
+          route.path = '/{version}/thing(.:format)'
+          expect(subject.build(route, options)).to eql ['Thing', '/thing']
+          route.path = '/{version}/thing/foo(.:format)'
+          expect(subject.build(route, options)).to eql ['Foo', '/thing/foo']
+          route.path = '/{version}/thing/:id'
+          expect(subject.build(route, options)).to eql ['Thing', '/thing/{id}']
+          route.path = '/{version}/thing/foo/:id'
+          expect(subject.build(route, options)).to eql ['Foo', '/thing/foo/{id}']
         end
       end
     end

--- a/spec/swagger_v2/endpoint_versioned_path_spec.rb
+++ b/spec/swagger_v2/endpoint_versioned_path_spec.rb
@@ -19,7 +19,7 @@ describe 'Grape::Endpoint#path_and_definitions' do
       end
     end
 
-    @options = { add_version: true}
+    @options = { add_version: true }
     @target_routes = API::Root.combined_namespace_routes
   end
 

--- a/spec/swagger_v2/endpoint_versioned_path_spec.rb
+++ b/spec/swagger_v2/endpoint_versioned_path_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+describe 'Grape::Endpoint#path_and_definitions' do
+  before do
+    module API
+      module V1
+        class Item < Grape::API
+          version 'v1', using: :path
+
+          resource :item do
+            get '/'
+          end
+        end
+      end
+
+      class Root < Grape::API
+        mount API::V1::Item
+        add_swagger_documentation add_version: true
+      end
+    end
+
+    @options = { add_version: true}
+    @target_routes = API::Root.combined_namespace_routes
+  end
+
+  it 'is returning a versioned path' do
+    expect(API::V1::Item.endpoints[0]
+      .path_and_definition_objects(@target_routes, @options)[0].keys[0]).to eql '/v1/item'
+  end
+end


### PR DESCRIPTION
A small change, because the :version is missing in options, but I've found it in route.options. So better to pass the route to PathString - to have it there for .path and .options