### PR TITLE
Corrected error in description of Models (definitions)

### DIFF
--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -211,7 +211,6 @@ module Grape
         next if memo.key?(204)
         next unless !response_model.start_with?('Swagger_doc') && (@definitions[response_model] || value[:model])
 
-        @definitions[response_model][:description] = description_object(route)
         # TODO: proof that the definition exist, if model isn't specified
         reference = { '$ref' => "#/definitions/#{response_model}" }
         memo[value[:code]][:schema] = if route.options[:is_array] && value[:code] < 300


### PR DESCRIPTION
I had created models using Grape Entities. In the generated Swagger JSON, each of the model was getting `description`, which was description of one of the API end points, which is incorrect.

Using a debugger I could figure out the line of code that is attaching the description. Removing it solves the problem.

I am not sure why this code was there. Please suggest if there is a better way to solve the issue.