### PR TITLE
Fix mounting APIs in route_param namespaces

### DIFF
--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -90,6 +90,16 @@ module Grape
         end
       end
 
+      def determine_namespaced_routes(name, parent_route)
+        if parent_route.nil?
+          @target_class.combined_routes.values.flatten
+        else
+          parent_route.reject do |route|
+            !route_path_start_with?(route, name) || !route_instance_variable_equals?(route, name)
+          end
+        end
+      end
+
       def combine_namespace_routes(namespaces)
         # iterate over each single namespace
         namespaces.each do |name, _|
@@ -97,9 +107,7 @@ module Grape
           parent_route_name = extract_parent_route(name)
           parent_route = @target_class.combined_routes[parent_route_name]
           # fetch all routes that are within the current namespace
-          namespace_routes = parent_route.reject do |route|
-            !route_path_start_with?(route, name) || !route_instance_variable_equals?(route, name)
-          end
+          namespace_routes = determine_namespaced_routes(name, parent_route)
 
           # default case when not explicitly specified or nested == true
           standalone_namespaces = namespaces.reject do |_, ns|
@@ -122,7 +130,10 @@ module Grape
       end
 
       def extract_parent_route(name)
-        name.match(%r{^/?([^/]*).*$})[1]
+        route_name = name.match(%r{^/?([^/]*).*$})[1]
+        return route_name unless route_name.include? ':'
+        matches = name.match(/\/[a-z]+/)
+        matches.nil? ? route_name : matches[0].delete('/')
       end
 
       def route_instance_variable(route)

--- a/lib/grape-swagger/doc_methods/tag_name_description.rb
+++ b/lib/grape-swagger/doc_methods/tag_name_description.rb
@@ -7,6 +7,7 @@ module GrapeSwagger
         def build(paths)
           paths.values.each_with_object([]) do |path, memo|
             tags = path.values.first[:tags]
+            next if tags.nil?
 
             case tags
             when String

--- a/spec/issues/267_nested_namespaces.rb
+++ b/spec/issues/267_nested_namespaces.rb
@@ -1,0 +1,56 @@
+# encoding: utf-8
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'nested namespaces' do
+  let(:app) do
+    Class.new(Grape::API) do
+      route_param :root do
+        resources :apps do
+          route_param :app_id do
+            resource :build do
+              desc 'Builds an application'
+              post do
+                { name: 'Test' }
+              end
+            end
+          end
+        end
+      end
+
+      add_swagger_documentation version: 'v1'
+    end
+  end
+
+  describe 'combined_namespace_routes' do
+    it 'parses root namespace properly' do
+      expect(app.combined_namespace_routes.keys).to include('apps')
+    end
+  end
+
+  describe '#extract_parent_route' do
+    it 'extracts parent for non-namespaced path properly' do
+      expect(app.send :extract_parent_route, '/apps/:app_id/build').to eq('apps')
+    end
+
+    it 'extracts parent for namespaced path properly' do
+      expect(app.send :extract_parent_route, '/:root/apps/:app_id/build').to eq('apps')
+    end
+  end
+
+  describe 'retrieves swagger-documentation on /swagger_doc' do
+    let(:route_name) { '{root}/apps/{app_id}/build' }
+
+    subject do
+      get '/swagger_doc.json'
+      JSON.parse(last_response.body)
+    end
+
+    context 'paths' do
+      specify do
+        expect(subject['paths'].keys).to include "/#{route_name}"
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is based on https://github.com/ruby-grape/grape-swagger/pull/543 by @milgner

I have applied the changes on top of latest master and included test cases.
