### PR TITLE
Add grape-swagger-entity to develop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,6 +18,7 @@ gem ENV['MODEL_PARSER'] if ENV.key?('MODEL_PARSER')
 group :development, :test do
   gem 'bundler'
   gem 'grape-entity'
+  gem 'grape-swagger-entity'
   gem 'pry', platforms: [:mri]
   gem 'pry-byebug', platforms: [:mri]
   gem 'rack'
@@ -31,7 +32,6 @@ end
 
 group :test do
   gem 'coveralls', '~> 0.8', require: false
-  gem 'grape-swagger-entity'
   gem 'ruby-grape-danger', '~> 0.1.1', require: false
   gem 'simplecov', require: false
 end

--- a/example/config.ru
+++ b/example/config.ru
@@ -13,6 +13,7 @@ require './api/entities'
 
 class Base < Grape::API
   require 'grape-entity'
+  require 'grape-swagger-entity'
   require '../lib/grape-swagger'
   format :json
 


### PR DESCRIPTION
Problem:
1. Go into example directory and run it: `bundle exec rackup` 
1. Go to: http://localhost:9292/swagger_doc
1. Got `GrapeSwagger::Errors::UnregisteredParser: No parser registered for Splines.`

![screen shot 2018-08-07 at 9 02 12 pm](https://user-images.githubusercontent.com/5189060/43777731-45bfb576-9a86-11e8-839b-e88678b1aa16.png)

Propose solution:
Add model parser as described in [README](https://github.com/ruby-grape/grape-swagger#model-parsers-)
Add `grape-swagger-entity` gem in Gemfile and require it at `config.ru`.