### PR TITLE
Make route summary optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Features
 
-* Your contribution here.
+* [#667](https://github.com/ruby-grape/grape-swagger/pull/667):  Make route summary optional - [@obduk](https://github.com/obduk).
 
 #### Fixes
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -134,7 +134,7 @@ module Grape
 
     def summary_object(route)
       summary = route.options[:desc] if route.options.key?(:desc)
-      summary = route.description if route.description.present?
+      summary = route.description if route.description.present? && route.options.key?(:detail)
       summary = route.options[:summary] if route.options.key?(:summary)
 
       summary

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -207,7 +207,6 @@ RSpec.shared_context 'entity swagger example' do
       'paths' => {
         '/v3/other_thing/{elements}' => {
           'get' => {
-            'summary' => 'nested route inside namespace',
             'description' => 'nested route inside namespace',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'body', 'name' => 'elements', 'description' => 'Set of configuration', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true }],
@@ -220,7 +219,6 @@ RSpec.shared_context 'entity swagger example' do
         },
         '/thing' => {
           'get' => {
-            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'parameters' => [
@@ -234,7 +232,6 @@ RSpec.shared_context 'entity swagger example' do
             'operationId' => 'getThing'
           },
           'post' => {
-            'summary' => 'This creates Thing.',
             'description' => 'This creates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -249,7 +246,6 @@ RSpec.shared_context 'entity swagger example' do
         },
         '/thing/{id}' => {
           'get' => {
-            'summary' => 'This gets Thing.',
             'description' => 'This gets Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -258,7 +254,6 @@ RSpec.shared_context 'entity swagger example' do
             'operationId' => 'getThingId'
           },
           'put' => {
-            'summary' => 'This updates Thing.',
             'description' => 'This updates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -272,7 +267,6 @@ RSpec.shared_context 'entity swagger example' do
             'operationId' => 'putThingId'
           },
           'delete' => {
-            'summary' => 'This deletes Thing.',
             'description' => 'This deletes Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -283,7 +277,6 @@ RSpec.shared_context 'entity swagger example' do
         },
         '/thing2' => {
           'get' => {
-            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
@@ -293,7 +286,6 @@ RSpec.shared_context 'entity swagger example' do
         },
         '/dummy/{id}' => {
           'delete' => {
-            'summary' => 'dummy route.',
             'description' => 'dummy route.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],

--- a/spec/support/model_parsers/mock_parser.rb
+++ b/spec/support/model_parsers/mock_parser.rb
@@ -199,7 +199,6 @@ RSpec.shared_context 'mock swagger example' do
       'paths' => {
         '/v3/other_thing/{elements}' => {
           'get' => {
-            'summary' => 'nested route inside namespace',
             'description' => 'nested route inside namespace',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'body', 'name' => 'elements', 'description' => 'Set of configuration', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true }],
@@ -212,7 +211,6 @@ RSpec.shared_context 'mock swagger example' do
         },
         '/thing' => {
           'get' => {
-            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'parameters' => [
@@ -226,7 +224,6 @@ RSpec.shared_context 'mock swagger example' do
             'operationId' => 'getThing'
           },
           'post' => {
-            'summary' => 'This creates Thing.',
             'description' => 'This creates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -241,7 +238,6 @@ RSpec.shared_context 'mock swagger example' do
         },
         '/thing/{id}' => {
           'get' => {
-            'summary' => 'This gets Thing.',
             'description' => 'This gets Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -250,7 +246,6 @@ RSpec.shared_context 'mock swagger example' do
             'operationId' => 'getThingId'
           },
           'put' => {
-            'summary' => 'This updates Thing.',
             'description' => 'This updates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -264,7 +259,6 @@ RSpec.shared_context 'mock swagger example' do
             'operationId' => 'putThingId'
           },
           'delete' => {
-            'summary' => 'This deletes Thing.',
             'description' => 'This deletes Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -275,7 +269,6 @@ RSpec.shared_context 'mock swagger example' do
         },
         '/thing2' => {
           'get' => {
-            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
@@ -285,7 +278,6 @@ RSpec.shared_context 'mock swagger example' do
         },
         '/dummy/{id}' => {
           'delete' => {
-            'summary' => 'dummy route.',
             'description' => 'dummy route.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],

--- a/spec/support/model_parsers/representable_parser.rb
+++ b/spec/support/model_parsers/representable_parser.rb
@@ -279,7 +279,6 @@ RSpec.shared_context 'representable swagger example' do
       'paths' => {
         '/v3/other_thing/{elements}' => {
           'get' => {
-            'summary' => 'nested route inside namespace',
             'description' => 'nested route inside namespace',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'body', 'name' => 'elements', 'description' => 'Set of configuration', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true }],
@@ -292,7 +291,6 @@ RSpec.shared_context 'representable swagger example' do
         },
         '/thing' => {
           'get' => {
-            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'parameters' => [
@@ -306,7 +304,6 @@ RSpec.shared_context 'representable swagger example' do
             'operationId' => 'getThing'
           },
           'post' => {
-            'summary' => 'This creates Thing.',
             'description' => 'This creates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -321,7 +318,6 @@ RSpec.shared_context 'representable swagger example' do
         },
         '/thing/{id}' => {
           'get' => {
-            'summary' => 'This gets Thing.',
             'description' => 'This gets Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -330,7 +326,6 @@ RSpec.shared_context 'representable swagger example' do
             'operationId' => 'getThingId'
           },
           'put' => {
-            'summary' => 'This updates Thing.',
             'description' => 'This updates Thing.',
             'produces' => ['application/json'],
             'consumes' => ['application/json'],
@@ -344,7 +339,6 @@ RSpec.shared_context 'representable swagger example' do
             'operationId' => 'putThingId'
           },
           'delete' => {
-            'summary' => 'This deletes Thing.',
             'description' => 'This deletes Thing.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],
@@ -355,7 +349,6 @@ RSpec.shared_context 'representable swagger example' do
         },
         '/thing2' => {
           'get' => {
-            'summary' => 'This gets Things.',
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
@@ -365,7 +358,6 @@ RSpec.shared_context 'representable swagger example' do
         },
         '/dummy/{id}' => {
           'delete' => {
-            'summary' => 'dummy route.',
             'description' => 'dummy route.',
             'produces' => ['application/json'],
             'parameters' => [{ 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true }],

--- a/spec/swagger_v2/api_swagger_v2_response_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_spec.rb
@@ -47,7 +47,6 @@ describe 'response' do
     end
     specify do
       expect(subject['paths']['/nested_type']['get']).to eql(
-        'summary' => 'This returns something',
         'description' => 'This returns something',
         'produces' => ['application/json'],
         'responses' => {
@@ -69,7 +68,6 @@ describe 'response' do
 
     specify do
       expect(subject['paths']['/entity_response']['get']).to eql(
-        'summary' => 'This returns something',
         'description' => 'This returns something',
         'produces' => ['application/json'],
         'responses' => {
@@ -91,7 +89,6 @@ describe 'response' do
 
     specify do
       expect(subject['paths']['/params_given']['post']).to eql(
-        'summary' => 'This returns something',
         'description' => 'This returns something',
         'produces' => ['application/json'],
         'consumes' => ['application/json'],

--- a/spec/swagger_v2/default_api_spec.rb
+++ b/spec/swagger_v2/default_api_spec.rb
@@ -31,7 +31,6 @@ describe 'Default API' do
         'paths' => {
           '/something' => {
             'get' => {
-              'summary' => 'This gets something.',
               'description' => 'This gets something.',
               'produces' => ['application/json'],
               'tags' => ['something'],
@@ -78,7 +77,6 @@ describe 'Default API' do
                             'paths' => {
                               '/something' => {
                                 'get' => {
-                                  'summary' => 'This gets something.',
                                   'description' => 'This gets something.',
                                   'produces' => ['application/json'],
                                   'tags' => ['something'],

--- a/spec/swagger_v2/guarded_endpoint_spec.rb
+++ b/spec/swagger_v2/guarded_endpoint_spec.rb
@@ -83,7 +83,6 @@ describe 'a guarded api endpoint' do
         'paths' => {
           '/auth' => {
             'get' => {
-              'summary' => 'Show endpoint if authenticated',
               'description' => 'Show endpoint if authenticated',
               'produces' => ['application/json'],
               'tags' => ['auth'],

--- a/spec/swagger_v2/hide_api_spec.rb
+++ b/spec/swagger_v2/hide_api_spec.rb
@@ -52,7 +52,6 @@ describe 'a hide mounted api' do
       'paths' => {
         '/simple' => {
           'get' => {
-            'summary' => 'Show this endpoint',
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
             'tags' => ['simple'],
@@ -62,7 +61,6 @@ describe 'a hide mounted api' do
         },
         '/lazy' => {
           'get' => {
-            'summary' => 'Lazily show endpoint',
             'description' => 'Lazily show endpoint',
             'produces' => ['application/json'],
             'tags' => ['lazy'],
@@ -115,7 +113,6 @@ describe 'a hide mounted api with same namespace' do
       'paths' => {
         '/simple/show' => {
           'get' => {
-            'summary' => 'Show this endpoint',
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
             'operationId' => 'getSimpleShow',
@@ -137,7 +134,6 @@ describe 'a hide mounted api with same namespace' do
       'paths' => {
         '/simple/show' => {
           'get' => {
-            'summary' => 'Show this endpoint',
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
             'tags' => ['simple'],

--- a/spec/swagger_v2/mount_override_api_spec.rb
+++ b/spec/swagger_v2/mount_override_api_spec.rb
@@ -50,7 +50,6 @@ describe 'mount override api' do
     end
 
     it 'shows documentation from new endpoint' do
-      expect(subject['summary']).to eql('new endpoint')
       expect(subject['parameters'][0]['description']).to eql('new param')
       expect(subject['parameters'][0]['type']).to eql('string')
       expect(subject['responses']['200']['description']).to eql('new message')

--- a/spec/swagger_v2/mounted_target_class_spec.rb
+++ b/spec/swagger_v2/mounted_target_class_spec.rb
@@ -39,7 +39,6 @@ describe 'docs mounted separately from api' do
       'paths' => {
         '/simple' => {
           'get' => {
-            'summary' => 'This gets something.',
             'description' => 'This gets something.',
             'produces' => ['application/json'],
             'responses' => { '200' => { 'description' => 'This gets something.' } },
@@ -62,7 +61,6 @@ describe 'docs mounted separately from api' do
       'paths' => {
         '/simple' => {
           'get' => {
-            'summary' => 'This gets something.',
             'description' => 'This gets something.',
             'produces' => ['application/json'],
             'responses' => {

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -102,7 +102,6 @@ describe 'a simple mounted api' do
         'paths' => {
           '/' => {
             'get' => {
-              'summary' => 'Document root',
               'description' => 'Document root',
               'produces' => ['application/json'],
               'responses' => { '200' => { 'description' => 'Document root' } },
@@ -111,7 +110,6 @@ describe 'a simple mounted api' do
           },
           '/simple' => {
             'get' => {
-              'summary' => 'This gets something.',
               'description' => 'This gets something.',
               'produces' => ['application/json'],
               'tags' => ['simple'],
@@ -121,7 +119,6 @@ describe 'a simple mounted api' do
           },
           '/simple-test' => {
             'get' => {
-              'summary' => 'This gets something for URL using - separator.',
               'description' => 'This gets something for URL using - separator.',
               'produces' => ['application/json'],
               'tags' => ['simple-test'],
@@ -147,7 +144,6 @@ describe 'a simple mounted api' do
           },
           '/simple_with_headers' => {
             'get' => {
-              'summary' => 'this gets something else',
               'description' => 'this gets something else',
               'produces' => ['application/json'],
               'parameters' => [
@@ -165,7 +161,6 @@ describe 'a simple mounted api' do
           },
           '/items' => {
             'post' => {
-              'summary' => 'this takes an array of parameters',
               'description' => 'this takes an array of parameters',
               'produces' => ['application/json'],
               'consumes' => ['application/json'],
@@ -177,7 +172,6 @@ describe 'a simple mounted api' do
           },
           '/custom' => {
             'get' => {
-              'summary' => 'this uses a custom parameter',
               'description' => 'this uses a custom parameter',
               'produces' => ['application/json'],
               'parameters' => [{ 'in' => 'formData', 'name' => 'custom', 'description' => 'array of items', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'CustomType' } }],
@@ -209,7 +203,6 @@ describe 'a simple mounted api' do
         'paths' => {
           '/simple' => {
             'get' => {
-              'summary' => 'This gets something.',
               'description' => 'This gets something.',
               'produces' => ['application/json'],
               'tags' => ['simple'],
@@ -241,7 +234,6 @@ describe 'a simple mounted api' do
           'paths' => {
             '/simple-test' => {
               'get' => {
-                'summary' => 'This gets something for URL using - separator.',
                 'description' => 'This gets something for URL using - separator.',
                 'produces' => ['application/json'],
                 'tags' => ['simple-test'],
@@ -264,7 +256,6 @@ describe 'a simple mounted api' do
         expect(subject['paths']).to eq(
           '/simple_with_headers' => {
             'get' => {
-              'summary' => 'this gets something else',
               'description' => 'this gets something else',
               'produces' => ['application/json'],
               'parameters' => [
@@ -294,7 +285,6 @@ describe 'a simple mounted api' do
         expect(subject['paths']).to eq(
           '/items' => {
             'post' => {
-              'summary' => 'this takes an array of parameters',
               'description' => 'this takes an array of parameters',
               'produces' => ['application/json'],
               'consumes' => ['application/json'],
@@ -318,7 +308,6 @@ describe 'a simple mounted api' do
         expect(subject['paths']).to eq(
           '/custom' => {
             'get' => {
-              'summary' => 'this uses a custom parameter',
               'description' => 'this uses a custom parameter',
               'produces' => ['application/json'],
               'parameters' => [{ 'in' => 'formData', 'name' => 'custom', 'description' => 'array of items', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'CustomType' } }],


### PR DESCRIPTION
Resolves #661

Currently if no summary is provided, grape-swagger uses the description.
This creates needless duplicate fields. As summary is an optional field
this changes functionality so summary is only populated if specifically
needed.

Reference https://swagger.io/specification/