### PR TITLE
Development deps in Gemfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: ruby
 
 sudo: false
+before_install:
+  - gem install bundler
 
 matrix:
   include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,7 @@
 
 #### Fixes
 
-* Your contribution here.
-
+* [#546](https://github.com/ruby-grape/grape-swagger/pull/546): Move development dependencies to Gemfile - [@olleolleolle](https://github.com/olleolleolle).
 
 ### 0.25.2 (November 30, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,6 @@
 #### Fixes
 
 * [#546](https://github.com/ruby-grape/grape-swagger/pull/546): Move development dependencies to Gemfile - [@olleolleolle](https://github.com/olleolleolle).
-* Your contribution here. 
 
 ### 0.25.2 (November 30, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 #### Fixes
 
-* Your contribution here. 
 * [#546](https://github.com/ruby-grape/grape-swagger/pull/546): Move development dependencies to Gemfile - [@olleolleolle](https://github.com/olleolleolle).
+* Your contribution here. 
 
 ### 0.25.2 (November 30, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* Your contribution here. 
 * [#546](https://github.com/ruby-grape/grape-swagger/pull/546): Move development dependencies to Gemfile - [@olleolleolle](https://github.com/olleolleolle).
 
 ### 0.25.2 (November 30, 2016)

--- a/Gemfile
+++ b/Gemfile
@@ -1,23 +1,36 @@
 source 'http://rubygems.org'
 
+ruby RUBY_VERSION
+
 gemspec
 
-case version = ENV['GRAPE_VERSION'] || '~> 0.18'
-when 'HEAD'
-  gem 'grape', github: 'ruby-grape/grape'
-else
-  gem 'grape', version
-end
+gem 'grape', case version = ENV['GRAPE_VERSION'] || '~> 0.18'
+             when 'HEAD'
+               { github: 'ruby-grape/grape' }
+             else
+               version
+             end
 
 gem ENV['MODEL_PARSER'] if ENV.key?('MODEL_PARSER')
 
-if RUBY_VERSION < '2.2.2'
-  gem 'rack', '<2.0.0'
-  gem 'activesupport', '<5.0.0'
+group :development, :test do
+  gem 'bundler'
+  gem 'kramdown'
+  gem 'pry', platforms: [:mri]
+  gem 'pry-byebug', platforms: [:mri]
+  gem 'rack'
+  gem 'rack-cors'
+  gem 'rack-test'
+  gem 'rake'
+  gem 'rdoc'
+  gem 'redcarpet', platforms: [:mri]
+  gem 'rouge', platforms: [:mri]
+  gem 'rspec', '~> 3.0'
+  gem 'rubocop', '~> 0.40'
+  gem 'shoulda'
 end
-
 group :test do
-  gem 'ruby-grape-danger', '~> 0.1.0', require: false
   gem 'grape-entity'
   gem 'grape-swagger-entity'
+  gem 'ruby-grape-danger', '~> 0.1.0', require: false
 end

--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -13,20 +13,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'grape', '>= 0.12.0'
 
-  s.add_development_dependency 'rake'
-  s.add_development_dependency 'shoulda'
-  s.add_development_dependency 'rdoc'
-  s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'bundler'
-  s.add_development_dependency 'rack-test'
-  s.add_development_dependency 'rack-cors'
-  s.add_development_dependency 'rubocop', '~> 0.40'
-  s.add_development_dependency 'kramdown'
-  s.add_development_dependency 'redcarpet' unless RUBY_PLATFORM.eql?('java') || RUBY_ENGINE.eql?('rbx')
-  s.add_development_dependency 'rouge' unless RUBY_PLATFORM.eql?('java') || RUBY_ENGINE.eql?('rbx')
-  s.add_development_dependency 'pry' unless RUBY_PLATFORM.eql?('java') || RUBY_ENGINE.eql?('rbx')
-  s.add_development_dependency 'pry-byebug' unless RUBY_PLATFORM.eql?('java') || RUBY_ENGINE.eql?('rbx')
-
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec}/*`.split("\n")
   s.require_paths = ['lib']


### PR DESCRIPTION
This PR moves the development dependencies to the Gemfile.

- move development dependencies to Gemfile (where there's `platforms` annotation support and `ruby` version identification - upcoming versions of Bundler will not need this last annotation)
- update the Bundler version to latest, in Travis build step `before_install`, so that the smarts keep working
- made Gemfile Rubocop-compliant
