### PR TITLE
Handle arrays in Grape::Endpoint#expose_params

### DIFF
--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -306,14 +306,17 @@ module Grape
     end
 
     def expose_params(value)
-      if value.is_a?(Class) && GrapeSwagger.model_parsers.find(value)
-        expose_params_from_model(value)
-      elsif value.is_a?(String)
+      case value
+      when Class
+        expose_params_from_model(value) if GrapeSwagger.model_parsers.find(value)
+      when String
         begin
-          expose_params(Object.const_get(value.gsub(/\[|\]/, ''))) # try to load class from its name
+          expose_params(Object.const_get(value))
         rescue NameError
           nil
         end
+      when Array
+        expose_params(value.first)
       end
     end
 

--- a/spec/swagger_v2/api_documentation_spec.rb
+++ b/spec/swagger_v2/api_documentation_spec.rb
@@ -27,12 +27,12 @@ describe 'API with additional options' do
             'locale' => {
               desc: 'Locale of API documentation',
               required: false,
-              type: 'Symbol'
+              type: Symbol
             },
             'name' => {
               desc: 'Resource name of mounted API',
               required: true,
-              type: 'String'
+              type: String
             }
           }
         }


### PR DESCRIPTION
Since, in  ruby-grape/grape#1863, I changed the code that made `type` a string, the code that generates the appropriate OpenAPI array definitions in `grape-swagger` broke.

In `#expose_params` there is a nasty trick (hack?) that removes the brackets from stringified Array classes in order to (recursively) expose the params (introduced [here](https://github.com/ruby-grape/grape-swagger/pull/511/files#diff-7af39528837333c960830618fb6a52e9R275)). The change in this PR treats arrays as first class objects.

Unfortunately I can't say I fully understand what's going on, therefore, please guide me and let me know if this is gonna introduce any regressions to existing projects.

This PR works with ruby-grape/grape#1863, thus specs might be broken for `HEAD` or other versions.