### PR TITLE
FIX description field (required) may be null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 * [#641](https://github.com/ruby-grape/grape-swagger/pull/641): Exclude default success code if http_codes define one already - [@anakinj](https://github.com/anakinj).
 * [#651](https://github.com/ruby-grape/grape-swagger/pull/651): Apply `values` and `default` of array params to its items - [@yewton](https://github.com/yewton).
 * [#654](https://github.com/ruby-grape/grape-swagger/pull/654): Allow setting the consumes for PATCH methods - [@anakinj](https://github.com/anakinj).
+* [#656](https://github.com/ruby-grape/grape-swagger/pull/656): Fix `description` field may be null - [@soranoba](https://github.com/soranoba).
 
 * Your contribution here.
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -143,6 +143,7 @@ module Grape
     def description_object(route)
       description = route.description if route.description.present?
       description = route.options[:detail] if route.options.key?(:detail)
+      description ||= ''
 
       description
     end
@@ -192,6 +193,7 @@ module Grape
       codes.map! { |x| x.is_a?(Array) ? { code: x[0], message: x[1], model: x[2] } : x }
 
       codes.each_with_object({}) do |value, memo|
+        value[:message] ||= ''
         memo[value[:code]] = { description: value[:message] }
         next build_file_response(memo[value[:code]]) if file_response?(value[:model])
 


### PR DESCRIPTION
Now, description fields are often null, but it is required.
I fixed it become the correct format by changing to empty character from null.

```diff
        "responses": {
          "201": {
-            "description": null,
+            "description": "",
            "schema": {
              "$ref": "#/definitions/HogeEntity"
            }
          }
        },
```

```diff
"definitions": {
    "HogeEntity": {
      "type": "object",
      "properties": {
         "id": {
          "type": "integer",
          "format": "int32",
          "description": ""
        }
     },
     "required": [
        "id"
      ],
-      "description": null
+      "description": ""
    }
```


This is caused by omitted of detail or message.
However, these are I/F assuming that they can be omitted.

```ruby
# detail omitted
post failure: [
    {code: 201, model: Entities::HogeEntity} # message omitted
] do
  status 201
end
```
