### PR TITLE
Default success codes to be excluded when http_codes define one already

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -18,7 +18,7 @@ Metrics/BlockLength:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 275
+  Max: 280
 
 # Offense count: 12
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#631](https://github.com/ruby-grape/grape-swagger/pull/631): Fix order of mounts with overrides - [@adie](https://github.com/adie).
 * [#267](https://github.com/ruby-grape/grape-swagger/pull/634): Fix mounting APIs in route_param namespaces - [@milgner](https://github.com/milgner), [@wojciechka](https://github.com/wojciechka).
 * [#642](https://github.com/ruby-grape/grape-swagger/pull/642): Fix examples link in readme - [@iBublik](https://github.com/iBublik).
+* [#641](https://github.com/ruby-grape/grape-swagger/pull/641): Exclude default success code if http_codes define one already - [@anakinj](https://github.com/anakinj).
 
 * Your contribution here.
 

--- a/spec/swagger_v2/api_swagger_v2_status_codes_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_status_codes_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'http status code behaivours' do
+  include_context "#{MODEL_PARSER} swagger example"
+
+  subject do
+    get '/swagger_doc'
+    JSON.parse(last_response.body)
+  end
+
+  context 'when non-default success codes are deifined' do
+    let(:app) do
+      Class.new(Grape::API) do
+        desc 'Has explicit http_codes defined' do
+          http_codes [{ code: 202, message: 'We got it!' },
+                      { code: 204, message: 'Or returned no content' }]
+        end
+
+        post '/accepting_endpoint' do
+          'We got the message!'
+        end
+        add_swagger_documentation
+      end
+    end
+
+    it 'only includes the defined http_codes' do
+      expect(subject['paths']['/accepting_endpoint']['post']['responses'].keys.sort).to eq(%w[202 204].sort)
+    end
+  end
+
+  context 'when no success codes defined' do
+    let(:app) do
+      Class.new(Grape::API) do
+        desc 'Has explicit http_codes defined' do
+          http_codes [{ code: 400, message: 'Error!' },
+                      { code: 404, message: 'Not found' }]
+        end
+
+        post '/accepting_endpoint' do
+          'We got the message!'
+        end
+        add_swagger_documentation
+      end
+    end
+
+    it 'adds the success code to the response' do
+      expect(subject['paths']['/accepting_endpoint']['post']['responses'].keys.sort).to eq(%w[201 400 404].sort)
+    end
+  end
+end

--- a/spec/swagger_v2/api_swagger_v2_status_codes_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_status_codes_spec.rb
@@ -13,9 +13,10 @@ describe 'http status code behaivours' do
   context 'when non-default success codes are deifined' do
     let(:app) do
       Class.new(Grape::API) do
-        desc 'Has explicit http_codes defined' do
+        desc 'Has explicit success http_codes defined' do
           http_codes [{ code: 202, message: 'We got it!' },
-                      { code: 204, message: 'Or returned no content' }]
+                      { code: 204, message: 'Or returned no content' },
+                      { code: 400, message: 'Bad request' }]
         end
 
         post '/accepting_endpoint' do
@@ -26,27 +27,47 @@ describe 'http status code behaivours' do
     end
 
     it 'only includes the defined http_codes' do
-      expect(subject['paths']['/accepting_endpoint']['post']['responses'].keys.sort).to eq(%w[202 204].sort)
+      expect(subject['paths']['/accepting_endpoint']['post']['responses'].keys.sort).to eq(%w[202 204 400].sort)
     end
   end
 
   context 'when no success codes defined' do
     let(:app) do
       Class.new(Grape::API) do
-        desc 'Has explicit http_codes defined' do
+        desc 'Has explicit error http_codes defined' do
           http_codes [{ code: 400, message: 'Error!' },
                       { code: 404, message: 'Not found' }]
         end
 
-        post '/accepting_endpoint' do
+        post '/error_endpoint' do
           'We got the message!'
         end
         add_swagger_documentation
       end
     end
 
-    it 'adds the success code to the response' do
-      expect(subject['paths']['/accepting_endpoint']['post']['responses'].keys.sort).to eq(%w[201 400 404].sort)
+    it 'adds the success codes to the response' do
+      expect(subject['paths']['/error_endpoint']['post']['responses'].keys.sort).to eq(%w[201 400 404].sort)
+    end
+  end
+
+  context 'when success and error codes are defined' do
+    let(:app) do
+      Class.new(Grape::API) do
+        desc 'Has success and error codes defined' do
+          http_codes [{ code: 200, message: 'Found' },
+                      { code: 404, message: 'Not found' }]
+        end
+
+        get '/endpoint' do
+          'We got the message!'
+        end
+        add_swagger_documentation
+      end
+    end
+
+    it 'adds the success codes and error codes to the response' do
+      expect(subject['paths']['/endpoint']['get']['responses'].keys.sort).to eq(%w[200 404].sort)
     end
   end
 end


### PR DESCRIPTION
It was not possible to override a POSTs default 201 status code. This change will prevent the default success code to be added if the http_codes array already include a success code.