### PR TITLE
Fixed find_definitions_and_params to not add :description to definiti…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#450](https://github.com/ruby-grape/grape-swagger/pull/438): Do not add :description to definitions if :description is missing on path - [@texpert](https://github.com/texpert).
 * Your contribution here.
 
 ### 0.21.0 (June 1, 2016)

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -41,7 +41,7 @@ module GrapeSwagger
 
           move_params_to_new(name, params)
 
-          @definitions[name][:description] = path[:description]
+          @definitions[name][:description] = path[:description] if path[:description]
           path[:parameters] << build_body_parameter(response.dup, name)
         end
 

--- a/spec/lib/move_params_spec.rb
+++ b/spec/lib/move_params_spec.rb
@@ -45,8 +45,9 @@ describe GrapeSwagger::DocMethods::MoveParams do
   describe 'find_definition_and_params' do
     specify do
       subject.instance_variable_set(:@definitions, definitions)
-      subject.find_definition_and_params(found_path, :post)
+      subject.find_definition_and_params(found_path[:post], :post)
       expect(definitions.keys).to include 'InBody'
+      expect(definitions['postRequestInBody'].keys).to_not include :description
     end
   end
 


### PR DESCRIPTION
…ons if :description is mising on path.

Spec of move_params updated.