### PR TITLE
Support for hiding parameters from documentation

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,7 +28,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 209
+  Max: 216
 
 # Offense count: 10
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 #### Features
 
 * [#448](https://github.com/ruby-grape/grape-swagger/pull/448): Header parameters are now prepended to the parameter list - [@anakinj](https://github.com/anakinj).
-* [#444](https://github.com/ruby-grape/grape-swagger/pull/444): With multi types parameter the first type is use as the documentation type [@scauglog](https://github.com/scauglog).
+* [#444](https://github.com/ruby-grape/grape-swagger/pull/444): With multi types parameter the first type is use as the documentation type - [@scauglog](https://github.com/scauglog).
+* [#463](https://github.com/ruby-grape/grape-swagger/pull/463): Added 'hidden' option for parameter to be exclude from generated documentation - [@anakinj](https://github.com/anakinj).
 * Your contribution here.
 
 #### Fixes

--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,8 @@ else
 end
 
 gem ENV['MODEL_PARSER'] if ENV.key?('MODEL_PARSER')
+
+if RUBY_VERSION < '2.2.2'
+  gem 'rack', '<2.0.0'
+  gem 'activesupport', '<5.0.0'
+end

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ add_swagger_documentation \
 * [Overriding param type](#overriding-param-type)
 * [Overriding type](#overriding-type)
 * [Multi types](#multi-types)
+* [Hiding parameters](#hiding-parameters)
 * [Response documentation](#response)
 
 
@@ -526,6 +527,20 @@ end
   "type": "string",
   "required": true
 }
+```
+
+#### Hiding parameters
+
+Exclude single optional parameter from the documentation
+
+```ruby
+params do
+  optional :one, documentation: { hidden: true }
+  optional :two, documentation: { hidden: -> { true } }
+end
+post :act do
+  ...
+end
 ```
 
 #### Overriding the route summary

--- a/spec/swagger_v2/api_swagger_v2_hide_param_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_hide_param_spec.rb
@@ -1,0 +1,90 @@
+require 'spec_helper'
+
+describe 'hidden flag enables a single endpoint parameter to be excluded from the documentation' do
+  include_context "#{MODEL_PARSER} swagger example"
+  before :all do
+    module TheApi
+      class HideParamsApi < Grape::API
+        namespace :flat_params_endpoint do
+          desc 'This is a endpoint with a flat parameter hierarchy'
+          params do
+            requires :name, type: String, documentation: { desc: 'name' }
+            optional :favourite_color, type: String, documentation: { desc: 'I should not be anywhere', hidden: true }
+            optional :proc_param, type: String, documentation: { desc: 'I should not be anywhere', hidden: -> { true } }
+          end
+
+          post do
+            { 'declared_params' => declared(params) }
+          end
+        end
+
+        namespace :nested_params_endpoint do
+          desc 'This is a endpoint with a nested parameter hierarchy'
+          params do
+            optional :name, type: String, documentation: { desc: 'name' }
+            optional :hidden_attribute, type: Hash do
+              optional :favourite_color, type: String, documentation: { desc: 'I should not be anywhere', hidden: true }
+            end
+
+            optional :attributes, type: Hash do
+              optional :attribute_1, type: String, documentation: { desc: 'Attribute one' }
+              optional :hidden_attribute, type: String, documentation: { desc: 'I should not be anywhere', hidden: true }
+            end
+          end
+
+          post do
+            { 'declared_params' => declared(params) }
+          end
+        end
+
+        namespace :required_param_endpoint do
+          desc 'This endpoint has hidden defined for a required parameter'
+          params do
+            requires :name, type: String, documentation: { desc: 'name', hidden: true }
+          end
+
+          post do
+            { 'declared_params' => declared(params) }
+          end
+        end
+
+        add_swagger_documentation
+      end
+    end
+  end
+
+  let(:app) { TheApi::HideParamsApi }
+
+  describe 'simple flat parameter hierarchy' do
+    subject do
+      get '/swagger_doc/flat_params_endpoint'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/flat_params_endpoint']['post']['parameters'].map { |p| p['name'] }).not_to include('favourite_color', 'proc_param')
+    end
+  end
+
+  describe 'nested parameter hierarchy' do
+    subject do
+      get '/swagger_doc/nested_params_endpoint'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/nested_params_endpoint']['post']['parameters'].map { |p| p['name'] }).not_to include(/hidden_attribute/)
+    end
+  end
+
+  describe 'hidden defined for required parameter' do
+    subject do
+      get '/swagger_doc/required_param_endpoint'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/required_param_endpoint']['post']['parameters'].map { |p| p['name'] }).to include('name')
+    end
+  end
+end


### PR DESCRIPTION
There is a need to be able to hide some experimental/internal parameters from the documentation but still have the possibility to use declared_params to validate that the parameters have been defined for the endpoint.

This kind of solution would allow the definition of parameters but they would be excluded from the swagger documentation.