### PR TITLE
Fix mounting APIs in route_param namespaces

### DIFF
--- a/lib/grape-swagger/doc_methods/tag_name_description.rb
+++ b/lib/grape-swagger/doc_methods/tag_name_description.rb
@@ -4,7 +4,9 @@ module GrapeSwagger
       class << self
         def build(paths)
           paths.values.each_with_object([]) do |path, memo|
-            path.values.first[:tags].each do |tag|
+            tags = path.values.first[:tags]
+            next if tags.nil?
+            tags.each do |tag|
               memo << {
                 name: tag,
                 description: "Operations about #{tag.pluralize}"


### PR DESCRIPTION
This hopefully closes [#267](https://github.com/ruby-grape/grape-swagger/issues/267),
which describes a scenario like:

    route_param :vendor do
      mount Endpoints::Events
    end

The fix is very barebone but resolved the issue for me. Please note that I don't have any idea what I'm doing :wink: Both Grape itself as well as the Swagger integration are very complex and the only thing I did was to look at exceptions and fix the incoming data in a way that would make them go away and finally generate some documentation :laughing:

Everything looks like it's supposed to look but there may be other scenarios that are failing now. So feel free to suggest improvements or add amendments as necessary.