### PR TITLE
Combine namespaces with their mount_path to allow APIs with specified mount_paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * [#503](https://github.com/ruby-grape/grape-swagger/pull/503): Corrects exposing of inline definitions - [@LeFnord](https://github.com/LeFnord).
 * [#494](https://github.com/ruby-grape/grape-swagger/pull/494): Header parametes are now included in documentation when body parameters have been defined - [@anakinj](https://github.com/anakinj).
+* [#505](https://github.com/ruby-grape/grape-swagger/pull/505): Combines namespaces with their mounted paths to allow APIs with specified mount_paths - [@KevinLiddle](https://github.com/KevinLiddle).
 * Your contribution here.
 
 ### 0.23.0 (August 5, 2016)

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -86,7 +86,9 @@ module Grape
                end
           # use the full namespace here (not the latest level only)
           # and strip leading slash
-          @target_class.combined_namespaces[endpoint.namespace.sub(/^\//, '')] = ns if ns
+          mount_path = (endpoint.namespace_stackable(:mount_path) || []).join('/')
+          full_namespace = (mount_path + endpoint.namespace).sub(/\/{2,}/, '/').sub(/^\//, '')
+          @target_class.combined_namespaces[full_namespace] = ns if ns
 
           combine_namespaces(endpoint.options[:app]) if endpoint.options[:app]
         end


### PR DESCRIPTION
I kept getting the following error when I tried to upgrade my grape and grape-swagger libraries:
```
/usr/local/rvm/gems/ruby-2.2.2/gems/grape-swagger-0.20.3/lib/grape-swagger.rb:97:in `block in combine_namespace_routes': undefined method `reject' for nil:NilClass (NoMethodError)
```
which I traced back to how the namespaced routes are collected. The app I'm working on has a bunch of APIs, all mounted with a specified `mount_path`:

```ruby
mount SomeAPI => "/some_api"
```
so this PR should fix the issue of generating proper swagger docs with APIs that have been mounted to a specific route. I think this makes sense, but let me know if I'm mistaken about something here.