### PR TITLE
prepare release 0.33.0

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,7 @@ AllCops:
   Exclude:
     - vendor/**/*
     - example/**/*
-  TargetRubyVersion: 2.4
+  TargetRubyVersion: 2.6
 
 Layout/EmptyLinesAroundArguments:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   - MODEL_PARSER=grape-swagger-entity
   - MODEL_PARSER=grape-swagger-representable
   - GRAPE_VERSION=1.0.3
-  - GRAPE_VERSION=1.2.2
+  - GRAPE_VERSION=1.2.4
   - GRAPE_VERSION=HEAD
 
 matrix:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@
 #### Fixes
 
 * Your contribution here.
+
+### 0.33.0 (June 21, 2019)
+
+#### Fixes
+
 * [#747](https://github.com/ruby-grape/grape-swagger/pull/747): Allow multiple different success responses - [@charanftp3](https://github.com/charanpanchagnula).
 * [#746](https://github.com/ruby-grape/grape-swagger/pull/746): Fix path with optional format - [@fnordfish](https://github.com/fnordfish).
 * [#743](https://github.com/ruby-grape/grape-swagger/pull/743): CI: use 2.4.6, 2.5.5 - [@olleolleolle](https://github.com/olleolleolle).

--- a/Gemfile
+++ b/Gemfile
@@ -26,7 +26,7 @@ group :development, :test do
   gem 'rake'
   gem 'rdoc'
   gem 'rspec', '~> 3.8'
-  gem 'rubocop', '~> 0.65', require: false
+  gem 'rubocop', '~> 0.71', require: false
 end
 
 group :test do

--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = 'Add auto generated documentation to your Grape API that can be displayed with Swagger.'
   s.license     = 'MIT'
 
-  s.required_ruby_version = '>= 2.3'
+  s.required_ruby_version = '>= 2.4'
   s.add_runtime_dependency 'grape', '>= 0.16.2'
 
   s.files         = `git ls-files`.split("\n")

--- a/lib/grape-swagger/version.rb
+++ b/lib/grape-swagger/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module GrapeSwagger
-  VERSION = '0.32.1'
+  VERSION = '0.33.0'
 end


### PR DESCRIPTION
- aligns ruby versions for travis, rubocop and the gem itself