### PR TITLE
corrects exposing of inline definitions

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,7 +28,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 231
+  Max: 240
 
 # Offense count: 10
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 #### Fixes
 
+* [#503](https://github.com/ruby-grape/grape-swagger/pull/503): Corrects exposing of inline definitions - [@LeFnord](https://github.com/LeFnord).
 * [#494](https://github.com/ruby-grape/grape-swagger/pull/494): Header parametes are now included in documentation when body parameters have been defined - [@anakinj](https://github.com/anakinj).
 * Your contribution here.
 

--- a/Gemfile
+++ b/Gemfile
@@ -18,4 +18,6 @@ end
 
 group :test do
   gem 'ruby-grape-danger', '~> 0.1.0', require: false
+  gem 'grape-entity'
+  gem 'grape-swagger-entity'
 end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -288,7 +288,17 @@ module Grape
     end
 
     def model_name(name)
-      name.respond_to?(:name) ? name.name.demodulize.camelize : name.split('::').last
+      if name.respond_to?(:entity_name)
+        name.entity_name
+      elsif name.to_s.end_with?('Entity', 'Entities')
+        length = 0
+        name.to_s.split('::')[0..-2].reverse.take_while do |x|
+          length += x.length
+          length < 42
+        end.reverse.join
+      else
+        name.name.demodulize.camelize
+      end
     end
 
     def hidden?(route, options)

--- a/spec/issues/430_entity_definitions_spec.rb
+++ b/spec/issues/430_entity_definitions_spec.rb
@@ -1,0 +1,48 @@
+require 'spec_helper'
+require 'grape-entity'
+require 'grape-swagger-entity'
+
+describe 'definition names' do
+  before :all do
+    module TestDefinition
+      module DummyEntities
+        module WithVeryLongName
+          module AnotherGroupingModule
+            class Class1
+              class Entity < Grape::Entity
+                expose :one_thing
+              end
+            end
+
+            class Class2
+              class Entity < Grape::Entity
+                expose :another_thing
+
+                def self.entity_name
+                  'FooKlass'
+                end
+              end
+            end
+          end
+        end
+      end
+
+      class NameApi < Grape::API
+        add_swagger_documentation models: [
+          DummyEntities::WithVeryLongName::AnotherGroupingModule::Class1::Entity,
+          DummyEntities::WithVeryLongName::AnotherGroupingModule::Class2::Entity
+        ]
+      end
+    end
+  end
+
+  let(:app) { TestDefinition::NameApi }
+
+  subject do
+    get '/swagger_doc'
+    JSON.parse(last_response.body)['definitions']
+  end
+
+  specify { expect(subject).to include 'AnotherGroupingModuleClass1' }
+  specify { expect(subject).to include 'FooKlass' }
+end


### PR DESCRIPTION
solves:

- https://github.com/ruby-grape/grape-swagger/pull/503
- https://github.com/ruby-grape/grape-swagger-entity/issues/13