### PR TITLE
Allow response headers for responses with no content and for files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#686](https://github.com/ruby-grape/grape-swagger/pull/686): Allow response headers for responses with no content and for files - [@jdmurphy](https://github.com/jdmurphy).
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -200,6 +200,9 @@ module Grape
       codes.each_with_object({}) do |value, memo|
         value[:message] ||= ''
         memo[value[:code]] = { description: value[:message] }
+
+        memo[value[:code]][:headers] = value[:headers] if value[:headers]
+
         next build_file_response(memo[value[:code]]) if file_response?(value[:model])
 
         response_model = @item
@@ -217,7 +220,6 @@ module Grape
 
         memo[value[:code]][:schema] = build_reference(route, value, response_model)
         memo[value[:code]][:examples] = value[:examples] if value[:examples]
-        memo[value[:code]][:headers] = value[:headers] if value[:headers]
       end
     end
 

--- a/spec/swagger_v2/api_swagger_v2_response_with_headers_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_with_headers_spec.rb
@@ -18,6 +18,22 @@ describe 'response with headers' do
           { 'declared_params' => declared(params) }
         end
 
+        desc 'A 204 can have headers too' do
+          success Hash[status: 204, message: 'No content', headers: { 'Location' => { description: 'Location of resource', type: 'string' } }]
+          failure [[400, 'Bad Request', Entities::ApiError, { 'application/json' => { code: 400, message: 'Bad request' } }, { 'Date' => { description: 'Date of failure', type: 'string' } }]]
+        end
+        delete '/no_content_response_headers' do
+          { 'declared_params' => declared(params) }
+        end
+
+        desc 'A file can have headers too' do
+          success Hash[status: 200, model: 'File', headers: { 'Cache-Control' => { description: 'Directive for caching', type: 'string' } }]
+          failure [[404, 'NotFound', Entities::ApiError, { 'application/json' => { code: 404, message: 'Not found' } }, { 'Date' => { description: 'Date of failure', type: 'string' } }]]
+        end
+        get '/file_response_headers' do
+          { 'declared_params' => declared(params) }
+        end
+
         desc 'This syntax also returns headers' do
           success model: Entities::UseResponse, headers: { 'Location' => { description: 'Location of resource', type: 'string' } }
           failure [
@@ -81,6 +97,66 @@ describe 'response with headers' do
         },
         'tags' => ['response_headers'],
         'operationId' => 'getResponseHeaders'
+      )
+    end
+  end
+
+  describe 'no content response headers' do
+    let(:header_204) do
+      { 'Location' => { 'description' => 'Location of resource', 'type' => 'string' } }
+    end
+    let(:header_400) do
+      { 'Date' => { 'description' => 'Date of failure', 'type' => 'string' } }
+    end
+    let(:examples_400) do
+      { 'application/json' => { 'code' => 400, 'message' => 'Bad request' } }
+    end
+
+    subject do
+      get '/swagger_doc/no_content_response_headers', {}
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/no_content_response_headers']['delete']).to eql(
+        'description' => 'A 204 can have headers too',
+        'produces' => ['application/json'],
+        'responses' => {
+          '204' => { 'description' => 'No content', 'headers' => header_204 },
+          '400' => { 'description' => 'Bad Request', 'headers' => header_400, 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => examples_400 }
+        },
+        'tags' => ['no_content_response_headers'],
+        'operationId' => 'deleteNoContentResponseHeaders'
+      )
+    end
+  end
+
+  describe 'file response headers' do
+    let(:header_200) do
+      { 'Cache-Control' => { 'description' => 'Directive for caching', 'type' => 'string' } }
+    end
+    let(:header_404) do
+      { 'Date' => { 'description' => 'Date of failure', 'type' => 'string' } }
+    end
+    let(:examples_404) do
+      { 'application/json' => { 'code' => 404, 'message' => 'Not found' } }
+    end
+
+    subject do
+      get '/swagger_doc/file_response_headers'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/file_response_headers']['get']).to eql(
+        'description' => 'A file can have headers too',
+        'produces' => ['application/json'],
+        'responses' => {
+          '200' => { 'description' => 'A file can have headers too', 'headers' => header_200, 'schema' => { 'type' => 'file' } },
+          '404' => { 'description' => 'NotFound', 'headers' => header_404, 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => examples_404 }
+        },
+        'tags' => ['file_response_headers'],
+        'operationId' => 'getFileResponseHeaders'
       )
     end
   end


### PR DESCRIPTION
@LeFnord, sorry for the quick turnaround. I realized that my original pull request for allowing documenting of response headers #684, was too limited and didn't allow documenting response headers for 204s, or files, due to the some of the breaks while creating a response object.

This update allows response headers to be documented for:
* 204 no content
* file responses
* responses without a model specified