### PR TITLE
Fix is_array check for non-contiguous sub and parent entities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * [#688](https://github.com/ruby-grape/grape-swagger/pull/688): Use deep merge for nested parameter definitions - [@jdmurphy](https://github.com/jdmurphy).
+* [#691](https://github.com/ruby-grape/grape-swagger/pull/691): Disregard order when parsing request params for arrays - [@jdmurphy](https://github.com/jdmurphy).
 * Your contribution here.
 
 ###  0.30.1 (July 19, 2018)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -306,13 +306,13 @@ module Grape
     end
 
     def parse_request_params(params)
-      array_key = nil
+      array_keys = []
       params.select { |param| public_parameter?(param) }.each_with_object({}) do |param, memo|
         name, options = *param
         param_type = options[:type]
         param_type = param_type.to_s unless param_type.nil?
-        array_key = name.to_s if param_type_is_array?(param_type)
-        options[:is_array] = true if array_key && name.start_with?(array_key)
+        array_keys << name.to_s if param_type_is_array?(param_type)
+        options[:is_array] = true if array_keys.any? { |key| name == key || name.start_with?(key + '[') }
         memo[name] = options unless %w[Hash Array].include?(param_type) && !options.key?(:documentation)
       end
     end

--- a/spec/lib/endpoint_spec.rb
+++ b/spec/lib/endpoint_spec.rb
@@ -7,19 +7,6 @@ describe Grape::Endpoint do
     described_class.new(Grape::Util::InheritableSetting.new, path: '/', method: :get)
   end
 
-  describe '#param_type_is_array?' do
-    it 'returns true if the value passed represents an array' do
-      expect(subject.send(:param_type_is_array?, 'Array')).to be_truthy
-      expect(subject.send(:param_type_is_array?, '[String]')).to be_truthy
-      expect(subject.send(:param_type_is_array?, 'Array[Integer]')).to be_truthy
-    end
-
-    it 'returns false if the value passed does not represent an array' do
-      expect(subject.send(:param_type_is_array?, 'String')).to be_falsey
-      expect(subject.send(:param_type_is_array?, '[String, Integer]')).to be_falsey
-    end
-  end
-
   describe '.content_types_for' do
     describe 'defined on target_class' do
       let(:own_json) { 'text/own-json' }
@@ -54,6 +41,123 @@ describe Grape::Endpoint do
           specify do
             expect(object).to eql %w[application/xml application/json text/plain]
           end
+        end
+      end
+    end
+  end
+
+  describe '#param_type_is_array?' do
+    it 'returns true if the value passed represents an array' do
+      expect(subject.send(:param_type_is_array?, 'Array')).to be_truthy
+      expect(subject.send(:param_type_is_array?, '[String]')).to be_truthy
+      expect(subject.send(:param_type_is_array?, 'Array[Integer]')).to be_truthy
+    end
+
+    it 'returns false if the value passed does not represent an array' do
+      expect(subject.send(:param_type_is_array?, 'String')).to be_falsey
+      expect(subject.send(:param_type_is_array?, '[String, Integer]')).to be_falsey
+    end
+  end
+
+  describe 'parse_request_params' do
+    before do
+      subject.send(:parse_request_params, params)
+    end
+
+    context 'when params do not contain an array' do
+      let(:params) do
+        [
+          ['id', { required: true, type: 'String' }],
+          ['description', { required: false, type: 'String' }]
+        ]
+      end
+
+      let(:expected_params) do
+        [
+          ['id', { required: true, type: 'String' }],
+          ['description', { required: false, type: 'String' }]
+        ]
+      end
+
+      it 'parses params correctly' do
+        expect(params).to eq expected_params
+      end
+    end
+
+    context 'when params contain a simple array' do
+      let(:params) do
+        [
+          ['id', { required: true, type: 'String' }],
+          ['description', { required: false, type: 'String' }],
+          ['stuffs', { required: true, type: 'Array[String]' }]
+        ]
+      end
+
+      let(:expected_params) do
+        [
+          ['id', { required: true, type: 'String' }],
+          ['description', { required: false, type: 'String' }],
+          ['stuffs', { required: true, type: 'Array[String]', is_array: true }]
+        ]
+      end
+
+      it 'parses params correctly and adds is_array to the array' do
+        expect(params).to eq expected_params
+      end
+    end
+
+    context 'when params contain a complex array' do
+      let(:params) do
+        [
+          ['id', { required: true, type: 'String' }],
+          ['description', { required: false, type: 'String' }],
+          ['stuffs', { required: true, type: 'Array' }],
+          ['stuffs[id]', { required: true, type: 'String' }]
+        ]
+      end
+
+      let(:expected_params) do
+        [
+          ['id', { required: true, type: 'String' }],
+          ['description', { required: false, type: 'String' }],
+          ['stuffs', { required: true, type: 'Array', is_array: true }],
+          ['stuffs[id]', { required: true, type: 'String', is_array: true }]
+        ]
+      end
+
+      it 'parses params correctly and adds is_array to the array and all elements' do
+        expect(params).to eq expected_params
+      end
+
+      context 'when array params are not contiguous with parent array' do
+        let(:params) do
+          [
+            ['id', { required: true, type: 'String' }],
+            ['description', { required: false, type: 'String' }],
+            ['stuffs', { required: true, type: 'Array' }],
+            ['stuffs[owners]', { required: true, type: 'Array' }],
+            ['stuffs[creators]', { required: true, type: 'Array' }],
+            ['stuffs[owners][id]', { required: true, type: 'String' }],
+            ['stuffs[creators][id]', { required: true, type: 'String' }],
+            ['stuffs_and_things', { required: true, type: 'String' }]
+          ]
+        end
+
+        let(:expected_params) do
+          [
+            ['id', { required: true, type: 'String' }],
+            ['description', { required: false, type: 'String' }],
+            ['stuffs', { required: true, type: 'Array', is_array: true }],
+            ['stuffs[owners]', { required: true, type: 'Array', is_array: true }],
+            ['stuffs[creators]', { required: true, type: 'Array', is_array: true }],
+            ['stuffs[owners][id]', { required: true, type: 'String', is_array: true }],
+            ['stuffs[creators][id]', { required: true, type: 'String', is_array: true }],
+            ['stuffs_and_things', { required: true, type: 'String' }]
+          ]
+        end
+
+        it 'parses params correctly and adds is_array to the array and all elements' do
+          expect(params).to eq expected_params
         end
       end
     end


### PR DESCRIPTION
While reviewing an API made with Grape, I noticed that an entity created for a POST request param body did not have the correct markings for array and object. In digging into the code, I found that the `parse_request_params` was dependent on the ordering of the params coming in. Specifically, since we initialize `array_key` [outside the loop](https://github.com/ruby-grape/grape-swagger/blob/v0.30.1/lib/grape-swagger/endpoint.rb#L309), and then set it [below](https://github.com/ruby-grape/grape-swagger/blob/v0.30.1/lib/grape-swagger/endpoint.rb#L314), it _should_ exist for elements of an array, but I found that my params were in an order that caused sub elements to not be by their parents. For example (from tests so that I don't have to leak my API internals):
```
[
  ['id', { required: true, type: 'String' }],
  ['description', { required: false, type: 'String' }],
  ['stuffs', { required: true, type: 'Array' }],
  ['stuffs[owners]', { required: true, type: 'Array' }],
  ['stuffs[creators]', { required: true, type: 'Array' }],
  ['stuffs[owners][id]', { required: true, type: 'String' }],
  ['stuffs[creators][id]', { required: true, type: 'String' }]
]
```
would be updated to (notice `'stuffs[owners][id]'`).
```
[
  ['id', { required: true, type: 'String' }],
  ['description', { required: false, type: 'String' }],
  ['stuffs', { required: true, type: 'Array', is_array: true }],
  ['stuffs[owners]', { required: true, type: 'Array', is_array: true }],
  ['stuffs[creators]', { required: true, type: 'Array', is_array: true }],
  ['stuffs[owners][id]', { required: true, type: 'String' }],
  ['stuffs[creators][id]', { required: true, type: 'String', is_array: true }]
]
```

I updated parse_request_params to keep all array keys and then see if the name of current param matches any of them exactly or matches any of the array keys with a `[` appended which would indicate it is a sub element.