### PR TITLE
UUID data_type format support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#531](https://github.com/ruby-grape/grape-swagger/pull/531): UUID data_type format support - [@migmartri](https://github.com/migmartri).
 * [#534](https://github.com/ruby-grape/grape-swagger/pull/534): Allows to overwrite defaults status codes - [@LeFnord](https://github.com/LeFnord).
 * Your contribution here.
 

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -83,7 +83,8 @@ module GrapeSwagger
         'dateTime' => %w(string date-time),
         'binary' => %w(string binary),
         'password' => %w(string password),
-        'email' => %w(string email)
+        'email' => %w(string email),
+        'uuid' => %w(string uuid)
       }.freeze
     end
   end


### PR DESCRIPTION
Hi!

In the [Swagger spec](http://swagger.io/specification/#dataTypeFormat), uuid is mentioned next to email as a custom format. So I have added support for it.

In any case, have you guys thought about allowing the format customization via `documentation[:format]?`, i.e  `documentation: { type: 'string', format: 'uuid' }`? so hardcoding formats is not needed anymore?

Currently the method `document_type_and_format` seems to to ignore the format for non primitive types.

Thanks!
Miguel