### PR TITLE
Fix Proc with arity one in param values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#613](https://github.com/ruby-grape/grape-swagger/pull/613): Fix Proc with arity one in param values - [@timothysu](https://github.com/timothysu).
 
 #### Fixes
 

--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -101,7 +101,7 @@ module GrapeSwagger
         def parse_enum_or_range_values(values)
           case values
           when Proc
-            parse_enum_or_range_values(values.call)
+            parse_enum_or_range_values(values.call) if values.parameters.empty?
           when Range
             parse_range_values(values) if values.first.is_a?(Integer)
           else

--- a/spec/lib/parse_params_spec.rb
+++ b/spec/lib/parse_params_spec.rb
@@ -47,6 +47,14 @@ describe GrapeSwagger::DocMethods::ParseParams do
           expect(parsed_range).to eql(enum: %w[a b c])
         end
       end
+
+      describe 'with arity one' do
+        let(:values) { proc { |v| v < 25 } }
+        specify do
+          parsed_range = subject.send(:parse_enum_or_range_values, values)
+          expect(parsed_range).to be_nil
+        end
+      end
     end
 
     describe 'values as Array -> enums' do


### PR DESCRIPTION
Recently ran into an issue where having custom validations in `values` would cause documentation generation to fail.  This simply mitigates an error from occurring.

---

From https://github.com/ruby-grape/grape/blob/master/README.md :

Alternatively, a Proc with arity one (i.e. taking one argument) can be used to explicitly validate
each parameter value.  In that case, the Proc is expected to return a truthy value if the parameter
value is valid.

```ruby
params do
  requires :number, type: Integer, values: ->(v) { v.even? && v < 25 }
end
```