### PR TITLE
Deep merge params for definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#688](https://github.com/ruby-grape/grape-swagger/pull/688): Use deep merge for nested parameter definitions - [@jdmurphy](https://github.com/jdmurphy).
 * Your contribution here.
 
 ###  0.30.1 (July 19, 2018)

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'active_support/core_ext/hash/deep_merge'
+
 module GrapeSwagger
   module DocMethods
     class MoveParams
@@ -114,11 +116,11 @@ module GrapeSwagger
 
         def recursive_call(properties, property, nested_params)
           if should_expose_as_array?(nested_params)
-            properties[property] = array_type
-            move_params_to_new(properties[property][:items], nested_params)
+            properties[property.to_sym] = array_type
+            move_params_to_new(properties[property.to_sym][:items], nested_params)
           else
-            properties[property] = object_type
-            move_params_to_new(properties[property], nested_params)
+            properties[property.to_sym] = object_type
+            move_params_to_new(properties[property.to_sym], nested_params)
           end
         end
 
@@ -135,10 +137,10 @@ module GrapeSwagger
 
         def add_properties_to_definition(definition, properties, required)
           if definition.key?(:items)
-            definition[:items][:properties].merge!(properties)
+            definition[:items][:properties].deep_merge!(properties)
             add_to_required(definition[:items], required)
           else
-            definition[:properties].merge!(properties)
+            definition[:properties].deep_merge!(properties)
             add_to_required(definition, required)
           end
         end

--- a/spec/lib/move_params_spec.rb
+++ b/spec/lib/move_params_spec.rb
@@ -513,5 +513,180 @@ describe GrapeSwagger::DocMethods::MoveParams do
         end
       end
     end
+
+    describe 'recursive_call' do
+      before :each do
+        subject.send(:recursive_call, properties, 'test', nested_params)
+      end
+
+      let(:properties) { {} }
+
+      context 'when nested params is an array' do
+        let(:nested_params) do
+          [
+            {
+              in: 'body',
+              name: 'aliases',
+              description: 'The aliases of test.',
+              type: 'array',
+              items: { type: 'string' },
+              required: true
+            }
+          ]
+        end
+
+        let(:expected_properties) do
+          {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                aliases: {
+                  type: 'string',
+                  description: 'The aliases of test.'
+                }
+              },
+              required: [:aliases]
+            }
+          }
+        end
+
+        it 'adds property as symbol with array type and items' do
+          expect(properties[:test]).to eq expected_properties
+        end
+      end
+
+      context 'when nested params is not an array' do
+        let(:nested_params) do
+          [
+            {
+              in: 'body',
+              name: 'id',
+              description: 'The unique ID of test.',
+              type: 'string',
+              required: true
+            }
+          ]
+        end
+
+        let(:expected_properties) do
+          {
+            type: 'object',
+            required: [:id],
+            properties: {
+              id: {
+                type: 'string',
+                description: 'The unique ID of test.'
+              }
+            }
+          }
+        end
+
+        it 'adds property as symbol with object type' do
+          expect(properties[:test]).to eq expected_properties
+        end
+      end
+    end
+
+    describe 'add_properties_to_definition' do
+      before :each do
+        subject.send(:add_properties_to_definition, definition, properties, [])
+      end
+
+      context 'when definition has items key' do
+        let(:definition) do
+          {
+            type: 'array',
+            items:  {
+              type: 'object',
+              properties: {
+                description: 'Test description'
+              }
+            }
+          }
+        end
+
+        let(:properties) do
+          {
+            strings: {
+              type: 'string',
+              description: 'string elements'
+            }
+          }
+        end
+
+        let(:expected_definition) do
+          {
+            type: 'array',
+            items: {
+              type: 'object',
+              properties: {
+                description: 'Test description',
+                strings: {
+                  type: 'string',
+                  description: 'string elements'
+                }
+              }
+            }
+          }
+        end
+
+        it 'deep merges properties into definition item properties' do
+          expect(definition).to eq expected_definition
+        end
+      end
+
+      context 'when definition does not have items key' do
+        let(:definition) do
+          {
+            type: 'object',
+            properties: {
+              parent: {
+                type: 'object',
+                description: 'Parent to child'
+              }
+            }
+          }
+        end
+
+        let(:properties) do
+          {
+            parent: {
+              type: 'object',
+              properties: {
+                id: {
+                  type: 'string',
+                  description: 'Parent ID'
+                }
+              },
+              required: [:id]
+            }
+          }
+        end
+
+        let(:expected_definition) do
+          {
+            type: 'object',
+            properties: {
+              parent: {
+                type: 'object',
+                description: 'Parent to child',
+                properties: {
+                  id: {
+                    type: 'string',
+                    description: 'Parent ID'
+                  }
+                },
+                required: [:id]
+              }
+            }
+          }
+        end
+
+        it 'deep merges properties into definition properties' do
+          expect(definition).to eq expected_definition
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
I found that when using body params in PUT and POST, a nested entity in the params that has a description set at the entity level will not have that description in the OpenAPI spec output. For example given:
```
params do
  requires :spline, description: 'It is a spline', documentation: {param_type: 'body'}, type: Hash do
    requires :x, type: Numeric
    requires :y, type: Numeric
  end
  optional :reticulated, type: Boolean, default: true, desc: 'True if the spline is reticulated.'
end
```
a definition will be created (notice that the `spline` hash under properties has no description): 
```
"postSplines":{  
   "type":"object",
   "properties":{  
      "spline":{  
         "type":"object",
         "properties":{  
            "x":{  
               "type":"integer",
               "format":"int64"
            },
            "y":{  
               "type":"integer",
               "format":"int64"
            }
         },
         "required":[  
            "x",
            "y"
         ]
      },
      "reticulated":{  
         "type":"boolean",
         "description":"True if the spline is reticulated."
      }
   },
   "required":[  
      "spline"
   ],
   "description":"Create a spline."
 }
```

With my fix a deep merge occurs which maintains elements on the parent object when merging a nested element: (and the `description` of "It is a spline" is kept)
```
"postSplines":{  
   "type":"object",
   "properties":{  
      "spline":{  
         "type":"object",
         "description":"It is a spline",
         "properties":{  
            "x":{  
               "type":"integer",
               "format":"int64"
            },
            "y":{  
               "type":"integer",
               "format":"int64"
            }
         },
         "required":[  
            "x",
            "y"
         ]
      },
      "reticulated":{  
         "type":"boolean",
         "description":"True if the spline is reticulated."
      }
   },
   "required":[  
      "spline"
   ],
   "description":"Create a spline."
}
```

while looking into this I noticed that the `recursive_call` function was using the `property` parameter as a key without regard to its format which could lead to having string and symbols mixed together specifically when nested params are being evaluated (the nested param would be the string whereas every other element would be a symbol), so I added a call to `.to_sym` to ensure use of symbols throughout since we are using Hash and not HashWithIndifferentAccess.