### PR TITLE
Fix regex for Array and Multi Type in doc_methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * [#476](https://github.com/ruby-grape/grape-swagger/pull/476): Fixes for handling the parameter type when body parameters are defined inside desc block - [@anakinj](https://github.com/anakinj).
 * [#478](https://github.com/ruby-grape/grape-swagger/pull/478): Refactors building of properties, corrects documentation of array items - [@LeFnord](https://github.com/LeFnord).
+* [#479](https://github.com/ruby-grape/grape-swagger/pull/479): Fix regex for Array and Multi Type in doc_methods. Parsing of "[APoint]" should return "APoint" - [@frodrigo](https://github.com/frodrigo).
 * Your contribution here.
 
 ### 0.22.0 (July 12, 2016)

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -32,7 +32,7 @@ module GrapeSwagger
         def parse_multi_type(raw_data_type)
           case raw_data_type
           when /\A\[.*\]\z/
-            raw_data_type.gsub(/[(\A\[)(\s+)(\]\z)]/, '').split(',').first
+            raw_data_type.gsub(/[\[\s+\]]/, '').split(',').first
           when Array
             raw_data_type.first
           else

--- a/spec/lib/data_type_spec.rb
+++ b/spec/lib/data_type_spec.rb
@@ -24,6 +24,12 @@ describe GrapeSwagger::DocMethods::DataType do
     it { expect(subject).to eql 'string' }
   end
 
+  describe 'Multi types in a string stating with A' do
+    let(:value) { { type: '[Apple, Orange]' } }
+
+    it { expect(subject).to eql 'Apple' }
+  end
+
   describe 'Multi types in array' do
     let(:value) { { type: [String, Integer] } }
 


### PR DESCRIPTION
Parsing of "[APoint]" should return "APoint"

With current regex it fails:
```
irb(main):001:0> "[APoint]".gsub(/[(\A\[)(\s+)(\]\z)]/, '')
=> "Point"
```
