### PR TITLE
Fix order of mounts with overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#631](https://github.com/ruby-grape/grape-swagger/pull/631): Fix order of mounts with overrides - [@adie](https://github.com/adie).
 * Your contribution here.
 
 ### 0.27.3 (July 11, 2017)

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -72,7 +72,7 @@ module Grape
           resource = '/' if resource.empty?
           @target_class.combined_routes[resource] ||= []
           next if doc_klass.hide_documentation_path && route.path.match(/#{doc_klass.mount_path}($|\/|\(\.)/)
-          @target_class.combined_routes[resource] << route
+          @target_class.combined_routes[resource].unshift route
         end
       end
 

--- a/spec/swagger_v2/mount_override_api_spec.rb
+++ b/spec/swagger_v2/mount_override_api_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'mount override api' do
+  def app
+    old_api = Class.new(Grape::API) do
+      desc 'old endpoint', success: { code: 200, message: 'old message' }
+      params do
+        optional :param, type: Integer, desc: 'old param'
+      end
+      get do
+        'old'
+      end
+    end
+
+    new_api = Class.new(Grape::API) do
+      desc 'new endpoint', success: { code: 200, message: 'new message' }
+      params do
+        optional :param, type: String, desc: 'new param'
+      end
+      get do
+        'new'
+      end
+    end
+
+    Class.new(Grape::API) do
+      mount new_api
+      mount old_api
+
+      add_swagger_documentation format: :json
+    end
+  end
+
+  context 'actual api request' do
+    subject do
+      get '/'
+      last_response.body
+    end
+
+    it 'returns data from new endpoint' do
+      is_expected.to eq 'new'
+    end
+  end
+
+  context 'api documentation' do
+    subject do
+      get '/swagger_doc'
+      JSON.parse(last_response.body)['paths']['/']['get']
+    end
+
+    it 'shows documentation from new endpoint' do
+      expect(subject['summary']).to eql('new endpoint')
+      expect(subject['parameters'][0]['description']).to eql('new param')
+      expect(subject['parameters'][0]['type']).to eql('string')
+      expect(subject['responses']['200']['description']).to eql('new message')
+    end
+  end
+end


### PR DESCRIPTION
The problem is that `grape` executes endpoints in the order of definition (like defined first - matched first), but documentation was showing information from the last defined endpoints.
Not sure if it's issue with the `grape` itself, but I think `grape-swagger` should be consistent with current state of `grape` gem.