### PR TITLE
Parameters delimited by dash cause exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * [#580](https://github.com/ruby-grape/grape-swagger/pull/580): Issue #578: fixes duplicated path params - [@LeFnord](https://github.com/LeFnord).
 * [#585](https://github.com/ruby-grape/grape-swagger/pull/585): Issue #584: do not mutate route.path - [@LeFnord](https://github.com/LeFnord).
+* [#586](https://github.com/ruby-grape/grape-swagger/pull/586): Issue #587: Parameters delimited by dash cause exception - [@risa](https://github.com/risa).
 
 * Your contribution here.
 

--- a/lib/grape-swagger/doc_methods/operation_id.rb
+++ b/lib/grape-swagger/doc_methods/operation_id.rb
@@ -18,7 +18,7 @@ module GrapeSwagger
 
         def manipulate(path)
           operation = path.split('/').map(&:capitalize).join
-          operation.gsub!(/\-(\w)/, &:upcase).delete!('-') if operation.include?('-')
+          operation.gsub!(/\-(\w)/, &:upcase).delete!('-') if operation[/\-(\w)/]
           operation.gsub!(/\_(\w)/, &:upcase).delete!('_') if operation.include?('_')
           operation.gsub!(/\.(\w)/, &:upcase).delete!('.') if operation.include?('.')
           if path.include?('{')

--- a/spec/issues/587_range_parameter_delimited_by_dash_spec.rb
+++ b/spec/issues/587_range_parameter_delimited_by_dash_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe '#XXX nested entity given as string' do
+describe '#587 process route with parameters delimited by dash' do
   let(:app) do
     Class.new(Grape::API) do
       namespace :range_parameter do
@@ -16,9 +16,9 @@ describe '#XXX nested entity given as string' do
 
   subject do
     get '/swagger_doc'
-    result = JSON.parse(last_response.body)['paths']
-    result
+    JSON.parse(last_response.body)['paths']
   end
 
   specify { expect(subject.keys).to include '/range_parameter/range/{range_start}-{range_end}' }
+  specify { expect(subject['/range_parameter/range/{range_start}-{range_end}']['get']['operationId']).to eql 'getRangeParameterRangeRangeStart-RangeEnd' }
 end

--- a/spec/issues/range_parameter_delimited_by_dash_spec.rb
+++ b/spec/issues/range_parameter_delimited_by_dash_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+describe '#XXX nested entity given as string' do
+  let(:app) do
+    Class.new(Grape::API) do
+      namespace :range_parameter do
+
+        desc 'Get a array with range'
+        get '/range/:range_start-:range_end' do
+          present []
+        end
+      end
+
+      add_swagger_documentation format: :json
+    end
+  end
+
+  subject do
+    get '/swagger_doc'
+    result = JSON.parse(last_response.body)['paths']
+    result
+  end
+
+  specify { expect(subject.keys).to include '/range_parameter/range/{range_start}-{range_end}' }
+end

--- a/spec/issues/range_parameter_delimited_by_dash_spec.rb
+++ b/spec/issues/range_parameter_delimited_by_dash_spec.rb
@@ -4,7 +4,6 @@ describe '#XXX nested entity given as string' do
   let(:app) do
     Class.new(Grape::API) do
       namespace :range_parameter do
-
         desc 'Get a array with range'
         get '/range/:range_start-:range_end' do
           present []


### PR DESCRIPTION
In our project we are using api calls to return a range from array, like this:

`get '/range/:range_start-:range_end'`

Currently this causes 
`NoMethodError: undefined method `delete!' for nil:NilClass
./lib/grape-swagger/doc_methods/operation_id.rb:22:in `manipulate'`

See the spec below for demostration. 

The problem is caused by difference between regexp `/\-(\w)/` and include?('-'). The path gets translated to operation: "Range_parameterRange{range_start}-{range_end}". The include?('-') matches the string but the regexp does not. And per specs the gsub! returns [nil if no substitutions were made](http://ruby-doc.org/core-2.4.0/String.html#method-i-gsub-21) (not the least surprise principle for me). 

We are using only dash, possibly underscore can be offending as well, but as a first attempt I suggest only dash. 

Suggestions and feedback welcome. Thanks. 
