### PR TITLE
Allow passing of Array with brackets (eg. Array[String], Array[Integer])

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,7 +28,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 206
+  Max: 209
 
 # Offense count: 10
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 #### Fixes
 
+* [#455](https://github.com/ruby-grape/grape-swagger/pull/455): Passing `Array[<primitive>]` should create json indicating `array` type - [@tyspring](https://github.com/tyspring).
 * [#450](https://github.com/ruby-grape/grape-swagger/pull/438): Do not add :description to definitions if :description is missing on path - [@texpert](https://github.com/texpert).
 * [#447](https://github.com/ruby-grape/grape-swagger/pull/447): Version part of the url is now ignored when generating tags for endpoint - [@anakinj](https://github.com/anakinj).
 * [#444](https://github.com/ruby-grape/grape-swagger//pull/444): Default value provided in the documentation hash, override the grape default [@scauglog](https://github.com/scauglog).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 #### Fixes
 
-* [#455](https://github.com/ruby-grape/grape-swagger/pull/455): Passing `Array[<primitive>]` should create json indicating `array` type - [@tyspring](https://github.com/tyspring).
+* [#455](https://github.com/ruby-grape/grape-swagger/pull/455): Setting `type:` option as `Array[Class]` creates `array` type in JSON - [@tyspring](https://github.com/tyspring).
 * [#450](https://github.com/ruby-grape/grape-swagger/pull/438): Do not add :description to definitions if :description is missing on path - [@texpert](https://github.com/texpert).
 * [#447](https://github.com/ruby-grape/grape-swagger/pull/447): Version part of the url is now ignored when generating tags for endpoint - [@anakinj](https://github.com/anakinj).
 * [#444](https://github.com/ruby-grape/grape-swagger//pull/444): Default value provided in the documentation hash, override the grape default [@scauglog](https://github.com/scauglog).

--- a/README.md
+++ b/README.md
@@ -481,6 +481,30 @@ end
 }
 ```
 
+#### Array type
+
+If you want to pass an array of primitive types, you can do this with the following:
+
+```ruby
+params do
+  requires :action_ids, type: Array[Integer]
+end
+post :act do
+  ...
+end
+```
+
+```json
+{
+  "in": "formData",
+  "name": "action_ids",
+  "type": "array",
+  "items": {
+      "type": "integer"
+  },
+  "required": true
+}
+```
 
 #### Multi types
 

--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ end
 
 #### Array type
 
-If you want to pass an array of primitive types, you can do this with the following:
+Array types are also supported.
 
 ```ruby
 params do

--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -64,7 +64,9 @@ module GrapeSwagger
           if value_type[:is_array]
             if value_type[:documentation].present?
               param_type = value_type[:documentation][:param_type]
-              type = GrapeSwagger::DocMethods::DataType.mapping(value_type[:documentation][:type])
+              if (doc_type = value_type[:documentation][:type])
+                type = GrapeSwagger::DocMethods::DataType.mapping(doc_type)
+              end
             end
             array_items = { 'type' => type || value_type[:data_type] }
 

--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -64,9 +64,8 @@ module GrapeSwagger
           if value_type[:is_array]
             if value_type[:documentation].present?
               param_type = value_type[:documentation][:param_type]
-              if (doc_type = value_type[:documentation][:type])
-                type = GrapeSwagger::DocMethods::DataType.mapping(doc_type)
-              end
+              doc_type = value_type[:documentation][:type]
+              type = GrapeSwagger::DocMethods::DataType.mapping(doc_type) if doc_type
             end
             array_items = { 'type' => type || value_type[:data_type] }
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -237,7 +237,7 @@ module Grape
 
     def param_type_is_array?(param_type)
       return false unless param_type
-      param_type == 'Array' || (param_type[0] == '[' && param_type[-1] == ']' && !param_type.include?(','))
+      param_type == 'Array' || param_type =~ /\[\w+\]\z/
     end
 
     def expose_params_from_model(model)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -222,16 +222,12 @@ module Grape
     end
 
     def parse_request_params(required)
+      array_key = nil
       required.each_with_object({}) do |param, memo|
-        @array_key = param.first.to_s.gsub('[', '[][') if param_type_is_array?(param.last[:type])
-        possible_key = param.first.to_s.gsub('[', '[][')
-        if @array_key && possible_key.start_with?(@array_key)
-          key = possible_key
-          param.last[:is_array] = true
-        else
-          key = param.first
-        end
-        memo[key] = param.last unless (param.last[:type] == 'Hash' || param.last[:type] == 'Array') && !param.last.key?(:documentation)
+        array_key = param.first.to_s if param_type_is_array?(param.last[:type])
+
+        param.last[:is_array] = true if array_key && param.first.start_with?(array_key)
+        memo[param.first] = param.last unless (param.last[:type] == 'Hash' || param.last[:type] == 'Array') && !param.last.key?(:documentation)
       end
     end
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -237,7 +237,11 @@ module Grape
 
     def param_type_is_array?(param_type)
       return false unless param_type
-      param_type == 'Array' || param_type =~ /\[\w+\]\z/
+      return true if param_type == 'Array'
+      param_types = param_type.match(/\[(.*)\]$/)
+      return false unless param_types
+      param_types = param_types[0].split(',') if param_types
+      param_types.size == 1
     end
 
     def expose_params_from_model(model)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -223,7 +223,7 @@ module Grape
 
     def parse_request_params(required)
       required.each_with_object({}) do |param, memo|
-        @array_key = param.first.to_s.gsub('[', '[][') if param.last[:type] == 'Array'
+        @array_key = param.first.to_s.gsub('[', '[][') if param_type_is_array?(param.last[:type])
         possible_key = param.first.to_s.gsub('[', '[][')
         if @array_key && possible_key.start_with?(@array_key)
           key = possible_key
@@ -233,6 +233,11 @@ module Grape
         end
         memo[key] = param.last unless (param.last[:type] == 'Hash' || param.last[:type] == 'Array') && !param.last.key?(:documentation)
       end
+    end
+
+    def param_type_is_array?(param_type)
+      return false unless param_type
+      param_type == 'Array' || (param_type[0] == '[' && param_type[-1] == ']' && !param_type.include?(','))
     end
 
     def expose_params_from_model(model)

--- a/spec/lib/data_type_spec.rb
+++ b/spec/lib/data_type_spec.rb
@@ -65,4 +65,16 @@ describe GrapeSwagger::DocMethods::DataType do
 
     it { expect(subject).to eql 'string' }
   end
+
+  describe '[String]' do
+    let(:value) { { type: '[String]' } }
+
+    it { expect(subject).to eq('string') }
+  end
+
+  describe '[Integer]' do
+    let(:value) { { type: '[Integer]' } }
+
+    it { expect(subject).to eq('integer') }
+  end
 end

--- a/spec/lib/endpoint_spec.rb
+++ b/spec/lib/endpoint_spec.rb
@@ -2,4 +2,17 @@ require 'spec_helper'
 
 describe Grape::Endpoint do
   subject { described_class.new(Grape::Util::InheritableSetting.new, path: '/', method: :get) }
+
+  describe '#param_type_is_array?' do
+    it 'returns true if the value passed represents an array' do
+      expect(subject.send(:param_type_is_array?, 'Array')).to be_truthy
+      expect(subject.send(:param_type_is_array?, '[String]')).to be_truthy
+      expect(subject.send(:param_type_is_array?, 'Array[Integer]')).to be_truthy
+    end
+
+    it 'returns false if the value passed does not represent an array' do
+      expect(subject.send(:param_type_is_array?, 'String')).to be_falsey
+      expect(subject.send(:param_type_is_array?, '[String, Integer]')).to be_falsey
+    end
+  end
 end

--- a/spec/swagger_v2/api_swagger_v2_detail_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_detail_spec.rb
@@ -144,7 +144,7 @@ describe 'details' do
     specify do
       expect(subject['paths']['/use_gfm_rc_detail']['get']).to include('description')
       expect(subject['paths']['/use_gfm_rc_detail']['get']['description']).to eql(
-        "<h1>This returns something</h1>\n\n<p># Burgers in Heaven</p>\n\n<blockquote>\n<p>A burger doesn&#39;t come for free</p>\n</blockquote>\n\n<p>If you want to reserve a burger in heaven, you have to do\nsome crazy stuff on earth.</p>\n<pre class=\"highlight plaintext\"><code>def do_good\nputs 'help people'\nend\n</code></pre>\n<ul>\n<li><em>Will go to Heaven:</em> Probably</li>\n<li><em>Will go to Hell:</em> Probably not</li>\n</ul>"
+        "<h1>This returns something</h1>\n\n<p># Burgers in Heaven</p>\n\n<blockquote>\n<p>A burger doesn&#39;t come for free</p>\n</blockquote>\n\n<p>If you want to reserve a burger in heaven, you have to do\nsome crazy stuff on earth.</p>\n<pre class=\"highlight plaintext\"><code>def do_good\nputs 'help people'\nend\n</code></pre>\n\n<ul>\n<li><em>Will go to Heaven:</em> Probably</li>\n<li><em>Will go to Hell:</em> Probably not</li>\n</ul>"
       )
     end
   end

--- a/spec/swagger_v2/params_array_spec.rb
+++ b/spec/swagger_v2/params_array_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'pry'
 
 describe 'Group Params as Array' do
   def app
@@ -33,6 +34,15 @@ describe 'Group Params as Array' do
       end
 
       post '/array_of_type' do
+        { 'declared_params' => declared(params) }
+      end
+
+      params do
+        requires :array_of_string, type: Array[String]
+        requires :array_of_integer, type: Array[Integer]
+      end
+
+      post '/array_of_type_in_form' do
         { 'declared_params' => declared(params) }
       end
 
@@ -88,6 +98,22 @@ describe 'Group Params as Array' do
         'array_of_integer' => {
           'type' => 'array', 'items' => { 'type' => 'integer' }, 'description' => 'nested array of integers'
         }
+      )
+    end
+  end
+
+  describe 'retrieves the documentation for typed group parameters' do
+    subject do
+      get '/swagger_doc/array_of_type_in_form'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/array_of_type_in_form']['post']['parameters']).to eql(
+        [
+          { 'in' => 'formData', 'name' => 'array_of_string', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true },
+          { 'in' => 'formData', 'name' => 'array_of_integer', 'type' => 'array', 'items' => { 'type' => 'integer' }, 'required' => true }
+        ]
       )
     end
   end

--- a/spec/swagger_v2/params_array_spec.rb
+++ b/spec/swagger_v2/params_array_spec.rb
@@ -1,5 +1,4 @@
 require 'spec_helper'
-require 'pry'
 
 describe 'Group Params as Array' do
   def app

--- a/spec/swagger_v2/params_array_spec.rb
+++ b/spec/swagger_v2/params_array_spec.rb
@@ -27,6 +27,15 @@ describe 'Group Params as Array' do
         { 'declared_params' => declared(params) }
       end
 
+      params do
+        requires :array_of_string, type: Array[String], documentation: { param_type: 'body', desc: 'nested array of strings' }
+        requires :array_of_integer, type: Array[Integer], documentation: { param_type: 'body', desc: 'nested array of integers' }
+      end
+
+      post '/array_of_type' do
+        { 'declared_params' => declared(params) }
+      end
+
       add_swagger_documentation
     end
   end
@@ -61,6 +70,24 @@ describe 'Group Params as Array' do
           { 'in' => 'formData', 'name' => 'typed_group[][email]', 'description' => 'email given', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'string' } },
           { 'in' => 'formData', 'name' => 'typed_group[][others]', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'integer' }, 'enum' => [1, 2, 3] }
         ]
+      )
+    end
+  end
+
+  describe 'retrieves the documentation for parameters that are arrays of primitive types' do
+    subject do
+      get '/swagger_doc/array_of_type'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['definitions']['postArrayOfType']['properties']).to eql(
+        'array_of_string' => {
+          'type' => 'array', 'items' => { 'type' => 'string' }, 'description' => 'nested array of strings'
+        },
+        'array_of_integer' => {
+          'type' => 'array', 'items' => { 'type' => 'integer' }, 'description' => 'nested array of integers'
+        }
       )
     end
   end

--- a/spec/swagger_v2/params_array_spec.rb
+++ b/spec/swagger_v2/params_array_spec.rb
@@ -58,8 +58,8 @@ describe 'Group Params as Array' do
     specify do
       expect(subject['paths']['/groups']['post']['parameters']).to eql(
         [
-          { 'in' => 'formData', 'name' => 'required_group[][required_param_1]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } },
-          { 'in' => 'formData', 'name' => 'required_group[][required_param_2]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } }
+          { 'in' => 'formData', 'name' => 'required_group[required_param_1]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } },
+          { 'in' => 'formData', 'name' => 'required_group[required_param_2]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } }
         ]
       )
     end
@@ -74,10 +74,10 @@ describe 'Group Params as Array' do
     specify do
       expect(subject['paths']['/type_given']['post']['parameters']).to eql(
         [
-          { 'in' => 'formData', 'name' => 'typed_group[][id]', 'description' => 'integer given', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'integer' } },
-          { 'in' => 'formData', 'name' => 'typed_group[][name]', 'description' => 'string given', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } },
-          { 'in' => 'formData', 'name' => 'typed_group[][email]', 'description' => 'email given', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'string' } },
-          { 'in' => 'formData', 'name' => 'typed_group[][others]', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'integer' }, 'enum' => [1, 2, 3] }
+          { 'in' => 'formData', 'name' => 'typed_group[id]', 'description' => 'integer given', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'integer' } },
+          { 'in' => 'formData', 'name' => 'typed_group[name]', 'description' => 'string given', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } },
+          { 'in' => 'formData', 'name' => 'typed_group[email]', 'description' => 'email given', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'string' } },
+          { 'in' => 'formData', 'name' => 'typed_group[others]', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'integer' }, 'enum' => [1, 2, 3] }
         ]
       )
     end

--- a/spec/swagger_v2/params_nested_spec.rb
+++ b/spec/swagger_v2/params_nested_spec.rb
@@ -42,8 +42,8 @@ describe 'nested group params' do
     specify do
       expect(subject['paths']['/nested_array']['post']['parameters']).to eql(
         [
-          { 'in' => 'formData', 'name' => 'a_array[][param_1]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'integer' } },
-          { 'in' => 'formData', 'name' => 'a_array[][b_array][][param_2]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } }
+          { 'in' => 'formData', 'name' => 'a_array[param_1]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'integer' } },
+          { 'in' => 'formData', 'name' => 'a_array[b_array][param_2]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } }
         ]
       )
     end


### PR DESCRIPTION
According to docs in Grape, you can pass a parameter of type array with a nested type, like so:
```ruby
params do
  requires :my_param, type: Array[String], documentation: { param_type: 'body' }
end
```
(See https://github.com/ruby-grape/grape#custom-types-and-coercions section for example).

Before this PR, if you do this, the swagger JSON that is generated looks like this:
```JSON
"my_param": {
    "type": "string",
    "description": "this is my param that is supposed to be an array of strings"
}
```

Now, it looks like this:
```JSON
"my_param": {
    "type": "array",
    "description": "This is my param that is an array of strings",
    "items": {
        "type": "string"
    }
}
```

