### PR TITLE
Add support for 'brackets' collection format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Features
 
-* Your contribution here.
+* [#622](https://github.com/ruby-grape/grape-swagger/pull/622): Add support for 'brackets' collection format - [@korstiaan](https://github.com/korstiaan).
 
 #### Fixes
 

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -80,7 +80,7 @@ module GrapeSwagger
         end
 
         def collections
-          %w[csv ssv tsv pipes multi]
+          %w[csv ssv tsv pipes multi brackets]
         end
       end
 

--- a/spec/swagger_v2/params_array_collection_fromat_spec.rb
+++ b/spec/swagger_v2/params_array_collection_fromat_spec.rb
@@ -31,6 +31,14 @@ describe 'Group Array Params, using collection format' do
         { 'declared_params' => declared(params) }
       end
 
+      params do
+        optional :array_of_strings, type: Array[String], desc: 'array in brackets collection format', documentation: { collectionFormat: 'brackets' }
+      end
+
+      get '/array_of_strings_brackets_collection_format' do
+        { 'declared_params' => declared(params) }
+      end
+
       add_swagger_documentation
     end
   end
@@ -60,6 +68,21 @@ describe 'Group Array Params, using collection format' do
       expect(subject['paths']['/array_of_strings_multi_collection_format']['get']['parameters']).to eql(
         [
           { 'in' => 'formData', 'name' => 'array_of_strings', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => false, 'collectionFormat' => 'multi', 'description' => 'array in multi collection format' }
+        ]
+      )
+    end
+  end
+
+  describe 'documentation for array parameters in brackets collectionFormat set from documentation' do
+    subject do
+      get '/swagger_doc/array_of_strings_brackets_collection_format'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/array_of_strings_brackets_collection_format']['get']['parameters']).to eql(
+        [
+          { 'in' => 'formData', 'name' => 'array_of_strings', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => false, 'collectionFormat' => 'brackets', 'description' => 'array in brackets collection format' }
         ]
       )
     end


### PR DESCRIPTION
Although not in the official spec, it is support by `swagger-ui`. The `multi` format (`foo=a&foo=b`) doesn't work with `rack` base apps (like `rails`). Rack wants it to look like `foo[]a=&foo[]=b`, which is exactly what the `brackets` format specifies.