### PR TITLE
Include documented Hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,17 @@
 #### Features
 
 * [#448](https://github.com/ruby-grape/grape-swagger/pull/448): Header parameters are now prepended to the parameter list - [@anakinj](https://github.com/anakinj).
-* [#444](https://github.com/ruby-grape/grape-swagger/pull/444): With multi types parameter the first type is use as the documentation type [@scauglog](https://github.com/scauglog)
+* [#444](https://github.com/ruby-grape/grape-swagger/pull/444): With multi types parameter the first type is use as the documentation type [@scauglog](https://github.com/scauglog).
+* Your contribution here.
 
 #### Fixes
 
 * [#450](https://github.com/ruby-grape/grape-swagger/pull/438): Do not add :description to definitions if :description is missing on path - [@texpert](https://github.com/texpert).
 * [#447](https://github.com/ruby-grape/grape-swagger/pull/447): Version part of the url is now ignored when generating tags for endpoint - [@anakinj](https://github.com/anakinj).
-* [#444](https://github.com/ruby-grape/grape-swagger//pull/444): Default value provided in the documentation hash, override the grape default [@scauglog](https://github.com/scauglog)
-* [#443](https://github.com/ruby-grape/grape-swagger/issues/443): Type provided in the documentation hash, override the grape type [@scauglog](https://github.com/scauglog)
+* [#444](https://github.com/ruby-grape/grape-swagger//pull/444): Default value provided in the documentation hash, override the grape default [@scauglog](https://github.com/scauglog).
+* [#443](https://github.com/ruby-grape/grape-swagger/issues/443): Type provided in the documentation hash, override the grape type [@scauglog](https://github.com/scauglog).
+* [#453](https://github.com/ruby-grape/grape-swagger/pull/453): Include documented Hashes in documentation output - [@aschuster3](https://github.com/aschuster3).
+* Your contribution here.
 
 ### 0.21.0 (June 1, 2016)
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -231,7 +231,7 @@ module Grape
         else
           key = param.first
         end
-        memo[key] = param.last unless param.last[:type] == 'Hash' || param.last[:type] == 'Array' && !param.last.key?(:documentation)
+        memo[key] = param.last unless (param.last[:type] == 'Hash' || param.last[:type] == 'Array') && !param.last.key?(:documentation)
       end
     end
 

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -116,6 +116,11 @@ RSpec.shared_context 'entity swagger example' do
         expose :name, documentation: { type: String, desc: 'The name.' }
         expose :children, using: self, documentation: { type: 'RecursiveModel', is_array: true, desc: 'The child nodes.' }
       end
+
+      class DocumentedHashAndArrayModel < Grape::Entity
+        expose :raw_hash, documentation: { type: Hash, desc: 'Example Hash.' }
+        expose :raw_array, documentation: { type: Array, desc: 'Example Array' }
+      end
     end
   end
 
@@ -124,7 +129,8 @@ RSpec.shared_context 'entity swagger example' do
       'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } } },
       'ResponseItem' => { 'type' => 'object', 'properties' => { 'id' => { 'type' => 'integer', 'format' => 'int32' }, 'name' => { 'type' => 'string' } } },
       'UseResponse' => { 'type' => 'object', 'properties' => { 'description' => { 'type' => 'string' }, '$responses' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/ResponseItem' } } } },
-      'RecursiveModel' => { 'type' => 'object', 'properties' => { 'name' => { 'type' => 'string', 'description' => 'The name.' }, 'children' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/RecursiveModel' }, 'description' => 'The child nodes.' } } }
+      'RecursiveModel' => { 'type' => 'object', 'properties' => { 'name' => { 'type' => 'string', 'description' => 'The name.' }, 'children' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/RecursiveModel' }, 'description' => 'The child nodes.' } } },
+      'DocumentedHashAndArrayModel' => { 'type' => 'object', 'properties' => { 'raw_hash' => { 'type' => 'object', 'description' => 'Example Hash.' }, 'raw_array' => { 'type' => 'array', 'description' => 'Example Array' } } }
     }
   end
 

--- a/spec/support/model_parsers/mock_parser.rb
+++ b/spec/support/model_parsers/mock_parser.rb
@@ -52,6 +52,7 @@ RSpec.shared_context 'mock swagger example' do
       class ApiError < OpenStruct; end
       class SecondApiError < OpenStruct; end
       class RecursiveModel < OpenStruct; end
+      class DocumentedHashAndArrayModel < OpenStruct; end
     end
   end
 
@@ -76,6 +77,15 @@ RSpec.shared_context 'mock swagger example' do
         }
       },
       'UseResponse' => {
+        'type' => 'object',
+        'properties' => {
+          'mock_data' => {
+            'type' => 'string',
+            'description' => "it's a mock"
+          }
+        }
+      },
+      'DocumentedHashAndArrayModel' => {
         'type' => 'object',
         'properties' => {
           'mock_data' => {

--- a/spec/support/model_parsers/representable_parser.rb
+++ b/spec/support/model_parsers/representable_parser.rb
@@ -186,6 +186,13 @@ RSpec.shared_context 'representable swagger example' do
         property :name, documentation: { type: String, desc: 'The name.' }
         property :children, decorator: self, documentation: { type: 'RecursiveModel', is_array: true, desc: 'The child nodes.' }
       end
+
+      class DocumentedHashAndArrayModel < Representable::Decorator
+        include Representable::JSON
+
+        property :raw_hash, documentation: { type: Hash, desc: 'Example Hash.' }
+        property :raw_array, documentation: { type: Array, desc: 'Example Array' }
+      end
     end
   end
 

--- a/spec/swagger_v2/api_swagger_v2_definitions-models_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_definitions-models_spec.rb
@@ -11,7 +11,8 @@ describe 'definitions/models' do
         add_swagger_documentation models: [
           ::Entities::UseResponse,
           ::Entities::ApiError,
-          ::Entities::RecursiveModel
+          ::Entities::RecursiveModel,
+          ::Entities::DocumentedHashAndArrayModel
         ]
       end
     end


### PR DESCRIPTION
This is opened to address Issue #445 

Because of the way the logic is stated, raw Hashes can never be included.  After digging through, I found that the reason this `unless` exists in the first place is because Hashes and Arrays are replaced with their object references (e.g. `"address"=>{"$ref"=>"#/definitions/someDefinition"}` is preferred over `"address"=>{"type"=>"object"}`).