### PR TITLE
Add an option to add braces to array params

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 275
+  Max: 282
 
 # Offense count: 12
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 282
+  Max: 291
 
 # Offense count: 12
 Metrics/CyclomaticComplexity:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 291
+  Max: 248
 
 # Offense count: 12
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#622](https://github.com/ruby-grape/grape-swagger/pull/622): Add support for 'brackets' collection format - [@korstiaan](https://github.com/korstiaan).
+* [#637](https://github.com/ruby-grape/grape-swagger/pull/637): Add an option to add braces to array params - [@adie](https://github.com/adie).
 
 * Your contribution here.
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -118,7 +118,7 @@ module Grape
       method[:description] = description_object(route)
       method[:produces]    = produces_object(route, options[:produces] || options[:format])
       method[:consumes]    = consumes_object(route, options[:format])
-      method[:parameters]  = params_object(route, path)
+      method[:parameters]  = params_object(route, options, path)
       method[:security]    = security_object(route)
       method[:responses]   = response_object(route)
       method[:tags]        = route.options.fetch(:tags, tag_object(route, path))
@@ -171,8 +171,8 @@ module Grape
       mime_types
     end
 
-    def params_object(route, path)
-      parameters = partition_params(route).map do |param, value|
+    def params_object(route, options, path)
+      parameters = partition_params(route, options).map do |param, value|
         value = { required: false }.merge(value) if value.is_a?(Hash)
         _, value = default_type([[param, value]]).first if value == ''
         if value[:type]
@@ -257,7 +257,7 @@ module Grape
       memo['schema'] = { type: 'file' }
     end
 
-    def partition_params(route)
+    def partition_params(route, settings)
       declared_params = route.settings[:declared_params] if route.settings[:declared_params].present?
       required = merge_params(route)
       required = GrapeSwagger::DocMethods::Headers.parse(route) + required unless route.headers.nil?
@@ -265,7 +265,7 @@ module Grape
       default_type(required)
 
       request_params = unless declared_params.nil? && route.headers.nil?
-                         parse_request_params(required)
+                         parse_request_params(required, settings)
                        end || {}
 
       request_params.empty? ? required : request_params
@@ -282,14 +282,25 @@ module Grape
       end
     end
 
-    def parse_request_params(params)
-      array_key = nil
+    def parse_request_params(params, settings)
+      array_keys = []
       params.select { |param| public_parameter?(param) }.each_with_object({}) do |param, memo|
         name, options = *param
         param_type = options[:type]
         param_type = param_type.to_s unless param_type.nil?
-        array_key = name.to_s if param_type_is_array?(param_type)
-        options[:is_array] = true if array_key && name.start_with?(array_key)
+
+        array_keys << name.to_s if param_type_is_array?(param_type)
+
+        keys = array_keys.find_all { |key| name.start_with? key }
+        if keys.any?
+          options[:is_array] = true
+          if settings[:array_use_braces] && !(options[:documentation] && options[:documentation][:param_type] == 'body')
+            keys.sort.reverse_each do |key|
+              name = name.sub(key, "#{key}[]")
+            end
+          end
+        end
+
         memo[name] = options unless %w[Hash Array].include?(param_type) && !options.key?(:documentation)
       end
     end

--- a/lib/grape-swagger/endpoint/params_parser.rb
+++ b/lib/grape-swagger/endpoint/params_parser.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+module GrapeSwagger
+  module Endpoint
+    class ParamsParser
+      attr_reader :params, :settings
+
+      def self.parse_request_params(params, settings)
+        new(params, settings).parse_request_params
+      end
+
+      def initialize(params, settings)
+        @params = params
+        @settings = settings
+      end
+
+      def parse_request_params
+        array_keys = []
+        public_params.each_with_object({}) do |(name, options), memo|
+          name = name.to_s
+          param_type = options[:type]
+          param_type = param_type.to_s unless param_type.nil?
+
+          if param_type_is_array?(param_type)
+            array_keys << name
+            options[:is_array] = true
+
+            name += '[]' if array_use_braces?(options)
+          else
+            keys = array_keys.find_all { |key| name.start_with? "#{key}[" }
+            if keys.any?
+              options[:is_array] = true
+              if array_use_braces?(options)
+                keys.sort.reverse_each do |key|
+                  name = name.sub(key, "#{key}[]")
+                end
+              end
+            end
+          end
+
+          memo[name] = options unless %w[Hash Array].include?(param_type) && !options.key?(:documentation)
+        end
+      end
+
+      private
+
+      def array_use_braces?(options)
+        settings[:array_use_braces] && !(options[:documentation] && options[:documentation][:param_type] == 'body')
+      end
+
+      def param_type_is_array?(param_type)
+        return false unless param_type
+        return true if param_type == 'Array'
+        param_types = param_type.match(/\[(.*)\]$/)
+        return false unless param_types
+        param_types = param_types[0].split(',') if param_types
+        param_types.size == 1
+      end
+
+      def public_params
+        params.select { |param| public_parameter?(param) }
+      end
+
+      def public_parameter?(param)
+        param_options = param.last
+        return true unless param_options.key?(:documentation) && !param_options[:required]
+        param_hidden = param_options[:documentation].fetch(:hidden, false)
+        param_hidden = param_hidden.call if param_hidden.is_a?(Proc)
+        !param_hidden
+      end
+    end
+  end
+end

--- a/spec/lib/endpoint/params_parser_spec.rb
+++ b/spec/lib/endpoint/params_parser_spec.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe GrapeSwagger::Endpoint::ParamsParser do
+  let(:settings) { {} }
+  let(:params) { [] }
+
+  let(:parser) { described_class.new(params, settings) }
+
+  describe '#parse_request_params' do
+    context 'when param is of array type' do
+      let(:params) { [['param_1', { type: 'Array[String]' }]] }
+
+      it 'adds is_array option' do
+        expect(parser.parse_request_params).to eq('param_1' => { type: 'Array[String]', is_array: true })
+      end
+
+      context 'and array_use_braces setting set to true' do
+        let(:settings) { { array_use_braces: true } }
+
+        it 'adds braces to the param key' do
+          expect(parser.parse_request_params.keys.first).to eq 'param_1[]'
+        end
+      end
+    end
+
+    context 'when param is of simple type' do
+      let(:params) { [['param_1', { type: 'String' }]] }
+
+      it 'does not change options' do
+        expect(parser.parse_request_params).to eq('param_1' => { type: 'String' })
+      end
+
+      context 'and array_use_braces setting set to true' do
+        let(:settings) { { array_use_braces: true } }
+
+        it 'does not add braces to the param key' do
+          expect(parser.parse_request_params.keys.first).to eq 'param_1'
+        end
+      end
+    end
+
+    context 'when param is nested in a param of array type' do
+      let(:params) { [['param_1', { type: 'Array' }], ['param_1[param_2]', { type: 'String' }]] }
+
+      it 'skips root parameter' do
+        expect(parser.parse_request_params).not_to have_key 'param_1'
+      end
+
+      it 'adds is_array option to the nested param' do
+        expect(parser.parse_request_params).to eq('param_1[param_2]' => { type: 'String', is_array: true })
+      end
+
+      context 'and array_use_braces setting set to true' do
+        let(:settings) { { array_use_braces: true } }
+
+        it 'adds braces to the param key' do
+          expect(parser.parse_request_params.keys.first).to eq 'param_1[][param_2]'
+        end
+      end
+    end
+
+    context 'when param is nested in a param of hash type' do
+      let(:params) { [['param_1', { type: 'Hash' }], ['param_1[param_2]', { type: 'String' }]] }
+
+      it 'skips root parameter' do
+        expect(parser.parse_request_params).not_to have_key 'param_1'
+      end
+
+      it 'does not change options to the nested param' do
+        expect(parser.parse_request_params).to eq('param_1[param_2]' => { type: 'String' })
+      end
+
+      context 'and array_use_braces setting set to true' do
+        let(:settings) { { array_use_braces: true } }
+
+        it 'does not add braces to the param key' do
+          expect(parser.parse_request_params.keys.first).to eq 'param_1[param_2]'
+        end
+      end
+    end
+  end
+
+  describe '#param_type_is_array?' do
+    it 'returns true if the value passed represents an array' do
+      expect(parser.send(:param_type_is_array?, 'Array')).to be_truthy
+      expect(parser.send(:param_type_is_array?, '[String]')).to be_truthy
+      expect(parser.send(:param_type_is_array?, 'Array[Integer]')).to be_truthy
+    end
+
+    it 'returns false if the value passed does not represent an array' do
+      expect(parser.send(:param_type_is_array?, 'String')).to be_falsey
+      expect(parser.send(:param_type_is_array?, '[String, Integer]')).to be_falsey
+    end
+  end
+end

--- a/spec/lib/endpoint_spec.rb
+++ b/spec/lib/endpoint_spec.rb
@@ -7,19 +7,6 @@ describe Grape::Endpoint do
     described_class.new(Grape::Util::InheritableSetting.new, path: '/', method: :get)
   end
 
-  describe '#param_type_is_array?' do
-    it 'returns true if the value passed represents an array' do
-      expect(subject.send(:param_type_is_array?, 'Array')).to be_truthy
-      expect(subject.send(:param_type_is_array?, '[String]')).to be_truthy
-      expect(subject.send(:param_type_is_array?, 'Array[Integer]')).to be_truthy
-    end
-
-    it 'returns false if the value passed does not represent an array' do
-      expect(subject.send(:param_type_is_array?, 'String')).to be_falsey
-      expect(subject.send(:param_type_is_array?, '[String, Integer]')).to be_falsey
-    end
-  end
-
   describe '.content_types_for' do
     describe 'defined on target_class' do
       let(:own_json) { 'text/own-json' }

--- a/spec/swagger_v2/params_array_spec.rb
+++ b/spec/swagger_v2/params_array_spec.rb
@@ -5,193 +5,199 @@ require 'spec_helper'
 describe 'Group Params as Array' do
   include_context "#{MODEL_PARSER} swagger example"
 
-  def app
-    Class.new(Grape::API) do
-      format :json
+  [true, false].each do |array_use_braces|
+    context "when array_use_braces option is set to #{array_use_braces}" do
+      let(:braces) { array_use_braces ? '[]' : '' }
 
-      params do
-        requires :required_group, type: Array do
-          requires :required_param_1
-          requires :required_param_2
+      let(:app) do
+        Class.new(Grape::API) do
+          format :json
+
+          params do
+            requires :required_group, type: Array do
+              requires :required_param_1
+              requires :required_param_2
+            end
+          end
+          post '/groups' do
+            { 'declared_params' => declared(params) }
+          end
+
+          params do
+            requires :typed_group, type: Array do
+              requires :id, type: Integer, desc: 'integer given'
+              requires :name, type: String, desc: 'string given'
+              optional :email, type: String, desc: 'email given'
+              optional :others, type: Integer, values: [1, 2, 3]
+            end
+          end
+          post '/type_given' do
+            { 'declared_params' => declared(params) }
+          end
+
+          # as body parameters it would be interpreted a bit different,
+          # cause it could not be distinguished anymore, so this would be translated to one array,
+          # see also next example for the difference
+          params do
+            requires :array_of_string, type: Array[String], documentation: { param_type: 'body', desc: 'nested array of strings' }
+            requires :array_of_integer, type: Array[Integer], documentation: { param_type: 'body', desc: 'nested array of integers' }
+          end
+
+          post '/array_of_type' do
+            { 'declared_params' => declared(params) }
+          end
+
+          params do
+            requires :array_of_string, type: Array[String], documentation: { param_type: 'body', desc: 'array of strings' }
+            requires :integer_value, type: Integer, documentation: { param_type: 'body', desc: 'integer value' }
+          end
+
+          post '/object_and_array' do
+            { 'declared_params' => declared(params) }
+          end
+
+          params do
+            requires :array_of_string, type: Array[String]
+            requires :array_of_integer, type: Array[Integer]
+          end
+
+          post '/array_of_type_in_form' do
+            { 'declared_params' => declared(params) }
+          end
+
+          params do
+            requires :array_of_entities, type: Array[Entities::ApiError]
+          end
+
+          post '/array_of_entities' do
+            { 'declared_params' => declared(params) }
+          end
+
+          add_swagger_documentation array_use_braces: array_use_braces
         end
       end
-      post '/groups' do
-        { 'declared_params' => declared(params) }
-      end
 
-      params do
-        requires :typed_group, type: Array do
-          requires :id, type: Integer, desc: 'integer given'
-          requires :name, type: String, desc: 'string given'
-          optional :email, type: String, desc: 'email given'
-          optional :others, type: Integer, values: [1, 2, 3]
+      describe 'retrieves the documentation for grouped parameters' do
+        subject do
+          get '/swagger_doc/groups'
+          JSON.parse(last_response.body)
+        end
+
+        specify do
+          expect(subject['paths']['/groups']['post']['parameters']).to eql(
+            [
+              { 'in' => 'formData', 'name' => "required_group#{braces}[required_param_1]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } },
+              { 'in' => 'formData', 'name' => "required_group#{braces}[required_param_2]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } }
+            ]
+          )
         end
       end
-      post '/type_given' do
-        { 'declared_params' => declared(params) }
+
+      describe 'retrieves the documentation for typed group parameters' do
+        subject do
+          get '/swagger_doc/type_given'
+          JSON.parse(last_response.body)
+        end
+
+        specify do
+          expect(subject['paths']['/type_given']['post']['parameters']).to eql(
+            [
+              { 'in' => 'formData', 'name' => "typed_group#{braces}[id]", 'description' => 'integer given', 'type' => 'array', 'items' => { 'type' => 'integer', 'format' => 'int32' }, 'required' => true },
+              { 'in' => 'formData', 'name' => "typed_group#{braces}[name]", 'description' => 'string given', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true },
+              { 'in' => 'formData', 'name' => "typed_group#{braces}[email]", 'description' => 'email given', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => false },
+              { 'in' => 'formData', 'name' => "typed_group#{braces}[others]", 'type' => 'array', 'items' => { 'type' => 'integer', 'format' => 'int32' }, 'enum' => [1, 2, 3], 'required' => false }
+            ]
+          )
+        end
       end
 
-      # as body parameters it would be interpreted a bit different,
-      # cause it could not be distinguished anymore, so this would be translated to one array,
-      # see also next example for the difference
-      params do
-        requires :array_of_string, type: Array[String], documentation: { param_type: 'body', desc: 'nested array of strings' }
-        requires :array_of_integer, type: Array[Integer], documentation: { param_type: 'body', desc: 'nested array of integers' }
+      describe 'retrieves the documentation for parameters that are arrays of primitive types' do
+        subject do
+          get '/swagger_doc/array_of_type'
+          JSON.parse(last_response.body)
+        end
+
+        specify do
+          expect(subject['definitions']['postArrayOfType']['type']).to eql 'array'
+          expect(subject['definitions']['postArrayOfType']['items']).to eql(
+            'type' => 'object',
+            'properties' => {
+              'array_of_string' => {
+                'type' => 'string', 'description' => 'nested array of strings'
+              },
+              'array_of_integer' => {
+                'type' => 'integer', 'format' => 'int32', 'description' => 'nested array of integers'
+              }
+            },
+            'required' => %w[array_of_string array_of_integer]
+          )
+        end
       end
 
-      post '/array_of_type' do
-        { 'declared_params' => declared(params) }
+      describe 'documentation for simple and array parameters' do
+        subject do
+          get '/swagger_doc/object_and_array'
+          JSON.parse(last_response.body)
+        end
+
+        specify do
+          expect(subject['definitions']['postObjectAndArray']['type']).to eql 'object'
+          expect(subject['definitions']['postObjectAndArray']['properties']).to eql(
+            'array_of_string' => {
+              'type' => 'array',
+              'description' => 'array of strings',
+              'items' => {
+                'type' => 'string'
+              }
+            },
+            'integer_value' => {
+              'type' => 'integer', 'format' => 'int32', 'description' => 'integer value'
+            }
+          )
+        end
       end
 
-      params do
-        requires :array_of_string, type: Array[String], documentation: { param_type: 'body', desc: 'array of strings' }
-        requires :integer_value, type: Integer, documentation: { param_type: 'body', desc: 'integer value' }
+      describe 'retrieves the documentation for typed group parameters' do
+        subject do
+          get '/swagger_doc/array_of_type_in_form'
+          JSON.parse(last_response.body)
+        end
+
+        specify do
+          expect(subject['paths']['/array_of_type_in_form']['post']['parameters']).to eql(
+            [
+              { 'in' => 'formData', 'name' => "array_of_string#{braces}", 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true },
+              { 'in' => 'formData', 'name' => "array_of_integer#{braces}", 'type' => 'array', 'items' => { 'type' => 'integer', 'format' => 'int32' }, 'required' => true }
+            ]
+          )
+        end
       end
 
-      post '/object_and_array' do
-        { 'declared_params' => declared(params) }
+      describe 'documentation for entity array parameters' do
+        let(:parameters) do
+          [
+            {
+              'in' => 'formData',
+              'name' => "array_of_entities#{braces}",
+              'type' => 'array',
+              'items' => {
+                '$ref' => '#/definitions/ApiError'
+              },
+              'required' => true
+            }
+          ]
+        end
+
+        subject do
+          get '/swagger_doc/array_of_entities'
+          JSON.parse(last_response.body)
+        end
+
+        specify do
+          expect(subject['definitions']['ApiError']).not_to be_blank
+          expect(subject['paths']['/array_of_entities']['post']['parameters']).to eql(parameters)
+        end
       end
-
-      params do
-        requires :array_of_string, type: Array[String]
-        requires :array_of_integer, type: Array[Integer]
-      end
-
-      post '/array_of_type_in_form' do
-        { 'declared_params' => declared(params) }
-      end
-
-      params do
-        requires :array_of_entities, type: Array[Entities::ApiError]
-      end
-
-      post '/array_of_entities' do
-        { 'declared_params' => declared(params) }
-      end
-
-      add_swagger_documentation
-    end
-  end
-
-  describe 'retrieves the documentation for grouped parameters' do
-    subject do
-      get '/swagger_doc/groups'
-      JSON.parse(last_response.body)
-    end
-
-    specify do
-      expect(subject['paths']['/groups']['post']['parameters']).to eql(
-        [
-          { 'in' => 'formData', 'name' => 'required_group[required_param_1]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } },
-          { 'in' => 'formData', 'name' => 'required_group[required_param_2]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } }
-        ]
-      )
-    end
-  end
-
-  describe 'retrieves the documentation for typed group parameters' do
-    subject do
-      get '/swagger_doc/type_given'
-      JSON.parse(last_response.body)
-    end
-
-    specify do
-      expect(subject['paths']['/type_given']['post']['parameters']).to eql(
-        [
-          { 'in' => 'formData', 'name' => 'typed_group[id]', 'description' => 'integer given', 'type' => 'array', 'items' => { 'type' => 'integer', 'format' => 'int32' }, 'required' => true },
-          { 'in' => 'formData', 'name' => 'typed_group[name]', 'description' => 'string given', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true },
-          { 'in' => 'formData', 'name' => 'typed_group[email]', 'description' => 'email given', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => false },
-          { 'in' => 'formData', 'name' => 'typed_group[others]', 'type' => 'array', 'items' => { 'type' => 'integer', 'format' => 'int32' }, 'enum' => [1, 2, 3], 'required' => false }
-        ]
-      )
-    end
-  end
-
-  describe 'retrieves the documentation for parameters that are arrays of primitive types' do
-    subject do
-      get '/swagger_doc/array_of_type'
-      JSON.parse(last_response.body)
-    end
-
-    specify do
-      expect(subject['definitions']['postArrayOfType']['type']).to eql 'array'
-      expect(subject['definitions']['postArrayOfType']['items']).to eql(
-        'type' => 'object',
-        'properties' => {
-          'array_of_string' => {
-            'type' => 'string', 'description' => 'nested array of strings'
-          },
-          'array_of_integer' => {
-            'type' => 'integer', 'format' => 'int32', 'description' => 'nested array of integers'
-          }
-        },
-        'required' => %w[array_of_string array_of_integer]
-      )
-    end
-  end
-
-  describe 'documentation for simple and array parameters' do
-    subject do
-      get '/swagger_doc/object_and_array'
-      JSON.parse(last_response.body)
-    end
-
-    specify do
-      expect(subject['definitions']['postObjectAndArray']['type']).to eql 'object'
-      expect(subject['definitions']['postObjectAndArray']['properties']).to eql(
-        'array_of_string' => {
-          'type' => 'array',
-          'description' => 'array of strings',
-          'items' => {
-            'type' => 'string'
-          }
-        },
-        'integer_value' => {
-          'type' => 'integer', 'format' => 'int32', 'description' => 'integer value'
-        }
-      )
-    end
-  end
-
-  describe 'retrieves the documentation for typed group parameters' do
-    subject do
-      get '/swagger_doc/array_of_type_in_form'
-      JSON.parse(last_response.body)
-    end
-
-    specify do
-      expect(subject['paths']['/array_of_type_in_form']['post']['parameters']).to eql(
-        [
-          { 'in' => 'formData', 'name' => 'array_of_string', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true },
-          { 'in' => 'formData', 'name' => 'array_of_integer', 'type' => 'array', 'items' => { 'type' => 'integer', 'format' => 'int32' }, 'required' => true }
-        ]
-      )
-    end
-  end
-
-  describe 'documentation for entity array parameters' do
-    let(:parameters) do
-      [
-        {
-          'in' => 'formData',
-          'name' => 'array_of_entities',
-          'type' => 'array',
-          'items' => {
-            '$ref' => '#/definitions/ApiError'
-          },
-          'required' => true
-        }
-      ]
-    end
-
-    subject do
-      get '/swagger_doc/array_of_entities'
-      JSON.parse(last_response.body)
-    end
-
-    specify do
-      expect(subject['definitions']['ApiError']).not_to be_blank
-      expect(subject['paths']['/array_of_entities']['post']['parameters']).to eql(parameters)
     end
   end
 end

--- a/spec/swagger_v2/params_nested_spec.rb
+++ b/spec/swagger_v2/params_nested_spec.rb
@@ -20,6 +20,7 @@ describe 'nested group params' do
                 requires :param_3, type: String
               end
             end
+            requires :a_array_foo, type: String
           end
           post '/nested_array' do
             { 'declared_params' => declared(params) }
@@ -35,6 +36,7 @@ describe 'nested group params' do
                 requires :param_3, type: String
               end
             end
+            requires :a_hash_foo, type: String
           end
           post '/nested_hash' do
             { 'declared_params' => declared(params) }
@@ -55,7 +57,8 @@ describe 'nested group params' do
             [
               { 'in' => 'formData', 'name' => "a_array#{braces}[param_1]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'integer', 'format' => 'int32' } },
               { 'in' => 'formData', 'name' => "a_array#{braces}[b_array]#{braces}[param_2]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } },
-              { 'in' => 'formData', 'name' => "a_array#{braces}[c_hash][param_3]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } }
+              { 'in' => 'formData', 'name' => "a_array#{braces}[c_hash][param_3]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } },
+              { 'in' => 'formData', 'name' => 'a_array_foo', 'required' => true, 'type' => 'string' }
             ]
           )
         end
@@ -72,7 +75,8 @@ describe 'nested group params' do
             [
               { 'in' => 'formData', 'name' => 'a_hash[param_1]', 'required' => true, 'type' => 'integer', 'format' => 'int32' },
               { 'in' => 'formData', 'name' => 'a_hash[b_hash][param_2]', 'required' => true, 'type' => 'string' },
-              { 'in' => 'formData', 'name' => "a_hash[c_array]#{braces}[param_3]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } }
+              { 'in' => 'formData', 'name' => "a_hash[c_array]#{braces}[param_3]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } },
+              { 'in' => 'formData', 'name' => 'a_hash_foo', 'required' => true, 'type' => 'string' }
             ]
           )
         end

--- a/spec/swagger_v2/params_nested_spec.rb
+++ b/spec/swagger_v2/params_nested_spec.rb
@@ -3,67 +3,80 @@
 require 'spec_helper'
 
 describe 'nested group params' do
-  def app
-    Class.new(Grape::API) do
-      format :json
+  [true, false].each do |array_use_braces|
+    context "when array_use_braces option is set to #{array_use_braces}" do
+      let(:braces) { array_use_braces ? '[]' : '' }
+      let(:app) do
+        Class.new(Grape::API) do
+          format :json
 
-      params do
-        requires :a_array, type: Array do
-          requires :param_1, type: Integer
-          requires :b_array, type: Array do
-            requires :param_2, type: String
+          params do
+            requires :a_array, type: Array do
+              requires :param_1, type: Integer
+              requires :b_array, type: Array do
+                requires :param_2, type: String
+              end
+              requires :c_hash, type: Hash do
+                requires :param_3, type: String
+              end
+            end
           end
+          post '/nested_array' do
+            { 'declared_params' => declared(params) }
+          end
+
+          params do
+            requires :a_hash, type: Hash do
+              requires :param_1, type: Integer
+              requires :b_hash, type: Hash do
+                requires :param_2, type: String
+              end
+              requires :c_array, type: Array do
+                requires :param_3, type: String
+              end
+            end
+          end
+          post '/nested_hash' do
+            { 'declared_params' => declared(params) }
+          end
+
+          add_swagger_documentation array_use_braces: array_use_braces
         end
       end
-      post '/nested_array' do
-        { 'declared_params' => declared(params) }
-      end
 
-      params do
-        requires :a_hash, type: Hash do
-          requires :param_1, type: Integer
-          requires :b_hash, type: Hash do
-            requires :param_2, type: String
-          end
+      describe 'retrieves the documentation for nested array parameters' do
+        subject do
+          get '/swagger_doc/nested_array'
+          JSON.parse(last_response.body)
+        end
+
+        specify do
+          expect(subject['paths']['/nested_array']['post']['parameters']).to eql(
+            [
+              { 'in' => 'formData', 'name' => "a_array#{braces}[param_1]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'integer', 'format' => 'int32' } },
+              { 'in' => 'formData', 'name' => "a_array#{braces}[b_array]#{braces}[param_2]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } },
+              { 'in' => 'formData', 'name' => "a_array#{braces}[c_hash][param_3]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } }
+            ]
+          )
         end
       end
-      post '/nested_hash' do
-        { 'declared_params' => declared(params) }
+
+      describe 'retrieves the documentation for nested hash parameters' do
+        subject do
+          get '/swagger_doc/nested_hash'
+          JSON.parse(last_response.body)
+        end
+
+        specify do
+          expect(subject['paths']['/nested_hash']['post']['parameters']).to eql(
+            [
+              { 'in' => 'formData', 'name' => 'a_hash[param_1]', 'required' => true, 'type' => 'integer', 'format' => 'int32' },
+              { 'in' => 'formData', 'name' => 'a_hash[b_hash][param_2]', 'required' => true, 'type' => 'string' },
+              { 'in' => 'formData', 'name' => "a_hash[c_array]#{braces}[param_3]", 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } }
+            ]
+          )
+        end
       end
-
-      add_swagger_documentation
-    end
-  end
-
-  describe 'retrieves the documentation for nested array parameters' do
-    subject do
-      get '/swagger_doc/nested_array'
-      JSON.parse(last_response.body)
-    end
-
-    specify do
-      expect(subject['paths']['/nested_array']['post']['parameters']).to eql(
-        [
-          { 'in' => 'formData', 'name' => 'a_array[param_1]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'integer', 'format' => 'int32' } },
-          { 'in' => 'formData', 'name' => 'a_array[b_array][param_2]', 'required' => true, 'type' => 'array', 'items' => { 'type' => 'string' } }
-        ]
-      )
-    end
-  end
-
-  describe 'retrieves the documentation for nested hash parameters' do
-    subject do
-      get '/swagger_doc/nested_hash'
-      JSON.parse(last_response.body)
-    end
-
-    specify do
-      expect(subject['paths']['/nested_hash']['post']['parameters']).to eql(
-        [
-          { 'in' => 'formData', 'name' => 'a_hash[param_1]', 'required' => true, 'type' => 'integer', 'format' => 'int32' },
-          { 'in' => 'formData', 'name' => 'a_hash[b_hash][param_2]', 'required' => true, 'type' => 'string' }
-        ]
-      )
     end
   end
 end


### PR DESCRIPTION
Right now it's more like a proof of concept in attempt to fix #636 
I've added `array_use_braces` option for the `add_swagger_documentation` so that it would be a feature toggle. Not sure if it's ok to do this globally.
It's possible that it fixes other issues with array params like #617 and #626 
Please let me know what do you think of such approach

TODO:
* [x] Distinguish between `water` and `watermelon`, e.g. check that it does not simply start from the string, but matches whole name.
* [ ] Document new option in README