### PR TITLE
Fixed move_params_to_new to allow name to be defined as a Symbol

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,7 +28,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 220
+  Max: 222
 
 # Offense count: 10
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#476](https://github.com/ruby-grape/grape-swagger/pull/476): Fixes for handling the parameter type when body parameters are defined inside desc block - [@anakinj](https://github.com/anakinj).
 * Your contribution here.
 
 ### 0.22.0 (July 12, 2016)

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -33,7 +33,7 @@ module GrapeSwagger
         end
 
         def move_params_to_new(definition, params)
-          params, nested_params = params.partition { |x| !x[:name].include?('[') }
+          params, nested_params = params.partition { |x| !x[:name].to_s.include?('[') }
 
           unless params.blank?
             properties, required = build_properties(params)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -231,9 +231,11 @@ module Grape
       array_key = nil
       params.select { |param| public_parameter?(param) }.each_with_object({}) do |param, memo|
         name, options = *param
-        array_key = name.to_s if param_type_is_array?(options[:type])
+        param_type = options[:type]
+        param_type = param_type.to_s unless param_type.nil?
+        array_key = name.to_s if param_type_is_array?(param_type)
         options[:is_array] = true if array_key && name.start_with?(array_key)
-        memo[param.first] = options unless (options[:type] == 'Hash' || options[:type] == 'Array') && !options.key?(:documentation)
+        memo[name] = options unless %w(Hash Array).include?(param_type) && !options.key?(:documentation)
       end
     end
 

--- a/spec/swagger_v2/api_swagger_v2_body_definitions_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_body_definitions_spec.rb
@@ -6,8 +6,14 @@ describe 'body parameter definitions' do
       class Endpoint < Grape::API
         resource :endpoint do
           desc 'The endpoint' do
-            params body_param: { type: String, desc: 'param', required: false, documentation: { in: 'body' } }
+            headers XAuthToken: {
+              description: 'Valdates your identity',
+              required: true
+            }
+            params body_param: { type: 'String', desc: 'param', documentation: { in: 'body' } },
+                   'body_string_param' => { type: String, desc: 'string_param', documentation: { in: 'body' } }
           end
+
           post do
             { 'declared_params' => declared(params) }
           end
@@ -27,10 +33,11 @@ describe 'body parameter definitions' do
     JSON.parse(last_response.body)
   end
 
-  context 'a definition is generated for the endpoints parameters' do
+  context 'a definition is generated for the endpoints parameters defined within the desc block' do
     specify do
       expect(subject['definitions']['postEndpoint']['properties']).to eql(
-        'body_param' => { 'type' => 'string', 'description' => 'param' }
+        'body_param' => { 'type' => 'string', 'description' => 'param' },
+        'body_string_param' => { 'type' => 'string', 'description' => 'string_param' }
       )
     end
   end

--- a/spec/swagger_v2/api_swagger_v2_body_definitions_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_body_definitions_spec.rb
@@ -11,7 +11,7 @@ describe 'body parameter definitions' do
               required: true
             }
             params body_param: { type: 'String', desc: 'param', documentation: { in: 'body' } },
-                   'body_string_param' => { type: String, desc: 'string_param', documentation: { in: 'body' } }
+                   body_type_as_const_param: { type: String, desc: 'string_param', documentation: { in: 'body' } }
           end
 
           post do
@@ -37,7 +37,7 @@ describe 'body parameter definitions' do
     specify do
       expect(subject['definitions']['postEndpoint']['properties']).to eql(
         'body_param' => { 'type' => 'string', 'description' => 'param' },
-        'body_string_param' => { 'type' => 'string', 'description' => 'string_param' }
+        'body_type_as_const_param' => { 'type' => 'string', 'description' => 'string_param' }
       )
     end
   end

--- a/spec/swagger_v2/api_swagger_v2_body_definitions_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_body_definitions_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+describe 'body parameter definitions' do
+  before :all do
+    module TheBodyApi
+      class Endpoint < Grape::API
+        resource :endpoint do
+          desc 'The endpoint' do
+            params body_param: { type: String, desc: 'param', required: false, documentation: { in: 'body' } }
+          end
+          post do
+            { 'declared_params' => declared(params) }
+          end
+        end
+
+        add_swagger_documentation
+      end
+    end
+  end
+
+  def app
+    TheBodyApi::Endpoint
+  end
+
+  subject do
+    get '/swagger_doc'
+    JSON.parse(last_response.body)
+  end
+
+  context 'a definition is generated for the endpoints parameters' do
+    specify do
+      expect(subject['definitions']['postEndpoint']['properties']).to eql(
+        'body_param' => { 'type' => 'string', 'description' => 'param' }
+      )
+    end
+  end
+end


### PR DESCRIPTION
I am trying to use a Entity to describe what is expected inside the request body, while doing this I noticed that when parameters have been defined as body params inside the desc block, grape-swagger causes the app to crash.
