### PR TITLE
Default in MoveParams#property_keys

### DIFF
--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -207,7 +207,7 @@ module GrapeSwagger
         end
 
         def property_keys
-          %i[type format description minimum maximum items enum]
+          %i[type format description minimum maximum items enum default]
         end
 
         def deletable?(param)


### PR DESCRIPTION
Basically the same PR as https://github.com/ruby-grape/grape-swagger/pull/630 only different key.

default property is already supported, but not when moved from params to definition