### PR TITLE
Fix handling of HTTP status codes from routes

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -21,7 +21,7 @@ Metrics/AbcSize:
 # Offense count: 3
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 283
+  Max: 287
 
 # Offense count: 10
 Metrics/CyclomaticComplexity:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 #### Fixes
 
 * [#664](https://github.com/ruby-grape/grape-swagger/pull/662): Removed all references to obsolete `hide_format` parameter - [@jonmchan](https://github.com/jonmchan).
+* [#669](https://github.com/ruby-grape/grape-swagger/pull/669): Fix handling of http status codes from routes - [@milgner](https://github.com/milgner).
 
 ### 0.28.0 (February 3, 2018)
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -224,8 +224,13 @@ module Grape
       end
     end
 
+    def success_code?(code)
+      status = code.is_a?(Array) ? code.first : code[:code]
+      status.between?(200, 299)
+    end
+
     def http_codes_from_route(route)
-      if route.http_codes.is_a?(Array) && route.http_codes.any? { |code| code[:code].between?(200, 299) }
+      if route.http_codes.is_a?(Array) && route.http_codes.any? { |code| success_code?(code) }
         route.http_codes.clone
       else
         success_codes_from_route(route) + (route.http_codes || route.options[:failure] || [])

--- a/spec/swagger_v2/api_swagger_v2_status_codes_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_status_codes_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-describe 'http status code behaivours' do
+describe 'http status code behaviours' do
   include_context "#{MODEL_PARSER} swagger example"
 
   subject do
@@ -10,7 +10,7 @@ describe 'http status code behaivours' do
     JSON.parse(last_response.body)
   end
 
-  context 'when non-default success codes are deifined' do
+  context 'when non-default success codes are defined' do
     let(:app) do
       Class.new(Grape::API) do
         desc 'Has explicit success http_codes defined' do
@@ -28,6 +28,26 @@ describe 'http status code behaivours' do
 
     it 'only includes the defined http_codes' do
       expect(subject['paths']['/accepting_endpoint']['post']['responses'].keys.sort).to eq(%w[202 204 400].sort)
+    end
+  end
+
+  context 'when success and failures are defined' do
+    let(:app) do
+      Class.new(Grape::API) do
+        desc 'Has explicit success http_codes defined' do
+          success code: 202, model: Entities::UseResponse, message: 'a changed status code'
+          failure [[400, 'Bad Request']]
+        end
+
+        post '/accepting_endpoint' do
+          'We got the message!'
+        end
+        add_swagger_documentation
+      end
+    end
+
+    it 'only includes the defined http codes' do
+      expect(subject['paths']['/accepting_endpoint']['post']['responses'].keys.sort).to eq(%w[202 400].sort)
     end
   end
 


### PR DESCRIPTION
After updating Grape, the documentation could not be generated anymore.

Upon investigation it turned out that the HTTP codes were not stored in a hash (anymore) but as a two-element array with the status code first and a message second. After applying this patch, documentation was generated successfully again.