### PR TITLE
Update README with 'Swagger-UI is supporting only implicit workflow yet.'

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,8 @@ add_swagger_documentation \
 #### security_definitions:
 Specify the [Security Definitions Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#security-definitions-object)
 
+_NOTE: [Swagger-UI is supporting only implicit flow yet](https://github.com/swagger-api/swagger-ui/issues/2406#issuecomment-248651879)_ 
+
 ```ruby
 add_swagger_documentation \
   security_definitions: {


### PR DESCRIPTION
Could have saved me some time to find why the HTTP_AUTHORIZATION header is missing from the request when tried to add security scopes to the endpoint' action description :)
