### PR TITLE
Allow empty security array for endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#729](https://github.com/ruby-grape/grape-swagger/pull/729): Allow empty security array for endpoints - [@fotos](https://github.com/fotos).
 
 ### 0.32.0 (November 26, 2018)
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -125,7 +125,7 @@ module Grape
       method[:tags]        = route.options.fetch(:tags, tag_object(route, path))
       method[:operationId] = GrapeSwagger::DocMethods::OperationId.build(route, path)
       method[:deprecated] = deprecated_object(route)
-      method.delete_if { |_, value| value.blank? }
+      method.delete_if { |_, value| value.nil? }
 
       [route.request_method.downcase.to_sym, method]
     end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -149,7 +149,6 @@ module Grape
     def description_object(route)
       description = route.description if route.description.present?
       description = route.options[:detail] if route.options.key?(:detail)
-      description ||= ''
 
       description
     end

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -279,6 +279,7 @@ RSpec.shared_context 'entity swagger example' do
           'get' => {
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
+            'parameters' => [],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
             'tags' => ['thing2'],
             'operationId' => 'getThing2'

--- a/spec/support/model_parsers/mock_parser.rb
+++ b/spec/support/model_parsers/mock_parser.rb
@@ -271,6 +271,7 @@ RSpec.shared_context 'mock swagger example' do
           'get' => {
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
+            'parameters' => [],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
             'tags' => ['thing2'],
             'operationId' => 'getThing2'

--- a/spec/support/model_parsers/representable_parser.rb
+++ b/spec/support/model_parsers/representable_parser.rb
@@ -351,6 +351,7 @@ RSpec.shared_context 'representable swagger example' do
           'get' => {
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
+            'parameters' => [],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
             'tags' => ['thing2'],
             'operationId' => 'getThing2'

--- a/spec/swagger_v2/api_swagger_v2_response_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_spec.rb
@@ -49,6 +49,7 @@ describe 'response' do
       expect(subject['paths']['/nested_type']['get']).to eql(
         'description' => 'This returns something',
         'produces' => ['application/json'],
+        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This returns something', 'schema' => { '$ref' => '#/definitions/UseItemResponseAsType' } },
           '400' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' } }
@@ -70,6 +71,7 @@ describe 'response' do
       expect(subject['paths']['/entity_response']['get']).to eql(
         'description' => 'This returns something',
         'produces' => ['application/json'],
+        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This returns something', 'schema' => { '$ref' => '#/definitions/UseResponse' } },
           '400' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' } }

--- a/spec/swagger_v2/api_swagger_v2_response_with_examples_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_with_examples_spec.rb
@@ -72,6 +72,7 @@ describe 'response with examples' do
       expect(subject['paths']['/response_examples']['get']).to eql(
         'description' => 'This returns examples',
         'produces' => ['application/json'],
+        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This returns examples', 'schema' => { '$ref' => '#/definitions/UseResponse' }, 'examples' => example_200 },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => example_404 }
@@ -102,6 +103,7 @@ describe 'response with examples' do
       expect(subject['paths']['/response_failure_examples']['get']).to eql(
         'description' => 'This syntax also returns examples',
         'produces' => ['application/json'],
+        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This syntax also returns examples', 'schema' => { '$ref' => '#/definitions/UseResponse' }, 'examples' => example_200 },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => example_404 },
@@ -123,6 +125,7 @@ describe 'response with examples' do
       expect(subject['paths']['/response_no_examples']['get']).to eql(
         'description' => 'This does not return examples',
         'produces' => ['application/json'],
+        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This does not return examples', 'schema' => { '$ref' => '#/definitions/UseResponse' } },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' } }

--- a/spec/swagger_v2/api_swagger_v2_response_with_headers_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_with_headers_spec.rb
@@ -91,6 +91,7 @@ describe 'response with headers' do
       expect(subject['paths']['/response_headers']['get']).to eql(
         'description' => 'This returns headers',
         'produces' => ['application/json'],
+        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This returns headers', 'schema' => { '$ref' => '#/definitions/UseResponse' }, 'headers' => header_200 },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => examples_404, 'headers' => header_404 }
@@ -121,6 +122,7 @@ describe 'response with headers' do
       expect(subject['paths']['/no_content_response_headers']['delete']).to eql(
         'description' => 'A 204 can have headers too',
         'produces' => ['application/json'],
+        'parameters' => [],
         'responses' => {
           '204' => { 'description' => 'No content', 'headers' => header_204 },
           '400' => { 'description' => 'Bad Request', 'headers' => header_400, 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => examples_400 }
@@ -151,6 +153,7 @@ describe 'response with headers' do
       expect(subject['paths']['/file_response_headers']['get']).to eql(
         'description' => 'A file can have headers too',
         'produces' => ['application/json'],
+        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'A file can have headers too', 'headers' => header_200, 'schema' => { 'type' => 'file' } },
           '404' => { 'description' => 'NotFound', 'headers' => header_404, 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => examples_404 }
@@ -181,6 +184,7 @@ describe 'response with headers' do
       expect(subject['paths']['/response_failure_headers']['get']).to eql(
         'description' => 'This syntax also returns headers',
         'produces' => ['application/json'],
+        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This syntax also returns headers', 'schema' => { '$ref' => '#/definitions/UseResponse' }, 'headers' => header_200 },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' }, 'headers' => header_404 },
@@ -202,6 +206,7 @@ describe 'response with headers' do
       expect(subject['paths']['/response_no_headers']['get']).to eql(
         'description' => 'This does not return headers',
         'produces' => ['application/json'],
+        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This does not return headers', 'schema' => { '$ref' => '#/definitions/UseResponse' } },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' } }

--- a/spec/swagger_v2/default_api_spec.rb
+++ b/spec/swagger_v2/default_api_spec.rb
@@ -33,6 +33,7 @@ describe 'Default API' do
             'get' => {
               'description' => 'This gets something.',
               'produces' => ['application/json'],
+              'parameters' => [],
               'tags' => ['something'],
               'operationId' => 'getSomething',
               'responses' => { '200' => { 'description' => 'This gets something.' } }
@@ -79,6 +80,7 @@ describe 'Default API' do
                                 'get' => {
                                   'description' => 'This gets something.',
                                   'produces' => ['application/json'],
+                                  'parameters' => [],
                                   'tags' => ['something'],
                                   'operationId' => 'getSomething',
                                   'responses' => { '200' => { 'description' => 'This gets something.' } }

--- a/spec/swagger_v2/guarded_endpoint_spec.rb
+++ b/spec/swagger_v2/guarded_endpoint_spec.rb
@@ -86,6 +86,7 @@ describe 'a guarded api endpoint' do
             'get' => {
               'description' => 'Show endpoint if authenticated',
               'produces' => ['application/json'],
+              'parameters' => [],
               'tags' => ['auth'],
               'operationId' => 'getAuth',
               'responses' => { '200' => { 'description' => 'Show endpoint if authenticated' } }

--- a/spec/swagger_v2/hide_api_spec.rb
+++ b/spec/swagger_v2/hide_api_spec.rb
@@ -54,6 +54,7 @@ describe 'a hide mounted api' do
           'get' => {
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
+            'parameters' => [],
             'tags' => ['simple'],
             'operationId' => 'getSimple',
             'responses' => { '200' => { 'description' => 'Show this endpoint' } }
@@ -63,6 +64,7 @@ describe 'a hide mounted api' do
           'get' => {
             'description' => 'Lazily show endpoint',
             'produces' => ['application/json'],
+            'parameters' => [],
             'tags' => ['lazy'],
             'operationId' => 'getLazy',
             'responses' => { '200' => { 'description' => 'Lazily show endpoint' } }
@@ -115,6 +117,7 @@ describe 'a hide mounted api with same namespace' do
           'get' => {
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
+            'parameters' => [],
             'operationId' => 'getSimpleShow',
             'tags' => ['simple'], 'responses' => { '200' => { 'description' => 'Show this endpoint' } }
           }
@@ -136,6 +139,7 @@ describe 'a hide mounted api with same namespace' do
           'get' => {
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
+            'parameters' => [],
             'tags' => ['simple'],
             'operationId' => 'getSimpleShow',
             'responses' => { '200' => { 'description' => 'Show this endpoint' } }

--- a/spec/swagger_v2/mounted_target_class_spec.rb
+++ b/spec/swagger_v2/mounted_target_class_spec.rb
@@ -41,6 +41,7 @@ describe 'docs mounted separately from api' do
           'get' => {
             'description' => 'This gets something.',
             'produces' => ['application/json'],
+            'parameters' => [],
             'responses' => { '200' => { 'description' => 'This gets something.' } },
             'tags' => ['simple'],
             'operationId' => 'getSimple'
@@ -63,6 +64,7 @@ describe 'docs mounted separately from api' do
           'get' => {
             'description' => 'This gets something.',
             'produces' => ['application/json'],
+            'parameters' => [],
             'responses' => {
               '200' => { 'description' => 'This gets something.' }
             },

--- a/spec/swagger_v2/security_requirement_spec.rb
+++ b/spec/swagger_v2/security_requirement_spec.rb
@@ -10,7 +10,24 @@ describe 'security requirement on endpoint method' do
         { foo: 'bar' }
       end
 
-      add_swagger_documentation
+      desc 'Endpoint without security requirement', security: []
+      get '/without_security' do
+        { foo: 'bar' }
+      end
+
+      add_swagger_documentation(
+        security_definitions: {
+          petstore_auth: {
+            type: 'oauth2',
+            flow: 'implicit',
+            authorizationUrl: 'https://petstore.swagger.io/oauth/dialog',
+            scopes: {
+              'read:pets': 'read your pets',
+              'write:pets': 'modify pets in your account'
+            }
+          }
+        }
+      )
     end
   end
 
@@ -21,5 +38,9 @@ describe 'security requirement on endpoint method' do
 
   it 'defines the security requirement on the endpoint method' do
     expect(subject['paths']['/with_security']['get']['security']).to eql ['oauth_pets' => ['read:pets', 'write:pets']]
+  end
+
+  it 'defines an empty security requirement on the endpoint method' do
+    expect(subject['paths']['/without_security']['get']['security']).to eql []
   end
 end

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -104,6 +104,8 @@ describe 'a simple mounted api' do
             'get' => {
               'description' => 'Document root',
               'produces' => ['application/json'],
+              'parameters' => [],
+              'tags' => [],
               'responses' => { '200' => { 'description' => 'Document root' } },
               'operationId' => 'get'
             }
@@ -112,6 +114,7 @@ describe 'a simple mounted api' do
             'get' => {
               'description' => 'This gets something.',
               'produces' => ['application/json'],
+              'parameters' => [],
               'tags' => ['simple'],
               'operationId' => 'getSimple',
               'responses' => { '200' => { 'description' => 'This gets something.' } }
@@ -121,6 +124,7 @@ describe 'a simple mounted api' do
             'get' => {
               'description' => 'This gets something for URL using - separator.',
               'produces' => ['application/json'],
+              'parameters' => [],
               'tags' => ['simple-test'],
               'operationId' => 'getSimpleTest',
               'responses' => { '200' => { 'description' => 'This gets something for URL using - separator.' } }
@@ -128,7 +132,9 @@ describe 'a simple mounted api' do
           },
           '/simple-head-test' => {
             'head' => {
+              'description' => '',
               'produces' => ['application/json'],
+              'parameters' => [],
               'responses' => { '200' => { 'description' => 'head SimpleHeadTest' } },
               'tags' => ['simple-head-test'],
               'operationId' => 'headSimpleHeadTest'
@@ -136,7 +142,9 @@ describe 'a simple mounted api' do
           },
           '/simple-options-test' => {
             'options' => {
+              'description' => '',
               'produces' => ['application/json'],
+              'parameters' => [],
               'responses' => { '200' => { 'description' => 'option SimpleOptionsTest' } },
               'tags' => ['simple-options-test'],
               'operationId' => 'optionsSimpleOptionsTest'
@@ -205,6 +213,7 @@ describe 'a simple mounted api' do
             'get' => {
               'description' => 'This gets something.',
               'produces' => ['application/json'],
+              'parameters' => [],
               'tags' => ['simple'],
               'operationId' => 'getSimple',
               'responses' => { '200' => { 'description' => 'This gets something.' } }
@@ -236,6 +245,7 @@ describe 'a simple mounted api' do
               'get' => {
                 'description' => 'This gets something for URL using - separator.',
                 'produces' => ['application/json'],
+                'parameters' => [],
                 'tags' => ['simple-test'],
                 'operationId' => 'getSimpleTest',
                 'responses' => { '200' => { 'description' => 'This gets something for URL using - separator.' } }

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -132,7 +132,6 @@ describe 'a simple mounted api' do
           },
           '/simple-head-test' => {
             'head' => {
-              'description' => '',
               'produces' => ['application/json'],
               'parameters' => [],
               'responses' => { '200' => { 'description' => 'head SimpleHeadTest' } },
@@ -142,7 +141,6 @@ describe 'a simple mounted api' do
           },
           '/simple-options-test' => {
             'options' => {
-              'description' => '',
               'produces' => ['application/json'],
               'parameters' => [],
               'responses' => { '200' => { 'description' => 'option SimpleOptionsTest' } },


### PR DESCRIPTION
Fixes a bug where empty arrays for endpoints (operations) are excluded from the generated schema.

The [OpenAPI 2.0 spec for `security`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#swagger-object):

> A declaration of which security schemes are applied for the API as a whole. The list of values describes alternative security schemes that can be used (that is, there is a logical OR between the security requirements). **Individual operations can override this definition.**

This is useful in the following scenario:

You define a top level `security` requirement (e.g. `OAuth2`) that applies to the whole API and then selectively whitelist endpoints that are public.

For example:

```
securityDefinitions:
  oauth:
    type: oauth2
    flow: password
    tokenUrl: 'http://127.0.0.1/oauth/token'
    scopes:
      read: Grants read access
      write: Grants write access
security:
  - oauth:
      - read

paths:
  /users:
    post:
      summary: Create User
      security: []
```

Which renders like this in `Swagger UI`:

<img width="660" alt="public" src="https://user-images.githubusercontent.com/11336/49351305-15325880-f6b3-11e8-8fe5-b657f7cc68fa.png">

*Note the absence of 🔓 for `/users`.*

There are a couple of more places where `#blank?` is used in `Grape::Endpoint`. Namely in `#swagger_object`, `#info_object`, `#license_object`, and `#contact_object`. I didn't change those since, for example, the `#license_object` can't be blank ([needs at least a `name`](https://github.com/OAI/OpenAPI-Specification/blob/master/versions/2.0.md#license-object)).

This change will produce empty arrays in `#method_object`, for keys such as `parameters` or `tags`. The generated schema is still valid since an empty `parameters` or `tags` is allowed. Especially for parameters it's allowed to override / amend (if defined) but not to remove. The empty array is successfully ignored by `Swagger UI`. This PR will make the generated schema a bit more verbose yet, still, valid. Another alternative is to call [`Object#presence`](https://api.rubyonrails.org/v5.2/classes/Object.html#method-i-presence) in `#params_object` and `#tag_object`.

In the last commit I remove the default empty `description` to bring the generated schema (and specs) closer to what they were originally (before this PR).

☝️ Let me know whether I should include / make those changes.