### PR TITLE
Fix incorrect data type linking for request params of entity types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@ doc
 # bundler
 .bundle
 
+#IDEA temp files
+.idea
+
 # jeweler generated
 pkg
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Fixes
 
 * [#515](https://github.com/ruby-grape/grape-swagger/pull/515): Removes limit on model names - [@LeFnord](https://github.com/LeFnord).
+* [#511](https://github.com/ruby-grape/grape-swagger/pull/511): Fix incorrect data type linking for request params of entity types - [@serggl](https://github.com/serggl).
 * Your contribution here.
 
 ### 0.24.0 (September 23, 2016)

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -41,13 +41,14 @@ module GrapeSwagger
         end
 
         def parse_entity_name(model)
-          if model.respond_to?(:entity_name)
+          if model.methods(false).include?(:entity_name)
             model.entity_name
+          elsif model.to_s.end_with?('::Entity', '::Entities')
+            model.to_s.split('::')[-2]
+          elsif model.respond_to?(:name)
+            model.name.demodulize.camelize
           else
-            name = model.to_s
-            entity_parts = name.split('::')
-            entity_parts.reject! { |p| p == 'Entity' || p == 'Entities' }
-            entity_parts.join('::')
+            model.to_s.split('::').last
           end
         end
 

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -74,7 +74,15 @@ module GrapeSwagger
         end
 
         def document_as_property(param)
-          property_keys.each_with_object({}) { |x, memo| memo[x] = param[x] if param[x].present? }
+          property_keys.each_with_object({}) do |x, memo|
+            value = param[x]
+            next if value.blank?
+            if x == :type && @definitions[value].present?
+              memo['$ref'] = "#/definitions/#{value}"
+            else
+              memo[x] = value
+            end
+          end
         end
 
         def build_nested_properties(params, properties = {})

--- a/lib/grape-swagger/model_parsers.rb
+++ b/lib/grape-swagger/model_parsers.rb
@@ -29,5 +29,12 @@ module GrapeSwagger
         yield klass, ancestor
       end
     end
+
+    def find(model)
+      GrapeSwagger.model_parsers.each do |klass, ancestor|
+        return klass if model.ancestors.map(&:to_s).include?(ancestor)
+      end
+      nil
+    end
   end
 end

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -57,6 +57,13 @@ RSpec.shared_context 'entity swagger example' do
         expose :message, documentation: { type: String, desc: 'error message' }
       end
 
+      module NestedModule
+        class ApiResponse < Grape::Entity
+          expose :status, documentation: { type: String }
+          expose :error, documentation: { type: ::Entities::ApiError }
+        end
+      end
+
       class SecondApiError < Grape::Entity
         expose :code, documentation: { type: Integer }
         expose :severity, documentation: { type: String }

--- a/spec/support/model_parsers/mock_parser.rb
+++ b/spec/support/model_parsers/mock_parser.rb
@@ -53,6 +53,9 @@ RSpec.shared_context 'mock swagger example' do
       class SecondApiError < OpenStruct; end
       class RecursiveModel < OpenStruct; end
       class DocumentedHashAndArrayModel < OpenStruct; end
+      module NestedModule
+        class ApiResponse < OpenStruct; end
+      end
     end
   end
 

--- a/spec/support/model_parsers/representable_parser.rb
+++ b/spec/support/model_parsers/representable_parser.rb
@@ -91,6 +91,15 @@ RSpec.shared_context 'representable swagger example' do
         property :message, documentation: { type: String, desc: 'error message' }
       end
 
+      module NestedModule
+        class ApiResponse < Representable::Decorator
+          include Representable::JSON
+
+          property :status, documentation: { type: String }
+          property :error, documentation: { type: ::Entities::ApiError }
+        end
+      end
+
       class SecondApiError < Representable::Decorator
         include Representable::JSON
 
@@ -236,7 +245,7 @@ RSpec.shared_context 'representable swagger example' do
       'prop_file' => { 'description' => 'prop_file description', 'type' => 'file' },
       'prop_float' => { 'description' => 'prop_float description', 'type' => 'number', 'format' => 'float' },
       'prop_integer' => { 'description' => 'prop_integer description', 'type' => 'integer', 'format' => 'int32' },
-      'prop_json' => { 'description' => 'prop_json description', 'type' => 'Representable::JSON' },
+      'prop_json' => { 'description' => 'prop_json description', 'type' => 'JSON' },
       'prop_long' => { 'description' => 'prop_long description', 'type' => 'integer', 'format' => 'int64' },
       'prop_password' => { 'description' => 'prop_password description', 'type' => 'string', 'format' => 'password' },
       'prop_string' => { 'description' => 'prop_string description', 'type' => 'string' },

--- a/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
@@ -54,6 +54,17 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
           end
         end
 
+        namespace :with_entity_param do
+          desc 'put in body with entity parameter'
+          params do
+            optional :data, type: ::Entities::NestedModule::ApiResponse, documentation: { desc: 'request data' }
+          end
+
+          post do
+            { 'declared_params' => declared(params) }
+          end
+        end
+
         add_swagger_documentation
       end
     end
@@ -154,6 +165,51 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
         },
         'description' => 'put in body with entity'
       )
+    end
+  end
+
+  describe 'complex entity given' do
+    let(:request_parameters_definition) do
+      [
+        {
+          'name' => 'WithEntityParam',
+          'in' => 'body',
+          'required' => true,
+          'schema' => {
+            '$ref' => '#/definitions/postWithEntityParam'
+          }
+        }
+      ]
+    end
+
+    let(:request_body_parameters_definition) do
+      {
+        'type' => 'object',
+        'properties' => {
+          'data' => {
+            '$ref' => '#/definitions/ApiResponse',
+            'description' => 'request data'
+          }
+        },
+        'description' => 'put in body with entity parameter'
+      }
+    end
+
+    subject do
+      get '/swagger_doc/with_entity_param'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/with_entity_param']['post']['parameters']).to eql(request_parameters_definition)
+    end
+
+    specify do
+      expect(subject['definitions']['ApiResponse']).not_to be_nil
+    end
+
+    specify do
+      expect(subject['definitions']['postWithEntityParam']).to eql(request_body_parameters_definition)
     end
   end
 end

--- a/spec/swagger_v2/params_array_spec.rb
+++ b/spec/swagger_v2/params_array_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 describe 'Group Params as Array' do
+  include_context "#{MODEL_PARSER} swagger example"
+
   def app
     Class.new(Grape::API) do
       format :json
@@ -54,6 +56,14 @@ describe 'Group Params as Array' do
       end
 
       post '/array_of_type_in_form' do
+        { 'declared_params' => declared(params) }
+      end
+
+      params do
+        requires :array_of_entities, type: Array[Entities::ApiError]
+      end
+
+      post '/array_of_entities' do
         { 'declared_params' => declared(params) }
       end
 
@@ -154,6 +164,32 @@ describe 'Group Params as Array' do
           { 'in' => 'formData', 'name' => 'array_of_integer', 'type' => 'array', 'items' => { 'type' => 'integer', 'format' => 'int32' }, 'required' => true }
         ]
       )
+    end
+  end
+
+  describe 'documentation for entity array parameters' do
+    let(:parameters) do
+      [
+        {
+          'in' => 'formData',
+          'name' => 'array_of_entities',
+          'type' => 'array',
+          'items' => {
+            '$ref' => '#/definitions/ApiError'
+          },
+          'required' => true
+        }
+      ]
+    end
+
+    subject do
+      get '/swagger_doc/array_of_entities'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['definitions']['ApiError']).not_to be_blank
+      expect(subject['paths']['/array_of_entities']['post']['parameters']).to eql(parameters)
     end
   end
 end


### PR DESCRIPTION
This is a fix for #507.

Few moments were changed:
1) Refactored to use a single method for parsing entity names (see recent comments to #503)
2) Custom parameter types are now parsed when parameter objects are parsed. This is new.  Previously all custom types were parsed at a later steps. Not sure if we need a `models` option in `add_swagger_documentation` method from now on, since it looks mostly like a workaround
3) changed links to custom types from `"type": "TypeA"` to `"$ref": "#/definitions/TypeA"`