### PR TITLE
Skip empty parameters and tags arrays

### DIFF
--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -191,7 +191,7 @@ module Grape
         parameters = GrapeSwagger::DocMethods::MoveParams.to_definition(path, parameters, route, @definitions)
       end
 
-      parameters
+      parameters.presence
     end
 
     def response_object(route)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -257,11 +257,12 @@ module Grape
     def tag_object(route, path)
       version = GrapeSwagger::DocMethods::Version.get(route)
       version = [version] unless version.is_a?(Array)
+
       Array(
         path.split('{')[0].split('/').reject(&:empty?).delete_if do |i|
           i == route.prefix.to_s || version.map(&:to_s).include?(i)
         end.first
-      )
+      ).presence
     end
 
     private

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -279,7 +279,6 @@ RSpec.shared_context 'entity swagger example' do
           'get' => {
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
-            'parameters' => [],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
             'tags' => ['thing2'],
             'operationId' => 'getThing2'

--- a/spec/support/model_parsers/mock_parser.rb
+++ b/spec/support/model_parsers/mock_parser.rb
@@ -271,7 +271,6 @@ RSpec.shared_context 'mock swagger example' do
           'get' => {
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
-            'parameters' => [],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
             'tags' => ['thing2'],
             'operationId' => 'getThing2'

--- a/spec/support/model_parsers/representable_parser.rb
+++ b/spec/support/model_parsers/representable_parser.rb
@@ -351,7 +351,6 @@ RSpec.shared_context 'representable swagger example' do
           'get' => {
             'description' => 'This gets Things.',
             'produces' => ['application/json'],
-            'parameters' => [],
             'responses' => { '200' => { 'description' => 'get Horses', 'schema' => { '$ref' => '#/definitions/Something' } }, '401' => { 'description' => 'HorsesOutError', 'schema' => { '$ref' => '#/definitions/ApiError' } } },
             'tags' => ['thing2'],
             'operationId' => 'getThing2'

--- a/spec/swagger_v2/api_swagger_v2_response_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_spec.rb
@@ -49,7 +49,6 @@ describe 'response' do
       expect(subject['paths']['/nested_type']['get']).to eql(
         'description' => 'This returns something',
         'produces' => ['application/json'],
-        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This returns something', 'schema' => { '$ref' => '#/definitions/UseItemResponseAsType' } },
           '400' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' } }
@@ -71,7 +70,6 @@ describe 'response' do
       expect(subject['paths']['/entity_response']['get']).to eql(
         'description' => 'This returns something',
         'produces' => ['application/json'],
-        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This returns something', 'schema' => { '$ref' => '#/definitions/UseResponse' } },
           '400' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' } }

--- a/spec/swagger_v2/api_swagger_v2_response_with_examples_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_with_examples_spec.rb
@@ -72,7 +72,6 @@ describe 'response with examples' do
       expect(subject['paths']['/response_examples']['get']).to eql(
         'description' => 'This returns examples',
         'produces' => ['application/json'],
-        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This returns examples', 'schema' => { '$ref' => '#/definitions/UseResponse' }, 'examples' => example_200 },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => example_404 }
@@ -103,7 +102,6 @@ describe 'response with examples' do
       expect(subject['paths']['/response_failure_examples']['get']).to eql(
         'description' => 'This syntax also returns examples',
         'produces' => ['application/json'],
-        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This syntax also returns examples', 'schema' => { '$ref' => '#/definitions/UseResponse' }, 'examples' => example_200 },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => example_404 },
@@ -125,7 +123,6 @@ describe 'response with examples' do
       expect(subject['paths']['/response_no_examples']['get']).to eql(
         'description' => 'This does not return examples',
         'produces' => ['application/json'],
-        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This does not return examples', 'schema' => { '$ref' => '#/definitions/UseResponse' } },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' } }

--- a/spec/swagger_v2/api_swagger_v2_response_with_headers_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_with_headers_spec.rb
@@ -91,7 +91,6 @@ describe 'response with headers' do
       expect(subject['paths']['/response_headers']['get']).to eql(
         'description' => 'This returns headers',
         'produces' => ['application/json'],
-        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This returns headers', 'schema' => { '$ref' => '#/definitions/UseResponse' }, 'headers' => header_200 },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => examples_404, 'headers' => header_404 }
@@ -122,7 +121,6 @@ describe 'response with headers' do
       expect(subject['paths']['/no_content_response_headers']['delete']).to eql(
         'description' => 'A 204 can have headers too',
         'produces' => ['application/json'],
-        'parameters' => [],
         'responses' => {
           '204' => { 'description' => 'No content', 'headers' => header_204 },
           '400' => { 'description' => 'Bad Request', 'headers' => header_400, 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => examples_400 }
@@ -153,7 +151,6 @@ describe 'response with headers' do
       expect(subject['paths']['/file_response_headers']['get']).to eql(
         'description' => 'A file can have headers too',
         'produces' => ['application/json'],
-        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'A file can have headers too', 'headers' => header_200, 'schema' => { 'type' => 'file' } },
           '404' => { 'description' => 'NotFound', 'headers' => header_404, 'schema' => { '$ref' => '#/definitions/ApiError' }, 'examples' => examples_404 }
@@ -184,7 +181,6 @@ describe 'response with headers' do
       expect(subject['paths']['/response_failure_headers']['get']).to eql(
         'description' => 'This syntax also returns headers',
         'produces' => ['application/json'],
-        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This syntax also returns headers', 'schema' => { '$ref' => '#/definitions/UseResponse' }, 'headers' => header_200 },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' }, 'headers' => header_404 },
@@ -206,7 +202,6 @@ describe 'response with headers' do
       expect(subject['paths']['/response_no_headers']['get']).to eql(
         'description' => 'This does not return headers',
         'produces' => ['application/json'],
-        'parameters' => [],
         'responses' => {
           '200' => { 'description' => 'This does not return headers', 'schema' => { '$ref' => '#/definitions/UseResponse' } },
           '404' => { 'description' => 'NotFound', 'schema' => { '$ref' => '#/definitions/ApiError' } }

--- a/spec/swagger_v2/default_api_spec.rb
+++ b/spec/swagger_v2/default_api_spec.rb
@@ -33,7 +33,6 @@ describe 'Default API' do
             'get' => {
               'description' => 'This gets something.',
               'produces' => ['application/json'],
-              'parameters' => [],
               'tags' => ['something'],
               'operationId' => 'getSomething',
               'responses' => { '200' => { 'description' => 'This gets something.' } }
@@ -80,7 +79,6 @@ describe 'Default API' do
                                 'get' => {
                                   'description' => 'This gets something.',
                                   'produces' => ['application/json'],
-                                  'parameters' => [],
                                   'tags' => ['something'],
                                   'operationId' => 'getSomething',
                                   'responses' => { '200' => { 'description' => 'This gets something.' } }

--- a/spec/swagger_v2/guarded_endpoint_spec.rb
+++ b/spec/swagger_v2/guarded_endpoint_spec.rb
@@ -86,7 +86,6 @@ describe 'a guarded api endpoint' do
             'get' => {
               'description' => 'Show endpoint if authenticated',
               'produces' => ['application/json'],
-              'parameters' => [],
               'tags' => ['auth'],
               'operationId' => 'getAuth',
               'responses' => { '200' => { 'description' => 'Show endpoint if authenticated' } }

--- a/spec/swagger_v2/hide_api_spec.rb
+++ b/spec/swagger_v2/hide_api_spec.rb
@@ -54,7 +54,6 @@ describe 'a hide mounted api' do
           'get' => {
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
-            'parameters' => [],
             'tags' => ['simple'],
             'operationId' => 'getSimple',
             'responses' => { '200' => { 'description' => 'Show this endpoint' } }
@@ -64,7 +63,6 @@ describe 'a hide mounted api' do
           'get' => {
             'description' => 'Lazily show endpoint',
             'produces' => ['application/json'],
-            'parameters' => [],
             'tags' => ['lazy'],
             'operationId' => 'getLazy',
             'responses' => { '200' => { 'description' => 'Lazily show endpoint' } }
@@ -117,7 +115,6 @@ describe 'a hide mounted api with same namespace' do
           'get' => {
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
-            'parameters' => [],
             'operationId' => 'getSimpleShow',
             'tags' => ['simple'], 'responses' => { '200' => { 'description' => 'Show this endpoint' } }
           }
@@ -139,7 +136,6 @@ describe 'a hide mounted api with same namespace' do
           'get' => {
             'description' => 'Show this endpoint',
             'produces' => ['application/json'],
-            'parameters' => [],
             'tags' => ['simple'],
             'operationId' => 'getSimpleShow',
             'responses' => { '200' => { 'description' => 'Show this endpoint' } }

--- a/spec/swagger_v2/mounted_target_class_spec.rb
+++ b/spec/swagger_v2/mounted_target_class_spec.rb
@@ -41,7 +41,6 @@ describe 'docs mounted separately from api' do
           'get' => {
             'description' => 'This gets something.',
             'produces' => ['application/json'],
-            'parameters' => [],
             'responses' => { '200' => { 'description' => 'This gets something.' } },
             'tags' => ['simple'],
             'operationId' => 'getSimple'
@@ -64,7 +63,6 @@ describe 'docs mounted separately from api' do
           'get' => {
             'description' => 'This gets something.',
             'produces' => ['application/json'],
-            'parameters' => [],
             'responses' => {
               '200' => { 'description' => 'This gets something.' }
             },

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -104,7 +104,6 @@ describe 'a simple mounted api' do
             'get' => {
               'description' => 'Document root',
               'produces' => ['application/json'],
-              'tags' => [],
               'responses' => { '200' => { 'description' => 'Document root' } },
               'operationId' => 'get'
             }

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -104,7 +104,6 @@ describe 'a simple mounted api' do
             'get' => {
               'description' => 'Document root',
               'produces' => ['application/json'],
-              'parameters' => [],
               'tags' => [],
               'responses' => { '200' => { 'description' => 'Document root' } },
               'operationId' => 'get'
@@ -114,7 +113,6 @@ describe 'a simple mounted api' do
             'get' => {
               'description' => 'This gets something.',
               'produces' => ['application/json'],
-              'parameters' => [],
               'tags' => ['simple'],
               'operationId' => 'getSimple',
               'responses' => { '200' => { 'description' => 'This gets something.' } }
@@ -124,7 +122,6 @@ describe 'a simple mounted api' do
             'get' => {
               'description' => 'This gets something for URL using - separator.',
               'produces' => ['application/json'],
-              'parameters' => [],
               'tags' => ['simple-test'],
               'operationId' => 'getSimpleTest',
               'responses' => { '200' => { 'description' => 'This gets something for URL using - separator.' } }
@@ -133,7 +130,6 @@ describe 'a simple mounted api' do
           '/simple-head-test' => {
             'head' => {
               'produces' => ['application/json'],
-              'parameters' => [],
               'responses' => { '200' => { 'description' => 'head SimpleHeadTest' } },
               'tags' => ['simple-head-test'],
               'operationId' => 'headSimpleHeadTest'
@@ -142,7 +138,6 @@ describe 'a simple mounted api' do
           '/simple-options-test' => {
             'options' => {
               'produces' => ['application/json'],
-              'parameters' => [],
               'responses' => { '200' => { 'description' => 'option SimpleOptionsTest' } },
               'tags' => ['simple-options-test'],
               'operationId' => 'optionsSimpleOptionsTest'
@@ -211,7 +206,6 @@ describe 'a simple mounted api' do
             'get' => {
               'description' => 'This gets something.',
               'produces' => ['application/json'],
-              'parameters' => [],
               'tags' => ['simple'],
               'operationId' => 'getSimple',
               'responses' => { '200' => { 'description' => 'This gets something.' } }
@@ -243,7 +237,6 @@ describe 'a simple mounted api' do
               'get' => {
                 'description' => 'This gets something for URL using - separator.',
                 'produces' => ['application/json'],
-                'parameters' => [],
                 'tags' => ['simple-test'],
                 'operationId' => 'getSimpleTest',
                 'responses' => { '200' => { 'description' => 'This gets something for URL using - separator.' } }


### PR DESCRIPTION
Skip empty `parameters` and `tags` arrays by using [`Object#presence`](https://api.rubyonrails.org/v5.2/classes/Object.html#method-i-presence).

This removes the redundant (yet not harmful) `parameters` and `tags` and retains the empty `security` array which is useful (for overriding the globally applicable `security` schemes).

This PR is related and a follow up to #729.

For convenience the complete diff over the 2 PRs is (excluding the `CHANGELOG`):

```diff
diff --git a/lib/grape-swagger/endpoint.rb b/lib/grape-swagger/endpoint.rb
index 57764aa..79dd3b1 100644
--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -125,7 +125,7 @@ module Grape
       method[:tags]        = route.options.fetch(:tags, tag_object(route, path))
       method[:operationId] = GrapeSwagger::DocMethods::OperationId.build(route, path)
       method[:deprecated] = deprecated_object(route)
-      method.delete_if { |_, value| value.blank? }
+      method.delete_if { |_, value| value.nil? }

       [route.request_method.downcase.to_sym, method]
     end
@@ -149,7 +149,6 @@ module Grape
     def description_object(route)
       description = route.description if route.description.present?
       description = route.options[:detail] if route.options.key?(:detail)
-      description ||= ''

       description
     end
@@ -192,7 +191,7 @@ module Grape
         parameters = GrapeSwagger::DocMethods::MoveParams.to_definition(path, parameters, route, @definitions)
       end

-      parameters
+      parameters.presence
     end

     def response_object(route)
@@ -258,11 +257,12 @@ module Grape
     def tag_object(route, path)
       version = GrapeSwagger::DocMethods::Version.get(route)
       version = [version] unless version.is_a?(Array)
+
       Array(
         path.split('{')[0].split('/').reject(&:empty?).delete_if do |i|
           i == route.prefix.to_s || version.map(&:to_s).include?(i)
         end.first
-      )
+      ).presence
     end

     private
diff --git a/spec/swagger_v2/security_requirement_spec.rb b/spec/swagger_v2/security_requirement_spec.rb
index 9c106d1..e7adb72 100644
--- a/spec/swagger_v2/security_requirement_spec.rb
+++ b/spec/swagger_v2/security_requirement_spec.rb
@@ -10,7 +10,24 @@ describe 'security requirement on endpoint method' do
         { foo: 'bar' }
       end

-      add_swagger_documentation
+      desc 'Endpoint without security requirement', security: []
+      get '/without_security' do
+        { foo: 'bar' }
+      end
+
+      add_swagger_documentation(
+        security_definitions: {
+          petstore_auth: {
+            type: 'oauth2',
+            flow: 'implicit',
+            authorizationUrl: 'https://petstore.swagger.io/oauth/dialog',
+            scopes: {
+              'read:pets': 'read your pets',
+              'write:pets': 'modify pets in your account'
+            }
+          }
+        }
+      )
     end
   end

@@ -22,4 +39,8 @@ describe 'security requirement on endpoint method' do
   it 'defines the security requirement on the endpoint method' do
     expect(subject['paths']['/with_security']['get']['security']).to eql ['oauth_pets' => ['read:pets', 'write:pets']]
   end
+
+  it 'defines an empty security requirement on the endpoint method' do
+    expect(subject['paths']['/without_security']['get']['security']).to eql []
+  end
 end
```