### PR TITLE
Prepare 0.32.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 #### Fixes
 
 * Your contribution here.
+
+### 0.32.2 (June 21, 2019)
+
+#### Fixes
+
 * [#747](https://github.com/ruby-grape/grape-swagger/pull/747): Allow multiple different success responses - [@charanftp3](https://github.com/charanpanchagnula).
 * [#746](https://github.com/ruby-grape/grape-swagger/pull/746): Fix path with optional format - [@fnordfish](https://github.com/fnordfish).
 * [#743](https://github.com/ruby-grape/grape-swagger/pull/743): CI: use 2.4.6, 2.5.5 - [@olleolleolle](https://github.com/olleolleolle).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -34,7 +34,7 @@ by enforcing correct usage of both possibilities:
 
 ### Upgrading to >= 0.25.0
 
-The global tag set now only includes tags for documented routes. This behaviour has impact in particular for calling the documtation of a specific route.
+The global tag set now only includes tags for documented routes. This behaviour has impact in particular for calling the documentation of a specific route.
 
 ### Upgrading to >= 0.21.0
 

--- a/lib/grape-swagger/version.rb
+++ b/lib/grape-swagger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GrapeSwagger
-  VERSION = '0.32.1'
+  VERSION = '0.32.2'
 end


### PR DESCRIPTION
Hi everybody, thank you very much for working on this great gem.
The last release was more than 6 months ago and the master branch already contains a bunch of useful fixes.
So maybe it makes sense to release the new version which contains those fixes?