### PR TITLE
ISSUE-508 undefined method `reject' for nil:NilClass for combine_namespace_routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 * [#497](https://github.com/ruby-grape/grape-swagger/pull/497): Use ruby-grape-danger in Dangerfile - [@dblock](https://github.com/dblock).
 
 #### Fixes
-
+* [#509](https://github.com/ruby-grape/grape-swagger/pull/509): Making parent-less routes working - [@contributor](https://github.com/mur-wtag).
 * [#503](https://github.com/ruby-grape/grape-swagger/pull/503): Corrects exposing of inline definitions - [@LeFnord](https://github.com/LeFnord).
 * [#494](https://github.com/ruby-grape/grape-swagger/pull/494): Header parametes are now included in documentation when body parameters have been defined - [@anakinj](https://github.com/anakinj).
 * [#505](https://github.com/ruby-grape/grape-swagger/pull/505): Combines namespaces with their mounted paths to allow APIs with specified mount_paths - [@KevinLiddle](https://github.com/KevinLiddle).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 #### Features
 
+* Your contribution here.
+
+#### Fixes
+
+* Your contribution here.
+
+### 0.24.0 (September 23, 2016)
+
+#### Features
+
 * [#504](https://github.com/ruby-grape/grape-swagger/pull/504): Added support for set the 'collectionFormat' of arrays - [@rczjns](https://github.com/rczjns).
 * [#502](https://github.com/ruby-grape/grape-swagger/pull/502): Adds specs for rake tasks - [@LeFnord](https://github.com/LeFnord).
 * [#501](https://github.com/ruby-grape/grape-swagger/pull/501): Adds getting of a specified resource for Rake Tasks - [@LeFnord](https://github.com/LeFnord).
@@ -9,14 +19,12 @@
 * [#493](https://github.com/ruby-grape/grape-swagger/pull/493): Swagger UI endpoint authorization. - [@texpert](https://github.com/texpert).
 * [#492](https://github.com/ruby-grape/grape/pull/492): Define security requirements on endpoint methods - [@tomregelink](https://github.com/tomregelink).
 * [#497](https://github.com/ruby-grape/grape-swagger/pull/497): Use ruby-grape-danger in Dangerfile - [@dblock](https://github.com/dblock).
-* Your contribution here.
 
 #### Fixes
 
 * [#503](https://github.com/ruby-grape/grape-swagger/pull/503): Corrects exposing of inline definitions - [@LeFnord](https://github.com/LeFnord).
 * [#494](https://github.com/ruby-grape/grape-swagger/pull/494): Header parametes are now included in documentation when body parameters have been defined - [@anakinj](https://github.com/anakinj).
 * [#505](https://github.com/ruby-grape/grape-swagger/pull/505): Combines namespaces with their mounted paths to allow APIs with specified mount_paths - [@KevinLiddle](https://github.com/KevinLiddle).
-* Your contribution here.
 
 ### 0.23.0 (August 5, 2016)
 

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -99,6 +99,8 @@ module Grape
         namespaces.each do |name, namespace|
           # get the parent route for the namespace
           parent_route_name = name.match(%r{^/?([^/]*).*$})[1]
+          # If parent is a parameter
+          parent_route_name = name.match(/\/[a-z]+/)[0].delete('/') if parent_route_name.include?(':')
           parent_route = @target_class.combined_routes[parent_route_name]
           # fetch all routes that are within the current namespace
           namespace_routes = parent_route.reject do |route|

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -98,9 +98,7 @@ module Grape
         # iterate over each single namespace
         namespaces.each do |name, namespace|
           # get the parent route for the namespace
-          parent_route_name = name.match(%r{^/?([^/]*).*$})[1]
-          # If parent is a parameter
-          parent_route_name = extract_parent_route(name) if parent_route_name.include?(':')
+          parent_route_name = extract_parent_route(name)
           parent_route = @target_class.combined_routes[parent_route_name]
           # fetch all routes that are within the current namespace
           namespace_routes = parent_route.reject do |route|
@@ -141,6 +139,8 @@ module Grape
       end
 
       def extract_parent_route(name)
+        route_name = name.match(%r{^/?([^/]*).*$})[1]
+        return route_name unless route_name.include? ':'
         name.match(/\/[a-z]+/)[0].delete('/')
       end
 

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -100,7 +100,7 @@ module Grape
           # get the parent route for the namespace
           parent_route_name = name.match(%r{^/?([^/]*).*$})[1]
           # If parent is a parameter
-          parent_route_name = name.match(/\/[a-z]+/)[0].delete('/') if parent_route_name.include?(':')
+          parent_route_name = extract_parent_route(name) if parent_route_name.include?(':')
           parent_route = @target_class.combined_routes[parent_route_name]
           # fetch all routes that are within the current namespace
           namespace_routes = parent_route.reject do |route|
@@ -138,6 +138,10 @@ module Grape
             end
           end
         end
+      end
+
+      def extract_parent_route(name)
+        name.match(/\/[a-z]+/)[0].delete('/')
       end
 
       def sub_routes_from(parent_route, sub_namespaces)

--- a/lib/grape-swagger/version.rb
+++ b/lib/grape-swagger/version.rb
@@ -1,3 +1,3 @@
 module GrapeSwagger
-  VERSION = '0.23.0'.freeze
+  VERSION = '0.24.0'.freeze
 end

--- a/spec/support/namespace_tags.rb
+++ b/spec/support/namespace_tags.rb
@@ -66,6 +66,23 @@ RSpec.shared_context 'namespace example' do
           end
         end
       end
+
+      class ParentLessNamespaceApi < Grape::API
+        route_param :animal do
+          route_param :breed do
+            resource :queues do
+              route_param :queue_id do
+                resource :reservations do
+                  desc 'Lists all reservations specific type of animal of specific breed in specific queue'
+                  get do
+                    { bla: 'Bla Black' }
+                  end
+                end
+              end
+            end
+          end
+        end
+      end
     end
   end
 end

--- a/spec/swagger_v2/parent_less_namespace.rb
+++ b/spec/swagger_v2/parent_less_namespace.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe 'a parent less namespace' do
+  include_context 'namespace example'
+
+  before :all do
+    class ParentLessApi < Grape::API
+      prefix :api
+      mount TheApi::ParentLessNamespaceApi
+      add_swagger_documentation version: 'v1'
+    end
+  end
+
+  def app
+    ParentLessApi
+  end
+
+  describe 'retrieves swagger-documentation on /swagger_doc' do
+    subject do
+      get '/api/swagger_doc.json'
+      JSON.parse(last_response.body)
+    end
+
+    context 'not raises error' do
+      specify do
+        expect(subject['tags']).to eql(
+                                     [
+                                       { 'name' => 'queues', 'description' => 'Operations about queues' }
+                                     ]
+                                   )
+
+        expect(subject['paths']['/api/{animal}/{breed}/queues/{queue_id}/reservations']['get']['operationId']).
+          to eql('getApiAnimalBreedQueuesQueueIdReservations')
+      end
+    end
+
+    context 'raises error' do
+      # If /lib/grape-swagger.rb:103 doesn't exist, it's raises
+      # NoMethodError:
+      #  undefined method `reject' for nil:NilClass
+    end
+  end
+end
+

--- a/spec/swagger_v2/parent_less_namespace.rb
+++ b/spec/swagger_v2/parent_less_namespace.rb
@@ -23,14 +23,9 @@ describe 'a parent less namespace' do
 
     context 'not raises error' do
       specify do
-        expect(subject['tags']).to eql(
-                                     [
-                                       { 'name' => 'queues', 'description' => 'Operations about queues' }
-                                     ]
-                                   )
-
-        expect(subject['paths']['/api/{animal}/{breed}/queues/{queue_id}/reservations']['get']['operationId']).
-          to eql('getApiAnimalBreedQueuesQueueIdReservations')
+        expect(subject['tags']).to eql([{ 'name' => 'queues', 'description' => 'Operations about queues' }])
+        expect(subject['paths']['/api/{animal}/{breed}/queues/{queue_id}/reservations']['get']['operationId'])
+          .to eql('getApiAnimalBreedQueuesQueueIdReservations')
       end
     end
 
@@ -41,4 +36,3 @@ describe 'a parent less namespace' do
     end
   end
 end
-

--- a/spec/swagger_v2/parent_less_namespace.rb
+++ b/spec/swagger_v2/parent_less_namespace.rb
@@ -16,6 +16,7 @@ describe 'a parent less namespace' do
   end
 
   describe 'retrieves swagger-documentation on /swagger_doc' do
+    let(:route_name) { ':animal/:breed/queues/:queue_id/reservations' }
     subject do
       get '/api/swagger_doc.json'
       JSON.parse(last_response.body)
@@ -30,9 +31,17 @@ describe 'a parent less namespace' do
     end
 
     context 'raises error' do
-      # If /lib/grape-swagger.rb:103 doesn't exist, it's raises
-      # NoMethodError:
-      #  undefined method `reject' for nil:NilClass
+      specify do
+        allow_any_instance_of(ParentLessApi).
+          to receive(:extract_parent_route).with(route_name).and_return(':animal') # BUT IT'S NOT STUBBING, CAUSE IT'S A PRIVATE METHODS
+        expect { subject }.to raise_error NoMethodError
+      end
+    end
+
+    context 'ParentLessApi.extract_parent_route' do
+      specify do
+        expect(ParentLessApi.send(:extract_parent_route, route_name)).to eq('queues')
+      end
     end
   end
 end


### PR DESCRIPTION
[ISSUE-508](https://github.com/ruby-grape/grape-swagger/issues/508)
