### PR TITLE
CI: Use 2.4.6, 2.5.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: ruby
 
-sudo: false
-
 before_install:
   - gem install bundler
 
@@ -9,8 +7,8 @@ after_success:
   - bundle exec danger
 
 rvm:
-  - 2.4.5
-  - 2.5.4
+  - 2.4.6
+  - 2.5.5
   - 2.6.2
 env:
   - MODEL_PARSER=grape-swagger-entity

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#743](https://github.com/ruby-grape/grape-swagger/pull/743): CI: use 2.4.6, 2.5.5 - [@olleolleolle](https://github.com/olleolleolle).
 * [#737](https://github.com/ruby-grape/grape-swagger/pull/737): Add swagger endpoint guard to both doc endpoints - [@urkle](https://github.com/urkle).
 
 ### 0.32.1 (December 7, 2018)


### PR DESCRIPTION
This PR updates the CI matrix.

  - Also: Removes an old setting from Travis. See https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration