### PR TITLE
Allow Security Definitions Objects to be defined

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,7 +28,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 219
+  Max: 220
 
 # Offense count: 10
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * [#448](https://github.com/ruby-grape/grape-swagger/pull/448): Header parameters are now prepended to the parameter list - [@anakinj](https://github.com/anakinj).
 * [#444](https://github.com/ruby-grape/grape-swagger/pull/444): With multi types parameter the first type is use as the documentation type - [@scauglog](https://github.com/scauglog).
 * [#463](https://github.com/ruby-grape/grape-swagger/pull/463): Added 'hidden' option for parameter to be exclude from generated documentation - [@anakinj](https://github.com/anakinj).
+* [#471](https://github.com/ruby-grape/grape-swagger/pull/471): Allow Security Definitions Objects to be defined - [@bendodd](https://github.com/bendodd).
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ add_swagger_documentation \
 This value is added to the `authorizations` key in the JSON documentation.
 
 
+#### *security_definitions*:
+This value is added to the `securityDefinitions` key in the JSON documentation.
 
 <a name="models" />
 #### models:

--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ end
 * [add_version](#add_version)
 * [doc_version](#doc_version)
 * [markdown](#markdown)
+* [security_definitions](#security_definitions)
 * [models](#models)
 * [hide_documentation_path](#hide_documentation_path)
 * [info](#info)
@@ -273,13 +274,23 @@ add_swagger_documentation \
   markdown: GrapeSwagger::Markdown::RedcarpetAdapter.new
 ```
 
+<a name="security_definitions" />
+#### security_definitions:
+Specify the [Security Definitions Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#security-definitions-object)
+
+```ruby
+add_swagger_documentation \
+  security_definitions: {
+    api_key: {
+      type: "apiKey",
+      name: "api_key",
+      in: "header"
+    }
+  }
+```
 
 #### *authorizations*:
 This value is added to the `authorizations` key in the JSON documentation.
-
-
-#### *security_definitions*:
-This value is added to the `securityDefinitions` key in the JSON documentation.
 
 <a name="models" />
 #### models:

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -102,6 +102,7 @@ module GrapeSwagger
         hide_documentation_path: true,
         format: :json,
         authorizations: nil,
+        security_definitions: nil,
         api_documentation: { desc: 'Swagger compatible API description' },
         specific_api_documentation: { desc: 'Swagger compatible API description for specific API' }
       }

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -24,6 +24,7 @@ module Grape
         swagger:        '2.0',
         produces:       content_types_for(target_class),
         authorizations: options[:authorizations],
+        securityDefinitions: options[:security_definitions],
         host:           GrapeSwagger::DocMethods::OptionalObject.build(:host, options, request),
         basePath:       GrapeSwagger::DocMethods::OptionalObject.build(:base_path, options, request),
         tags:           GrapeSwagger::DocMethods::TagNameDescription.build(options),

--- a/spec/swagger_v2/api_swagger_v2_global_configuration_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_global_configuration_spec.rb
@@ -46,7 +46,7 @@ describe 'global configuration stuff' do
       expect(subject['paths'].keys.first).to eql '/somewhere/over/the/rainbow/v3/configuration'
       expect(subject['schemes']).to eql ['https']
       expect(subject['securityDefinitions'].keys).to include('api_key')
-      expect(subject['securityDefinitions']['api_key']).to include("foo" => "bar")
+      expect(subject['securityDefinitions']['api_key']).to include('foo' => 'bar')
     end
   end
 end

--- a/spec/swagger_v2/api_swagger_v2_global_configuration_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_global_configuration_spec.rb
@@ -23,7 +23,8 @@ describe 'global configuration stuff' do
                                   base_path: -> { 'somewhere/over/the/rainbow' },
                                   mount_path: 'documentation',
                                   add_base_path: true,
-                                  add_version: true
+                                  add_version: true,
+                                  security_definitions: { api_key: { foo: 'bar' } }
       end
     end
   end
@@ -44,6 +45,8 @@ describe 'global configuration stuff' do
       expect(subject['basePath']).to eql 'somewhere/over/the/rainbow'
       expect(subject['paths'].keys.first).to eql '/somewhere/over/the/rainbow/v3/configuration'
       expect(subject['schemes']).to eql ['https']
+      expect(subject['securityDefinitions'].keys).to include('api_key')
+      expect(subject['securityDefinitions']['api_key']).to include("foo" => "bar")
     end
   end
 end


### PR DESCRIPTION
Add securityDefinitions to allow Swagger UI to authenticate

A basic solution for #432 