### PR TITLE
Allow Security Object to be defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Your contribution here.
 
+* [#602](https://github.com/ruby-grape/grape-swagger/pull/602): Allow security object to be defined - [@markevich](https://github.com/markevich).
+
 #### Fixes
 
 * Your contribution here.

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ end
 * [swagger_endpoint_guard](#swagger_endpoint_guard)
 * [token_owner](#token_owner)
 * [security_definitions](#security_definitions)
+* [security](#security)
 * [models](#models)
 * [tags](#tags)
 * [hide_documentation_path](#hide_documentation_path)
@@ -309,6 +310,18 @@ add_swagger_documentation \
       in: "header"
     }
   }
+```
+
+#### security: <a name="security" />
+Specify the [Security Object](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#securityRequirementObject)
+
+```ruby
+add_swagger_documentation \
+  security: [
+    {
+      api_key: []
+    }
+  ]
 ```
 
 

--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -99,6 +99,7 @@ module GrapeSwagger
         format: :json,
         authorizations: nil,
         security_definitions: nil,
+        security: nil,
         api_documentation: { desc: 'Swagger compatible API description' },
         specific_api_documentation: { desc: 'Swagger compatible API description for specific API' },
         endpoint_auth_wrapper: nil,

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -29,6 +29,7 @@ module Grape
         produces:       content_types_for(target_class),
         authorizations: options[:authorizations],
         securityDefinitions: options[:security_definitions],
+        security: options[:security],
         host:           GrapeSwagger::DocMethods::OptionalObject.build(:host, options, request),
         basePath:       GrapeSwagger::DocMethods::OptionalObject.build(:base_path, options, request),
         schemes:        options[:schemes].is_a?(String) ? [options[:schemes]] : options[:schemes]

--- a/spec/swagger_v2/api_swagger_v2_global_configuration_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_global_configuration_spec.rb
@@ -26,7 +26,8 @@ describe 'global configuration stuff' do
                                   mount_path: 'documentation',
                                   add_base_path: true,
                                   add_version: true,
-                                  security_definitions: { api_key: { foo: 'bar' } }
+                                  security_definitions: { api_key: { foo: 'bar' } },
+                                  security: [{ api_key: [] }]
       end
     end
   end
@@ -49,6 +50,7 @@ describe 'global configuration stuff' do
       expect(subject['schemes']).to eql ['https']
       expect(subject['securityDefinitions'].keys).to include('api_key')
       expect(subject['securityDefinitions']['api_key']).to include('foo' => 'bar')
+      expect(subject['security']).to include('api_key' => [])
     end
   end
 end


### PR DESCRIPTION
Hi!
It's relates to #471 
We can describe ```securityDefinition```, but it is only the definition :) We need to define second object ```security``` to make swagger add authorization key to every request.