### PR TITLE
support custom DELETE responses with models

### DIFF
--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -180,7 +180,7 @@ module Grape
           value[:code] = 204
         end
 
-        next if memo.key?(204)
+        next if value[:code] == 204
         next unless !response_model.start_with?('Swagger_doc') &&
                     ((@definitions[response_model] && value[:code].to_s.start_with?('2')) || value[:model])
 


### PR DESCRIPTION
If we create and endpoint with such a description:
```ruby
desc 'Endpoint desc', http_codes: [{ code: 200, message: 'desc', model: ExampleEntity }]
```
the entity won't appear in swagger json because of [this line](https://github.com/ruby-grape/grape-swagger/blob/c1c1040accaa097d2d5656b7663c5b4cf10b61ac/lib/grape-swagger/endpoint.rb#L183). It sees default 204 response (which was built few lines upper) and immediately moves to next entry.
This PR fixes that.