### PR TITLE
Order of header parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 #### Features
 
-* Your contribution here.
+* [#448](https://github.com/ruby-grape/grape-swagger/pull/448): Header parameters are now prepended to the parameter list - [@anakinj](https://github.com/anakinj).
 
 #### Fixes
 
-* [#448](https://github.com/ruby-grape/grape-swagger/pull/448): Header parameters are now prepended to the parameter list - [@anakinj](https://github.com/anakinj).
+* Your contribution here.
 
 ### 0.21.0 (June 1, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#448](https://github.com/ruby-grape/grape-swagger/pull/448): Header parameters are now prepended to the parameter list - [@anakinj](https://github.com/anakinj).
 
 ### 0.21.0 (June 1, 2016)
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -203,7 +203,7 @@ module Grape
     def partition_params(route)
       declared_params = route.settings[:declared_params] if route.settings[:declared_params].present?
       required, exposed = route.params.partition { |x| x.first.is_a? String }
-      required.concat GrapeSwagger::DocMethods::Headers.parse(route) unless route.headers.nil?
+      required = GrapeSwagger::DocMethods::Headers.parse(route) + required unless route.headers.nil?
       default_type(required)
       default_type(exposed)
 

--- a/spec/swagger_v2/api_swagger_v2_headers_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_headers_spec.rb
@@ -18,6 +18,9 @@ describe 'headers' do
              },
 
              entity: Entities::UseResponse
+        params do
+          optional :param_x, type: String, desc: 'This is a parameter', documentation: { param_type: 'query' }
+        end
         get '/use_headers' do
           { 'declared_params' => declared(params) }
         end
@@ -37,15 +40,17 @@ describe 'headers' do
   end
 
   specify do
-    expect(subject['paths']['/use_headers']['get']['parameters']).to eql(
-      [
-        { 'in' => 'header',
-          'name' => 'X-Rate-Limit-Limit',
-          'description' => 'The number of allowed requests in the current period',
-          'type' => 'integer',
-          'format' => 'int32',
-          'required' => false }
-      ]
+    parameters = subject['paths']['/use_headers']['get']['parameters']
+    expect(parameters).to include(
+      'in' => 'header',
+      'name' => 'X-Rate-Limit-Limit',
+      'description' => 'The number of allowed requests in the current period',
+      'type' => 'integer',
+      'format' => 'int32',
+      'required' => false
     )
+    expect(parameters.size).to eq(2)
+    expect(parameters.first['in']).to eq('header')
+    expect(parameters.last['in']).to eq('query')
   end
 end


### PR DESCRIPTION
Noticed that the order of the parameters had changed at some point, nowadays the header parameters are added to the end of the parameter array.

That results in possible headers are located at the end of the list in Swagger UI.

What do you think of always having the possible header parameters at the beginning of the list?