### PR TITLE
Include headers when body parameters have been defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 #### Fixes
 
+* [#494](https://github.com/ruby-grape/grape-swagger/pull/494): Header parametes are now included in documentation when body parameters have been defined - [@anakinj](https://github.com/anakinj).
 * Your contribution here.
 
 ### 0.23.0 (August 5, 2016)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -222,15 +222,17 @@ module Grape
       declared_params = route.settings[:declared_params] if route.settings[:declared_params].present?
       required, exposed = route.params.partition { |x| x.first.is_a? String }
       required = GrapeSwagger::DocMethods::Headers.parse(route) + required unless route.headers.nil?
+
       default_type(required)
       default_type(exposed)
 
-      unless declared_params.nil? && route.headers.nil?
-        request_params = parse_request_params(required)
-      end
+      request_params = unless declared_params.nil? && route.headers.nil?
+                         parse_request_params(required)
+                       end || {}
 
-      return route.params if route.params.present? && !route.settings[:declared_params].present?
-      request_params || {}
+      request_params = route.params.merge(request_params) if route.params.present? && !route.settings[:declared_params].present?
+
+      request_params
     end
 
     def default_type(params)

--- a/spec/swagger_v2/api_swagger_v2_body_definitions_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_body_definitions_spec.rb
@@ -39,6 +39,8 @@ describe 'body parameter definitions' do
         'body_param' => { 'type' => 'string', 'description' => 'param' },
         'body_type_as_const_param' => { 'type' => 'string', 'description' => 'string_param' }
       )
+
+      expect(subject['paths']['/endpoint']['post']['parameters'].any? { |p| p['name'] == 'XAuthToken' && p['in'] == 'header' }).to eql(true)
     end
   end
 end


### PR DESCRIPTION
Seems that the header parameters is left out from the documentation in some situations, this change will always merge the header parameters to the request parameters.