### PR TITLE
Allow body parameter name to be specified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#607](https://github.com/ruby-grape/grape-swagger/pull/607): Allow body parameter name to be specified - [@tjwp](https://github.com/tjwp).
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -521,6 +521,20 @@ end
 ```
 
 
+#### Overriding the name of the body parameter
+
+By default, body parameters have a generated name based on the operation. For
+deeply nested resources, this name can get very long. To override the name of
+body parameter add `body_name: 'post_body'` after the description.
+
+```ruby
+namespace 'order' do
+  desc 'Create an order', body_name: 'post_body'
+  post do
+    ...
+  end
+end
+```
 
 #### Defining an endpoint as an array <a name="array" />
 

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -42,9 +42,9 @@ module GrapeSwagger
 
           move_params_to_new(definition, params)
 
-          definition[:description] = route.description if route.respond_to?(:description)
+          definition[:description] = route.description if route.try(:description)
 
-          build_body_parameter(referenced_definition, definition_name)
+          build_body_parameter(referenced_definition, definition_name, route.options)
         end
 
         def move_params_to_new(definition, params)
@@ -150,9 +150,9 @@ module GrapeSwagger
           definition[:required].push(*value)
         end
 
-        def build_body_parameter(reference, name)
+        def build_body_parameter(reference, name, options)
           {}.tap do |x|
-            x[:name] = name
+            x[:name] = options[:body_name] || name
             x[:in] = 'body'
             x[:required] = true
             x[:schema] = { '$ref' => "#/definitions/#{reference}" }


### PR DESCRIPTION
For deeply nested resources, the generated name for a body parameter, based on the operation, can get very long. This change allows the generated name to be overridden using a `:body_name` option on the desc.

While adding tests for this, I found that the relevant specs used a `Grape::Request` while the actual object that is passed is a `Grape::Router::Route`, so they are updated accordingly.