### PR TITLE
Spec: rename an it clause to match test

### DIFF
--- a/spec/swagger_v2/api_swagger_v2_format-content_type_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_format-content_type_spec.rb
@@ -41,7 +41,7 @@ describe 'format, content_type' do
           { 'declared_params' => declared(params) }
         end
 
-        desc 'This uses produces for produces',
+        desc 'This uses consumes for consumes',
              failure: [{ code: 400, model: Entities::ApiError }],
              consumes: ['application/www_url_encoded'],
              entity: Entities::UseResponse


### PR DESCRIPTION
This PR edit fixes #715, by making the test descriptions tell a coherent story.