### PR TITLE
Include documented Hashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * [#447](https://github.com/ruby-grape/grape-swagger/pull/447): Version part of the url is now ignored when generating tags for endpoint - [@anakinj](https://github.com/anakinj).
 * [#444](https://github.com/ruby-grape/grape-swagger//pull/444): Default value provided in the documentation hash, override the grape default [@scauglog](https://github.com/scauglog).
 * [#443](https://github.com/ruby-grape/grape-swagger/issues/443): Type provided in the documentation hash, override the grape type [@scauglog](https://github.com/scauglog).
-* [#453](https://github.com/ruby-grape/grape-swagger/pull/453): Include documented Hashes in documentation output - [@aschuster3](https://github.com/aschuster3).
+* [#454](https://github.com/ruby-grape/grape-swagger/pull/453): Include documented Hashes in documentation output - [@aschuster3](https://github.com/aschuster3).
 * Your contribution here.
 
 ### 0.21.0 (June 1, 2016)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,17 @@
 #### Features
 
 * [#448](https://github.com/ruby-grape/grape-swagger/pull/448): Header parameters are now prepended to the parameter list - [@anakinj](https://github.com/anakinj).
-* [#444](https://github.com/ruby-grape/grape-swagger/pull/444): With multi types parameter the first type is use as the documentation type [@scauglog](https://github.com/scauglog)
+* [#444](https://github.com/ruby-grape/grape-swagger/pull/444): With multi types parameter the first type is use as the documentation type [@scauglog](https://github.com/scauglog).
+* Your contribution here.
 
 #### Fixes
 
 * [#450](https://github.com/ruby-grape/grape-swagger/pull/438): Do not add :description to definitions if :description is missing on path - [@texpert](https://github.com/texpert).
 * [#447](https://github.com/ruby-grape/grape-swagger/pull/447): Version part of the url is now ignored when generating tags for endpoint - [@anakinj](https://github.com/anakinj).
-* [#444](https://github.com/ruby-grape/grape-swagger//pull/444): Default value provided in the documentation hash, override the grape default [@scauglog](https://github.com/scauglog)
-* [#443](https://github.com/ruby-grape/grape-swagger/issues/443): Type provided in the documentation hash, override the grape type [@scauglog](https://github.com/scauglog)
+* [#444](https://github.com/ruby-grape/grape-swagger//pull/444): Default value provided in the documentation hash, override the grape default [@scauglog](https://github.com/scauglog).
+* [#443](https://github.com/ruby-grape/grape-swagger/issues/443): Type provided in the documentation hash, override the grape type [@scauglog](https://github.com/scauglog).
+* [#453](https://github.com/ruby-grape/grape-swagger/pull/453): Include documented Hashes in documentation output - [@aschuster3](https://github.com/aschuster3).
+* Your contribution here.
 
 ### 0.21.0 (June 1, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 * [#447](https://github.com/ruby-grape/grape-swagger/pull/447): Version part of the url is now ignored when generating tags for endpoint - [@anakinj](https://github.com/anakinj).
 * [#444](https://github.com/ruby-grape/grape-swagger//pull/444): Default value provided in the documentation hash, override the grape default [@scauglog](https://github.com/scauglog).
 * [#443](https://github.com/ruby-grape/grape-swagger/issues/443): Type provided in the documentation hash, override the grape type [@scauglog](https://github.com/scauglog).
-* [#454](https://github.com/ruby-grape/grape-swagger/pull/453): Include documented Hashes in documentation output - [@aschuster3](https://github.com/aschuster3).
+* [#454](https://github.com/ruby-grape/grape-swagger/pull/454): Include documented Hashes in documentation output - [@aschuster3](https://github.com/aschuster3).
 * Your contribution here.
 
 ### 0.21.0 (June 1, 2016)

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -144,13 +144,11 @@ module GrapeSwagger
         end
 
         def movable?(param)
-          return true if param[:in] == 'body' || param[:in] == 'path'
-          false
+          param[:in] == 'body'
         end
 
         def deletable?(param)
-          return true if movable?(param) && param[:in] == 'body'
-          false
+          param[:in] == 'body'
         end
 
         def should_move?(params)

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -63,7 +63,6 @@ module GrapeSwagger
               end
             end
 
-            properties[name][:readOnly] = true unless deletable?(param)
             params.delete(param) if deletable?(param)
 
             definition[:required] << name if deletable?(param) && param[:required]

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -231,7 +231,7 @@ module Grape
         else
           key = param.first
         end
-        memo[key] = param.last unless param.last[:type] == 'Hash' || param.last[:type] == 'Array' && !param.last.key?(:documentation)
+        memo[key] = param.last unless (param.last[:type] == 'Hash' || param.last[:type] == 'Array') && !param.last.key?(:documentation)
       end
     end
 

--- a/spec/lib/move_params_spec.rb
+++ b/spec/lib/move_params_spec.rb
@@ -184,7 +184,7 @@ describe GrapeSwagger::DocMethods::MoveParams do
     describe 'movable' do
       describe 'path' do
         let(:param) { { in: 'path', name: 'key', description: nil, type: 'integer', format: 'int32', required: true } }
-        it { expect(subject.send(:movable?, param)).to be true }
+        it { expect(subject.send(:movable?, param)).to be false }
       end
 
       describe 'body' do

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -116,6 +116,11 @@ RSpec.shared_context 'entity swagger example' do
         expose :name, documentation: { type: String, desc: 'The name.' }
         expose :children, using: self, documentation: { type: 'RecursiveModel', is_array: true, desc: 'The child nodes.' }
       end
+
+      class DocumentedHashAndArrayModel < Grape::Entity
+        expose :raw_hash, documentation: { type: Hash, desc: 'Example Hash.' }
+        expose :raw_array, documentation: { type: Array, desc: 'Example Array' }
+      end
     end
   end
 
@@ -124,7 +129,8 @@ RSpec.shared_context 'entity swagger example' do
       'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } } },
       'ResponseItem' => { 'type' => 'object', 'properties' => { 'id' => { 'type' => 'integer', 'format' => 'int32' }, 'name' => { 'type' => 'string' } } },
       'UseResponse' => { 'type' => 'object', 'properties' => { 'description' => { 'type' => 'string' }, '$responses' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/ResponseItem' } } } },
-      'RecursiveModel' => { 'type' => 'object', 'properties' => { 'name' => { 'type' => 'string', 'description' => 'The name.' }, 'children' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/RecursiveModel' }, 'description' => 'The child nodes.' } } }
+      'RecursiveModel' => { 'type' => 'object', 'properties' => { 'name' => { 'type' => 'string', 'description' => 'The name.' }, 'children' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/RecursiveModel' }, 'description' => 'The child nodes.' } } },
+      'DocumentedHashAndArrayModel' => { 'type' => 'object', 'properties' => { 'raw_hash' => { 'type' => 'object', 'description' => 'Example Hash.' }, 'raw_array' => { 'type' => 'array', 'description' => 'Example Array' } } }
     }
   end
 

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -118,8 +118,8 @@ RSpec.shared_context 'entity swagger example' do
       end
 
       class DocumentedHashAndArrayModel < Grape::Entity
-        expose :raw_hash, documentation: { type: Hash, desc: 'Example Hash.' }
-        expose :raw_array, documentation: { type: Array, desc: 'Example Array' }
+        expose :raw_hash, documentation: { type: Hash, desc: 'Example Hash.', documentation: { in: 'body' } }
+        expose :raw_array, documentation: { type: Array, desc: 'Example Array', documentation: { in: 'body' } }
       end
     end
   end

--- a/spec/support/model_parsers/mock_parser.rb
+++ b/spec/support/model_parsers/mock_parser.rb
@@ -52,6 +52,7 @@ RSpec.shared_context 'mock swagger example' do
       class ApiError < OpenStruct; end
       class SecondApiError < OpenStruct; end
       class RecursiveModel < OpenStruct; end
+      class DocumentedHashAndArrayModel < OpenStruct; end
     end
   end
 
@@ -76,6 +77,15 @@ RSpec.shared_context 'mock swagger example' do
         }
       },
       'UseResponse' => {
+        'type' => 'object',
+        'properties' => {
+          'mock_data' => {
+            'type' => 'string',
+            'description' => "it's a mock"
+          }
+        }
+      },
+      'DocumentedHashAndArrayModel' => {
         'type' => 'object',
         'properties' => {
           'mock_data' => {

--- a/spec/support/model_parsers/representable_parser.rb
+++ b/spec/support/model_parsers/representable_parser.rb
@@ -186,6 +186,13 @@ RSpec.shared_context 'representable swagger example' do
         property :name, documentation: { type: String, desc: 'The name.' }
         property :children, decorator: self, documentation: { type: 'RecursiveModel', is_array: true, desc: 'The child nodes.' }
       end
+
+      class DocumentedHashAndArrayModel < Representable::Decorator
+        include Representable::JSON
+
+        property :raw_hash, documentation: { type: Hash, desc: 'Example Hash.' }
+        property :raw_array, documentation: { type: Array, desc: 'Example Array' }
+      end
     end
   end
 

--- a/spec/support/the_paths_definitions.rb
+++ b/spec/support/the_paths_definitions.rb
@@ -97,8 +97,7 @@ RSpec.shared_context 'the api paths/defs' do
       properties: {
         in_body_1: { type: 'integer', format: 'int32', description: 'in_body_1' },
         in_body_2: { type: 'string', description: 'in_body_2' },
-        in_body_3: { type: 'string', description: 'in_body_3' },
-        key: { type: 'integer', format: 'int32', readOnly: true }
+        in_body_3: { type: 'string', description: 'in_body_3' }
       },
       required: [:in_body_1]
     }

--- a/spec/swagger_v2/api_swagger_v2_definitions-models_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_definitions-models_spec.rb
@@ -11,7 +11,8 @@ describe 'definitions/models' do
         add_swagger_documentation models: [
           ::Entities::UseResponse,
           ::Entities::ApiError,
-          ::Entities::RecursiveModel
+          ::Entities::RecursiveModel,
+          ::Entities::DocumentedHashAndArrayModel
         ]
       end
     end

--- a/spec/swagger_v2/api_swagger_v2_hash_and_array_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_hash_and_array_spec.rb
@@ -8,7 +8,7 @@ describe 'document hash and array' do
       class TestApi < Grape::API
         format :json
 
-        documentation = ::Entities::DocumentedHashAndArrayModel.try(:documentation)
+        documentation = ::Entities::DocumentedHashAndArrayModel.documentation if ::Entities::DocumentedHashAndArrayModel.respond_to?(:documentation)
 
         desc 'This returns something'
         namespace :arbitrary do

--- a/spec/swagger_v2/api_swagger_v2_hash_and_array_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_hash_and_array_spec.rb
@@ -1,0 +1,60 @@
+require 'spec_helper'
+
+describe 'document hash and array' do
+  include_context "#{MODEL_PARSER} swagger example"
+
+  before :all do
+    module TheApi
+      class TestApi < Grape::API
+        format :json
+
+        documentation = ::Entities::DocumentedHashAndArrayModel.try(:documentation)
+
+        desc 'This returns something'
+        namespace :arbitrary do
+          params do
+            requires :id, type: Integer
+          end
+          route_param :id do
+            desc 'Timeless treasure'
+            params do
+              requires :body, using: documentation unless documentation.nil?
+              requires :raw_hash, type: Hash, documentation: { param_type: 'body' } if documentation.nil?
+              requires :raw_array, type: Array, documentation: { param_type: 'body' } if documentation.nil?
+            end
+            put '/id_and_hash' do
+              {}
+            end
+          end
+        end
+
+        add_swagger_documentation
+      end
+    end
+  end
+
+  def app
+    TheApi::TestApi
+  end
+
+  subject do
+    get '/swagger_doc'
+    JSON.parse(last_response.body)
+  end
+  describe 'generated request definition' do
+    it 'has hash' do
+      expect(subject['definitions'].keys).to include('putArbitraryIdIdAndHash')
+      expect(subject['definitions']['putArbitraryIdIdAndHash']['properties'].keys).to include('raw_hash')
+    end
+
+    it 'has array' do
+      expect(subject['definitions'].keys).to include('putArbitraryIdIdAndHash')
+      expect(subject['definitions']['putArbitraryIdIdAndHash']['properties'].keys).to include('raw_array')
+    end
+
+    it 'does not have the path parameter' do
+      expect(subject['definitions'].keys).to include('putArbitraryIdIdAndHash')
+      expect(subject['definitions']['putArbitraryIdIdAndHash']).to_not include('id')
+    end
+  end
+end

--- a/spec/swagger_v2/api_swagger_v2_param_type_body_nested_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_param_type_body_nested_spec.rb
@@ -137,7 +137,6 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
         'type' => 'object',
         'properties' => {
           'address' => { '$ref' => '#/definitions/putRequestUseNestedWithAddressAddress' },
-          'id' => { 'type' => 'integer', 'format' => 'int32', 'readOnly' => true },
           'name' => { 'type' => 'string', 'description' => 'name' }
         }
       )
@@ -176,7 +175,6 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
         'properties' => {
           'address' => { '$ref' => '#/definitions/putRequestUseNestedWithAddressAddress' },
           'delivery_address' => { '$ref' => '#/definitions/putRequestUseNestedWithAddressDeliveryAddress' },
-          'id' => { 'type' => 'integer', 'format' => 'int32', 'readOnly' => true },
           'name' => { 'type' => 'string', 'description' => 'name' }
         }
       )

--- a/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
@@ -104,7 +104,6 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
         'description' => 'put in body /wo entity',
         'type' => 'object',
         'properties' => {
-          'key' => { 'type' => 'integer', 'format' => 'int32', 'readOnly' => true },
           'in_body_1' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'in_body_1' },
           'in_body_2' => { 'type' => 'string', 'description' => 'in_body_2' },
           'in_body_3' => { 'type' => 'string', 'description' => 'in_body_3' }
@@ -152,7 +151,6 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
         'description' => 'put in body with entity',
         'type' => 'object',
         'properties' => {
-          'id' => { 'type' => 'integer', 'format' => 'int32', 'readOnly' => true },
           'name' => { 'type' => 'string', 'description' => 'name' }
         }
       )


### PR DESCRIPTION
This is opened to address Issue #445 and is a reopen of PR #453 

Because of the way the logic is stated, raw Hashes can never be included. After digging through, I found that the reason this exists in the first place is because Hashes and Arrays are replaced with their object references when possible (e.g. `"address"=>{"$ref"=>"#/definitions/someDefinition"}` is preferred over `"address"=>{"type"=>"object"}`).

Another addition to this PR that was relevant to the original problem is that `readOnly` parameters are included in a request definition generated by the MoveParams class.  [Open API v2 spec says to exclude readOnly parameters in request objects](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#fixed-fields-13) and seeing as the purpose of MoveParams is to generate a helper request definition, I removed the addition of readOnly parameters.  This specifically addresses redundant path parameters in the JSON block.

Because the problems both of these features are closely related, I felt that the scope of this PR encompasses both changes.