### PR TITLE
Use 'token_owner' instead of 'oauth_token' on Swagger UI endpoint aut…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#510](https://github.com/ruby-grape/grape-swagger/pull/510): Use 'token_owner' instead of 'oauth_token' on Swagger UI endpoint authorization. - [@texpert](https://github.com/texpert).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -97,7 +97,7 @@ module GrapeSwagger
         specific_api_documentation: { desc: 'Swagger compatible API description for specific API' },
         endpoint_auth_wrapper: nil,
         swagger_endpoint_guard: nil,
-        oauth_token: nil
+        token_owner: nil
       }
     end
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -304,7 +304,7 @@ module Grape
     def hidden?(route, options)
       route_hidden = route.options[:hidden]
       return route_hidden unless route_hidden.is_a?(Proc)
-      options[:oauth_token] ? route_hidden.call(send(options[:oauth_token].to_sym)) : route_hidden.call
+      options[:token_owner] ? route_hidden.call(send(options[:token_owner].to_sym)) : route_hidden.call
     end
 
     def public_parameter?(param)

--- a/spec/swagger_v2/guarded_endpoint_spec.rb
+++ b/spec/swagger_v2/guarded_endpoint_spec.rb
@@ -21,6 +21,10 @@ class SampleAuth < Grape::Middleware::Base
     def access_token=(token)
       @_access_token = token
     end
+
+    def resource_owner
+      @resource_owner = true if access_token == '12345'
+    end
   end
 
   def context
@@ -50,9 +54,9 @@ end
 describe 'a guarded api endpoint' do
   before :all do
     class GuardedMountedApi < Grape::API
-      access_token_valid = proc { |token = nil| token.nil? || token != '12345' }
+      resource_owner_valid = proc { |token_owner = nil| token_owner.nil? }
 
-      desc 'Show endpoint if authenticated', hidden: access_token_valid
+      desc 'Show endpoint if authenticated', hidden: resource_owner_valid
       get '/auth' do
         { foo: 'bar' }
       end
@@ -62,7 +66,7 @@ describe 'a guarded api endpoint' do
       mount GuardedMountedApi
       add_swagger_documentation endpoint_auth_wrapper: SampleAuth,
                                 swagger_endpoint_guard: 'sample_auth false',
-                                oauth_token: 'access_token'
+                                token_owner: 'resource_owner'
     end
   end
 


### PR DESCRIPTION
…horization.

Typically the authorization middleware is making available the 'resource_owner' in the endpoint context. so better to use it instead of 'oauth_token' - it will save a request to the DB.