### PR TITLE
consumes support for PATCH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * [#642](https://github.com/ruby-grape/grape-swagger/pull/642): Fix examples link in readme - [@iBublik](https://github.com/iBublik).
 * [#641](https://github.com/ruby-grape/grape-swagger/pull/641): Exclude default success code if http_codes define one already - [@anakinj](https://github.com/anakinj).
 * [#651](https://github.com/ruby-grape/grape-swagger/pull/651): Apply `values` and `default` of array params to its items - [@yewton](https://github.com/yewton).
+* [#654](https://github.com/ruby-grape/grape-swagger/pull/654): Allow setting the consumes for PATCH methods - [@anakinj](https://github.com/anakinj).
 
 * Your contribution here.
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -161,14 +161,11 @@ module Grape
       route_mime_types.present? ? route_mime_types : mime_types
     end
 
-    def consumes_object(route, format)
-      method = route.request_method.downcase.to_sym
-      if route.settings.dig(:description, :consumes)
-        format = route.settings[:description][:consumes]
-      end
-      mime_types = GrapeSwagger::DocMethods::ProducesConsumes.call(format) if %i[post put].include?(method)
+    SUPPORTS_CONSUMES = %i[post put patch].freeze
 
-      mime_types
+    def consumes_object(route, format)
+      return unless SUPPORTS_CONSUMES.include?(route.request_method.downcase.to_sym)
+      GrapeSwagger::DocMethods::ProducesConsumes.call(route.settings.dig(:description, :consumes) || format)
     end
 
     def params_object(route, path)

--- a/spec/swagger_v2/api_swagger_v2_format-content_type_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_format-content_type_spec.rb
@@ -49,6 +49,14 @@ describe 'format, content_type' do
           { 'declared_params' => declared(params) }
         end
 
+        desc 'This uses consumes for consumes',
+             failure: [{ code: 400, model: Entities::ApiError }],
+             consumes: ['application/www_url_encoded'],
+             entity: Entities::UseResponse
+        patch '/use_consumes' do
+          { 'declared_params' => declared(params) }
+        end
+
         add_swagger_documentation
       end
     end
@@ -123,6 +131,7 @@ describe 'format, content_type' do
     specify do
       expect(subject['paths']['/use_consumes']['post']).to include('consumes')
       expect(subject['paths']['/use_consumes']['post']['consumes']).to eql ['application/www_url_encoded']
+      expect(subject['paths']['/use_consumes']['patch']['consumes']).to eql ['application/www_url_encoded']
     end
   end
 end


### PR DESCRIPTION
Trying to get our Swagger docs to pass some validations and noticed that for some reason the consumes setting was not supported for PATCH methods. This should fix the issue.