### PR TITLE
Add a fail spec for #705

### DIFF
--- a/spec/swagger_v2/api_swagger_v2_is_array_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_is_array_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'desc is_array option' do
+  let(:app) do
+    class User < Grape::Entity
+      expose :name
+    end
+    Class.new(Grape::API) do
+      namespace :hash do
+        desc 'Get users',
+             success: User,
+             is_array: true
+        get {}
+      end
+      namespace :block do
+        desc 'Get users' do
+          success User
+          is_array true
+        end
+        get {}
+      end
+
+      add_swagger_documentation format: :json
+    end
+  end
+
+  subject do
+    get '/swagger_doc'
+    JSON.parse(last_response.body)
+  end
+
+  def type_in_success_response_schema(style)
+    subject['paths']["/#{style}"]['get']['responses']['200']['schema']['type']
+  end
+
+  context 'in hash style' do
+    it { expect(type_in_success_response_schema('hash')).to eq 'array' }
+  end
+
+  context 'in block style' do
+    it { expect(type_in_success_response_schema('block')).to eq 'array' }
+  end
+end


### PR DESCRIPTION
Add a fail spec for #705 

```sh
Failures:

  1) desc is_array option in hash style
     Failure/Error: is_array true

     NoMethodError:
       undefined method `is_array' for #<#<Class:0x00007fc42dd0c660>:0x00007fc42dd07980>
       Did you mean?  is_a?
     # ./spec/issues/705_is_array_not_supported_in_desc_block_spec.rb:20:in `block (5 levels) in <top (required)>'
    ...
```

