### PR TITLE
Add response examples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#667](https://github.com/ruby-grape/grape-swagger/pull/667): Make route summary optional - [@obduk](https://github.com/obduk).
 * [#670](https://github.com/ruby-grape/grape-swagger/pull/670): Add support for deprecated field - [@ioanatia](https://github.com/ioanatia).
+* [#675](https://github.com/ruby-grape/grape-swagger/pull/675): Add response examples - [@gamartin](https://github.com/gamartin).
 
 * Your contribution here.
 

--- a/README.md
+++ b/README.md
@@ -1015,6 +1015,59 @@ route_setting :x_def, [{ for: 422, other: 'stuff' }, { for: 200, some: 'stuff' }
 ```
 
 
+#### Response examples documentation <a name="response-examples" />
+
+You can also add examples to your responses by using the `desc` DSL with block syntax.
+
+By specifying examples to `success` and `failure`.
+
+```ruby
+desc 'This returns examples' do
+  success model: Entities::UseResponse, examples: { 'application/json' => { description: 'Names list', items: [{ id: '123', name: 'John' }] } }
+  failure [[404, 'NotFound', Entities::ApiError, { 'application/json' => { code: 404, message: 'Not found' } }]]
+end
+get '/response_examples' do
+  ...
+end
+```
+
+The result will look like following:
+
+```json
+  "responses": {
+    "200": {
+      "description": "This returns examples",
+      "schema": {
+        "$ref": "#/definitions/UseResponse"
+      },
+      "examples": {
+        "application/json": {
+          "description": "Names list",
+          "items": [
+            {
+              "id": "123",
+              "name": "John"
+            }
+          ]
+        }
+      }
+    },
+    "404": {
+      "description": "NotFound",
+      "schema": {
+        "$ref": "#/definitions/ApiError"
+      },
+      "examples": {
+        "application/json": {
+          "code": 404,
+          "message": "Not found"
+        }
+      }
+    }
+  }
+```
+
+
 
 ## Using Grape Entities <a name="grape-entity" />
 

--- a/README.md
+++ b/README.md
@@ -1023,10 +1023,10 @@ By specifying examples to `success` and `failure`.
 
 ```ruby
 desc 'This returns examples' do
-  success model: Entities::UseResponse, examples: { 'application/json' => { description: 'Names list', items: [{ id: '123', name: 'John' }] } }
-  failure [[404, 'NotFound', Entities::ApiError, { 'application/json' => { code: 404, message: 'Not found' } }]]
+  success model: Thing, examples: { 'application/json' => { description: 'Names list', items: [{ id: '123', name: 'John' }] } }
+  failure [[404, 'NotFound', ApiError, { 'application/json' => { code: 404, message: 'Not found' } }]]
 end
-get '/response_examples' do
+get '/thing' do
   ...
 end
 ```
@@ -1038,7 +1038,7 @@ The result will look like following:
     "200": {
       "description": "This returns examples",
       "schema": {
-        "$ref": "#/definitions/UseResponse"
+        "$ref": "#/definitions/Thing"
       },
       "examples": {
         "application/json": {

--- a/README.md
+++ b/README.md
@@ -1067,6 +1067,7 @@ The result will look like following:
   }
 ```
 
+Failure information can be passed as an array of arrays or an array of hashes.
 
 
 ## Using Grape Entities <a name="grape-entity" />
@@ -1222,7 +1223,7 @@ The guard method should inject the Security Requirement Object into the endpoint
 The 'oauth2 false' added to swagger_documentation is making the main Swagger endpoint protected with OAuth, i.e. the
 access_token is being retreiving from the HTTP request, but the 'false' scope is for skipping authorization and
 showing the UI for everyone. If the scope would be set to something else, like 'oauth2 admin', for example, than the UI
- wouldn't be displayed at all to unauthorized users.  
+ wouldn't be displayed at all to unauthorized users.
 
 Further on, the guard could be used, where necessary, for endpoint access protection. Put it prior to the endpoint's method:
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -195,7 +195,7 @@ module Grape
 
     def response_object(route)
       codes = http_codes_from_route(route)
-      codes.map! { |x| x.is_a?(Array) ? { code: x[0], message: x[1], model: x[2] } : x }
+      codes.map! { |x| x.is_a?(Array) ? { code: x[0], message: x[1], model: x[2], examples: x[3] } : x }
 
       codes.each_with_object({}) do |value, memo|
         value[:message] ||= ''
@@ -221,6 +221,8 @@ module Grape
                                       else
                                         reference
                                       end
+
+        memo[value[:code]][:examples] = value[:examples] if value[:examples]
       end
     end
 
@@ -243,6 +245,7 @@ module Grape
         default_code[:code] = @entity[:code] if @entity[:code].present?
         default_code[:model] = @entity[:model] if @entity[:model].present?
         default_code[:message] = @entity[:message] || route.description || default_code[:message].sub('{item}', @item)
+        default_code[:examples] = @entity[:examples] if @entity[:examples]
       else
         default_code = GrapeSwagger::DocMethods::StatusCodes.get[route.request_method.downcase.to_sym]
         default_code[:model] = @entity if @entity

--- a/spec/swagger_v2/api_swagger_v2_response_with_examples_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_with_examples_spec.rb
@@ -18,6 +18,27 @@ describe 'response with examples' do
           { 'declared_params' => declared(params) }
         end
 
+        desc 'This syntax also returns examples' do
+          success model: Entities::UseResponse, examples: { 'application/json' => { description: 'Names list', items: [{ id: '123', name: 'John' }] } }
+          failure [
+            {
+              code: 404,
+              message: 'NotFound',
+              model: Entities::ApiError,
+              examples: { 'application/json' => { code: 404, message: 'Not found' } }
+            },
+            {
+              code: 400,
+              message: 'BadRequest',
+              model: Entities::ApiError,
+              examples: { 'application/json' => { code: 400, message: 'Bad Request' } }
+            }
+          ]
+        end
+        get '/response_failure_examples' do
+          { 'declared_params' => declared(params) }
+        end
+
         desc 'This does not return examples' do
           success model: Entities::UseResponse
           failure [[404, 'NotFound', Entities::ApiError]]
@@ -57,6 +78,37 @@ describe 'response with examples' do
         },
         'tags' => ['response_examples'],
         'operationId' => 'getResponseExamples'
+      )
+    end
+  end
+
+  describe 'response failure examples' do
+    let(:example_200) do
+      { 'application/json' => { 'description' => 'Names list', 'items' => [{ 'id' => '123', 'name' => 'John' }] } }
+    end
+    let(:example_404) do
+      { 'application/json' => { 'code' => 404, 'message' => 'Not found' } }
+    end
+    let(:example_400) do
+      { 'application/json' => { 'code' => 400, 'message' => 'Bad Request' } }
+    end
+
+    subject do
+      get '/swagger_doc/response_failure_examples'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/response_failure_examples']['get']).to eql(
+        'description' => 'This syntax also returns examples',
+        'produces' => ['application/json'],
+        'responses' => {
+          '200' => { 'description' => 'This syntax also returns examples', 'schema' => { '$ref' => '#/definitions/UseResponse' }, 'examples' => example_200 },
+          '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => example_404 },
+          '400' => { 'description' => 'BadRequest', 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => example_400 }
+        },
+        'tags' => ['response_failure_examples'],
+        'operationId' => 'getResponseFailureExamples'
       )
     end
   end

--- a/spec/swagger_v2/api_swagger_v2_response_with_examples_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_with_examples_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'response with examples' do
+  include_context "#{MODEL_PARSER} swagger example"
+
+  before :all do
+    module TheApi
+      class ResponseApiExamples < Grape::API
+        format :json
+
+        desc 'This returns examples' do
+          success model: Entities::UseResponse, examples: { 'application/json' => { description: 'Names list', items: [{ id: '123', name: 'John' }] } }
+          failure [[404, 'NotFound', Entities::ApiError, { 'application/json' => { code: 404, message: 'Not found' } }]]
+        end
+        get '/response_examples' do
+          { 'declared_params' => declared(params) }
+        end
+
+        add_swagger_documentation
+      end
+    end
+  end
+
+  def app
+    TheApi::ResponseApiExamples
+  end
+
+  describe 'response examples' do
+    let(:example_200) do
+      { 'application/json' => { 'description' => 'Names list', 'items' => [{ 'id' => '123', 'name' => 'John' }] } }
+    end
+    let(:example_404) do
+      { 'application/json' => { 'code' => 404, 'message' => 'Not found' } }
+    end
+
+    subject do
+      get '/swagger_doc/response_examples'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/response_examples']['get']).to eql(
+        'description' => 'This returns examples',
+        'produces' => ['application/json'],
+        'responses' => {
+          '200' => { 'description' => 'This returns examples', 'schema' => { '$ref' => '#/definitions/UseResponse' }, 'examples' => example_200 },
+          '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => example_404 }
+        },
+        'tags' => ['response_examples'],
+        'operationId' => 'getResponseExamples'
+      )
+    end
+  end
+end

--- a/spec/swagger_v2/api_swagger_v2_response_with_examples_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_with_examples_spec.rb
@@ -18,6 +18,13 @@ describe 'response with examples' do
           { 'declared_params' => declared(params) }
         end
 
+        desc 'This does not return examples' do
+          success model: Entities::UseResponse
+          failure [[404, 'NotFound', Entities::ApiError]]
+        end
+        get '/response_no_examples' do
+          { 'declared_params' => declared(params) }
+        end
         add_swagger_documentation
       end
     end
@@ -50,6 +57,26 @@ describe 'response with examples' do
         },
         'tags' => ['response_examples'],
         'operationId' => 'getResponseExamples'
+      )
+    end
+  end
+
+  describe 'response no examples' do
+    subject do
+      get '/swagger_doc/response_no_examples'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/response_no_examples']['get']).to eql(
+        'description' => 'This does not return examples',
+        'produces' => ['application/json'],
+        'responses' => {
+          '200' => { 'description' => 'This does not return examples', 'schema' => { '$ref' => '#/definitions/UseResponse' } },
+          '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' } }
+        },
+        'tags' => ['response_no_examples'],
+        'operationId' => 'getResponseNoExamples'
       )
     end
   end


### PR DESCRIPTION
Added support to expose [response examples](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#exampleObject)

* Available only with `desc` DSL block syntax.
* Consumer is responsible for generating the example