### PR TITLE
Relax the minor version requirement

### DIFF
--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Add auto generated documentation to your Grape API that can be displayed with Swagger.'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '>= 2.2.6'
+  s.required_ruby_version = '>= 2.2'
   s.add_runtime_dependency 'grape', '>= 0.16.2'
 
   s.files         = `git ls-files`.split("\n")


### PR DESCRIPTION
Ruby 2.2 series is pretty much alive and many production apps are still not upgraded to last minor version.

Locking to 2.2.6 would make things much more difficult for users to make transition.