### PR TITLE
Add ability to override data type in swagger when using Custom Types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 #### Features
 
-* Your contribution here.
+* [#733](https://github.com/ruby-grape/grape-swagger/pull/733): Override a Custom Type data type with `:custom_type_data_type_override` - [@shanempope](https://github.com/shanempope).
 
 #### Fixes
 

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -60,8 +60,8 @@ module GrapeSwagger
                     rescue NameError
                       nil
                     end
-            if klass.respond_to?(:custom_type_data_type_override)
-              klass.custom_type_data_type_override.camelize
+            if klass.respond_to?(:data_type)
+              klass.data_type.camelize
             else
               model.to_s.split('::').last
             end

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -55,7 +55,16 @@ module GrapeSwagger
           elsif model.respond_to?(:name)
             model.name.demodulize.camelize
           else
-            model.to_s.split('::').last
+            klass = begin
+                      Object.const_get(model, false)
+                    rescue NameError
+                      nil
+                    end
+            if klass.respond_to?(:custom_type_data_type_override)
+              klass.custom_type_data_type_override.camelize
+            else
+              model.to_s.split('::').last
+            end
           end
         end
 

--- a/spec/lib/data_type_spec.rb
+++ b/spec/lib/data_type_spec.rb
@@ -96,4 +96,16 @@ describe GrapeSwagger::DocMethods::DataType do
 
     it { is_expected.to eq('integer') }
   end
+
+  describe 'Custom Type with :name method defined' do
+    class CustomNumericObject
+      def self.custom_type_data_type_override
+        'integer'
+      end
+    end
+
+    let(:value) { { type: 'CustomNumericObject' } }
+
+    it { is_expected.to eq('Integer') }
+  end
 end

--- a/spec/lib/data_type_spec.rb
+++ b/spec/lib/data_type_spec.rb
@@ -99,7 +99,7 @@ describe GrapeSwagger::DocMethods::DataType do
 
   describe 'Custom Type with :name method defined' do
     class CustomNumericObject
-      def self.custom_type_data_type_override
+      def self.data_type
         'integer'
       end
     end


### PR DESCRIPTION
```ruby
def self.custom_type_data_type_override
  'Integer'
end
```
on your [custom type](https://github.com/ruby-grape/grape#custom-types-and-coercions) will allow you to override the datatype. This would allow you to define it on the custom type once and not have to add documentation hash for every require that uses the custom type.