### PR TITLE
multi type and documentation hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,11 +3,14 @@
 #### Features
 
 * [#448](https://github.com/ruby-grape/grape-swagger/pull/448): Header parameters are now prepended to the parameter list - [@anakinj](https://github.com/anakinj).
+* [#444](https://github.com/ruby-grape/grape-swagger/pull/444): With multi types parameter the first type is use as the documentation type [@scauglog](https://github.com/scauglog)
 
 #### Fixes
 
 * [#450](https://github.com/ruby-grape/grape-swagger/pull/438): Do not add :description to definitions if :description is missing on path - [@texpert](https://github.com/texpert).
 * [#447](https://github.com/ruby-grape/grape-swagger/pull/447): Version part of the url is now ignored when generating tags for endpoint - [@anakinj](https://github.com/anakinj).
+* [#444](https://github.com/ruby-grape/grape-swagger//pull/444): Default value provided in the documentation hash, override the grape default [@scauglog](https://github.com/scauglog)
+* [#443](https://github.com/ruby-grape/grape-swagger/issues/443): Type provided in the documentation hash, override the grape type [@scauglog](https://github.com/scauglog)
 
 ### 0.21.0 (June 1, 2016)
 

--- a/README.md
+++ b/README.md
@@ -344,9 +344,13 @@ add_swagger_documentation \
 
 * [Swagger Header Parameters](#headers)
 * [Hiding an Endpoint](#hiding)
+* [Overriding Auto-Generated Nicknames](#overriding-auto-generated-nicknames)
 * [Defining an endpoint as array](#array)
 * [Using an options hash](#options)
 * [Specify endpoint details](#details)
+* [Overriding param type](#overriding-param-type)
+* [Overriding type](#overriding-type)
+* [Multi types](#multi-types)
 * [Response documentation](#response)
 
 
@@ -454,6 +458,51 @@ post :act do
 end
 ```
 
+#### Overriding type
+
+You can override type, using the documentation hash.
+
+```ruby
+params do
+  requires :input, type: String, documentation: { type: 'integer' }
+end
+post :act do
+  ...
+end
+```
+
+```json
+{
+  "in": "formData",
+  "name": "input",
+  "type": "integer",
+  "format": "int32",
+  "required": true
+}
+```
+
+
+#### Multi types
+
+By default when you set multi types, the first type is selected as swagger type
+
+```ruby
+params do
+  requires :action, types: [String, Integer]
+end
+post :act do
+  ...
+end
+```
+
+```json
+{
+  "in": "formData",
+  "name": "action",
+  "type": "string",
+  "required": true
+}
+```
 
 #### Overriding the route summary
 

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -3,9 +3,10 @@ module GrapeSwagger
     class DataType
       class << self
         def call(value)
-          raw_data_type = value[:type] if value.is_a?(Hash)
-          raw_data_type = value unless value.is_a?(Hash)
-          raw_data_type ||= 'string'
+          raw_data_type = value.is_a?(Hash) ? value[:type] : value
+          raw_data_type ||= 'String'
+          raw_data_type = parse_multi_type(raw_data_type)
+
           case raw_data_type.to_s
           when 'Boolean', 'Date', 'Integer', 'String', 'Float', 'JSON', 'Array'
             raw_data_type.to_s.downcase
@@ -25,6 +26,17 @@ module GrapeSwagger
             'string'
           else
             parse_entity_name(raw_data_type)
+          end
+        end
+
+        def parse_multi_type(raw_data_type)
+          case raw_data_type
+          when /\A\[.*\]\z/
+            raw_data_type.gsub(/[(\A\[)(\s+)(\]\z)]/, '').split(',').first
+          when Array
+            raw_data_type.first
+          else
+            raw_data_type
           end
         end
 

--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -6,11 +6,9 @@ module GrapeSwagger
           path = route.path
           method = route.request_method
 
+          additional_documentation = settings.fetch(:documentation, {})
+          settings.merge!(additional_documentation)
           data_type = GrapeSwagger::DocMethods::DataType.call(settings)
-          additional_documentation = settings[:documentation]
-          if additional_documentation
-            settings = additional_documentation.merge(settings)
-          end
 
           value_type = settings.merge(data_type: data_type, path: path, param_name: param, method: method)
 

--- a/spec/lib/data_type_spec.rb
+++ b/spec/lib/data_type_spec.rb
@@ -19,7 +19,7 @@ describe GrapeSwagger::DocMethods::DataType do
   end
 
   describe 'Multi types in a string' do
-    let(:value) { { type: "[String, Integer]" } }
+    let(:value) { { type: '[String, Integer]' } }
 
     it { expect(subject).to eql 'string' }
   end

--- a/spec/lib/data_type_spec.rb
+++ b/spec/lib/data_type_spec.rb
@@ -18,6 +18,18 @@ describe GrapeSwagger::DocMethods::DataType do
     it { expect(subject).to eql 'object' }
   end
 
+  describe 'Multi types in a string' do
+    let(:value) { { type: "[String, Integer]" } }
+
+    it { expect(subject).to eql 'string' }
+  end
+
+  describe 'Multi types in array' do
+    let(:value) { { type: [String, Integer] } }
+
+    it { expect(subject).to eql 'string' }
+  end
+
   describe 'Rack::Multipart::UploadedFile' do
     let(:value) { { type: Rack::Multipart::UploadedFile } }
 

--- a/spec/swagger_v2/param_multi_type_spec.rb
+++ b/spec/swagger_v2/param_multi_type_spec.rb
@@ -1,13 +1,62 @@
 require 'spec_helper'
 
-if Grape::VERSION >= '0.14'
-  describe 'Params Multi Types' do
+describe 'Params Multi Types' do
+  def app
+    Class.new(Grape::API) do
+      format :json
+
+      params do
+        if Grape::VERSION < '0.14'
+          requires :input, type: [String, Integer]
+        else
+          requires :input, types: [String, Integer]
+        end
+        requires :another_input, type: [String, Integer]
+      end
+      post :action do
+      end
+
+      add_swagger_documentation
+    end
+  end
+
+  subject do
+    get '/swagger_doc/action'
+    expect(last_response.status).to eq 200
+    body = JSON.parse last_response.body
+    body['paths']['/action']['post']['parameters']
+  end
+
+  it 'reads param type correctly' do
+    expect(subject).to eq [
+      {
+        'in' => 'formData',
+        'name' => 'input',
+        'type' => 'string',
+        'required' => true
+      },
+      {
+        'in' => 'formData',
+        'name' => 'another_input',
+        'type' => 'string',
+        'required' => true
+      }
+    ]
+  end
+
+  describe 'header params' do
     def app
       Class.new(Grape::API) do
         format :json
 
+        desc 'Some API', headers: { 'My-Header' => { required: true, description: 'Set this!' } }
         params do
-          requires :input, types: [String, Integer]
+          if Grape::VERSION < '0.14'
+            requires :input, type: [String, Integer]
+          else
+            requires :input, types: [String, Integer]
+          end
+          requires :another_input, type: [String, Integer]
         end
         post :action do
         end
@@ -16,42 +65,9 @@ if Grape::VERSION >= '0.14'
       end
     end
 
-    subject do
-      get '/swagger_doc/action'
-      expect(last_response.status).to eq 200
-      body = JSON.parse last_response.body
-      body['paths']['/action']['post']['parameters']
-    end
-
-    it 'reads param type correctly' do
-      expect(subject).to eq [{
-        'in' => 'formData',
-        'name' => 'input',
-        'type' => 'string',
-        'required' => true
-      }]
-    end
-
-    describe 'header params' do
-      def app
-        Class.new(Grape::API) do
-          format :json
-
-          desc 'Some API', headers: { 'My-Header' => { required: true, description: 'Set this!' } }
-          params do
-            requires :input, types: [String, Integer]
-          end
-          post :action do
-          end
-
-          add_swagger_documentation
-        end
-      end
-
-      it 'has consistent types' do
-        types = subject.map { |param| param['type'] }
-        expect(types).to eq(%w(string string))
-      end
+    it 'has consistent types' do
+      types = subject.map { |param| param['type'] }
+      expect(types).to eq(%w(string string string))
     end
   end
 end

--- a/spec/swagger_v2/param_multi_type_spec.rb
+++ b/spec/swagger_v2/param_multi_type_spec.rb
@@ -1,43 +1,11 @@
 require 'spec_helper'
 
 if Grape::VERSION >= '0.14'
-describe 'Params Multi Types' do
-  def app
-    Class.new(Grape::API) do
-      format :json
-
-      params do
-        requires :input, types: [String, Integer]
-      end
-      post :action do
-      end
-
-      add_swagger_documentation
-    end
-  end
-
-  subject do
-    get '/swagger_doc/action'
-    expect(last_response.status).to eq 200
-    body = JSON.parse last_response.body
-    body['paths']['/action']['post']['parameters']
-  end
-
-  it 'reads param type correctly' do
-    expect(subject).to eq [{
-      'in' => 'formData',
-      'name' => 'input',
-      'type' => 'string',
-      'required' => true
-    }]
-  end
-
-  describe 'header params' do
+  describe 'Params Multi Types' do
     def app
       Class.new(Grape::API) do
         format :json
 
-        desc 'Some API', headers: { 'My-Header' => { required: true, description: 'Set this!' } }
         params do
           requires :input, types: [String, Integer]
         end
@@ -48,10 +16,42 @@ describe 'Params Multi Types' do
       end
     end
 
-    it 'has consistent types' do
-      types = subject.map { |param| param['type'] }
-      expect(types).to eq(%w(string string))
+    subject do
+      get '/swagger_doc/action'
+      expect(last_response.status).to eq 200
+      body = JSON.parse last_response.body
+      body['paths']['/action']['post']['parameters']
+    end
+
+    it 'reads param type correctly' do
+      expect(subject).to eq [{
+        'in' => 'formData',
+        'name' => 'input',
+        'type' => 'string',
+        'required' => true
+      }]
+    end
+
+    describe 'header params' do
+      def app
+        Class.new(Grape::API) do
+          format :json
+
+          desc 'Some API', headers: { 'My-Header' => { required: true, description: 'Set this!' } }
+          params do
+            requires :input, types: [String, Integer]
+          end
+          post :action do
+          end
+
+          add_swagger_documentation
+        end
+      end
+
+      it 'has consistent types' do
+        types = subject.map { |param| param['type'] }
+        expect(types).to eq(%w(string string))
+      end
     end
   end
-end
 end

--- a/spec/swagger_v2/param_multi_type_spec.rb
+++ b/spec/swagger_v2/param_multi_type_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
+if Grape::VERSION >= '0.14'
 describe 'Params Multi Types' do
   def app
     Class.new(Grape::API) do
@@ -52,4 +53,5 @@ describe 'Params Multi Types' do
       expect(types).to eq(%w(string string))
     end
   end
+end
 end

--- a/spec/swagger_v2/param_multi_type_spec.rb
+++ b/spec/swagger_v2/param_multi_type_spec.rb
@@ -1,0 +1,55 @@
+require 'spec_helper'
+
+describe 'Params Multi Types' do
+  def app
+    Class.new(Grape::API) do
+      format :json
+
+      params do
+        requires :input, types: [String, Integer]
+      end
+      post :action do
+      end
+
+      add_swagger_documentation
+    end
+  end
+
+  subject do
+    get '/swagger_doc/action'
+    expect(last_response.status).to eq 200
+    body = JSON.parse last_response.body
+    body['paths']['/action']['post']['parameters']
+  end
+
+  it 'reads param type correctly' do
+    expect(subject).to eq [{
+      'in' => 'formData',
+      'name' => 'input',
+      'type' => 'string',
+      'required' => true
+    }]
+  end
+
+  describe 'header params' do
+    def app
+      Class.new(Grape::API) do
+        format :json
+
+        desc 'Some API', headers: { 'My-Header' => { required: true, description: 'Set this!' } }
+        params do
+          requires :input, types: [String, Integer]
+        end
+        post :action do
+        end
+
+        add_swagger_documentation
+      end
+    end
+
+    it 'has consistent types' do
+      types = subject.map { |param| param['type'] }
+      expect(types).to eq(%w(string string))
+    end
+  end
+end

--- a/spec/swagger_v2/param_type_spec.rb
+++ b/spec/swagger_v2/param_type_spec.rb
@@ -11,45 +11,72 @@ describe 'Params Types' do
       post :action do
       end
 
+      params do
+        requires :input, type: String, default: '14', documentation: { type: 'email', default: '42' }
+      end
+      post :action_with_doc do
+      end
+
       add_swagger_documentation
     end
   end
-
-  subject do
-    get '/swagger_doc/action'
-    expect(last_response.status).to eq 200
-    body = JSON.parse last_response.body
-    body['paths']['/action']['post']['parameters']
-  end
-
-  it 'reads param type correctly' do
-    expect(subject).to eq [{
-      'in' => 'formData',
-      'name' => 'input',
-      'type' => 'string',
-      'required' => true
-    }]
-  end
-
-  describe 'header params' do
-    def app
-      Class.new(Grape::API) do
-        format :json
-
-        desc 'Some API', headers: { 'My-Header' => { required: true, description: 'Set this!' } }
-        params do
-          requires :input, type: String
-        end
-        post :action do
-        end
-
-        add_swagger_documentation
-      end
+  context 'with no documentation hash' do
+    subject do
+      get '/swagger_doc/action'
+      expect(last_response.status).to eq 200
+      body = JSON.parse last_response.body
+      body['paths']['/action']['post']['parameters']
     end
 
-    it 'has consistent types' do
-      types = subject.map { |param| param['type'] }
-      expect(types).to eq(%w(string string))
+    it 'reads param type correctly' do
+      expect(subject).to eq [{
+        'in' => 'formData',
+        'name' => 'input',
+        'type' => 'string',
+        'required' => true
+      }]
+    end
+
+    describe 'header params' do
+      def app
+        Class.new(Grape::API) do
+          format :json
+
+          desc 'Some API', headers: { 'My-Header' => { required: true, description: 'Set this!' } }
+          params do
+            requires :input, type: String
+          end
+          post :action do
+          end
+
+          add_swagger_documentation
+        end
+      end
+
+      it 'has consistent types' do
+        types = subject.map { |param| param['type'] }
+        expect(types).to eq(%w(string string))
+      end
+    end
+  end
+
+  context 'with documentation hash' do
+    subject do
+      get '/swagger_doc/action_with_doc'
+      expect(last_response.status).to eq 200
+      body = JSON.parse last_response.body
+      body['paths']['/action_with_doc']['post']['parameters']
+    end
+
+    it 'reads param type correctly' do
+      expect(subject).to eq [{
+        'in' => 'formData',
+        'name' => 'input',
+        'type' => 'string',
+        'format' => 'email',
+        'default' => '42',
+        'required' => true
+      }]
     end
   end
 end


### PR DESCRIPTION
multi type parameter default to first type
when :type and :default are provided in a documenation hash they override grape :type and :default