### PR TITLE
Fix array_use_braces for body params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#757](https://github.com/ruby-grape/grape-swagger/pull/757): Fix `array_use_braces` for nested body params - [@bikolya](https://github.com/bikolya).
 
 ### 0.33.0 (June 21, 2019)
 

--- a/lib/grape-swagger/endpoint/params_parser.rb
+++ b/lib/grape-swagger/endpoint/params_parser.rb
@@ -15,17 +15,14 @@ module GrapeSwagger
       end
 
       def parse_request_params
-        array_keys = []
         public_params.each_with_object({}) do |(name, options), memo|
           name = name.to_s
           param_type = options[:type]
           param_type = param_type.to_s unless param_type.nil?
 
           if param_type_is_array?(param_type)
-            array_keys << name
             options[:is_array] = true
-
-            name += '[]' if array_use_braces?(options)
+            name += '[]' if array_use_braces?
           end
 
           memo[name] = options
@@ -34,8 +31,8 @@ module GrapeSwagger
 
       private
 
-      def array_use_braces?(options)
-        settings[:array_use_braces] && !(options[:documentation] && options[:documentation][:param_type] == 'body')
+      def array_use_braces?
+        @array_use_braces ||= settings[:array_use_braces] && !includes_body_param?
       end
 
       def param_type_is_array?(param_type)
@@ -60,6 +57,12 @@ module GrapeSwagger
         param_hidden = param_options[:documentation].fetch(:hidden, false)
         param_hidden = param_hidden.call if param_hidden.is_a?(Proc)
         !param_hidden
+      end
+
+      def includes_body_param?
+        params.any? do |_, options|
+          options.dig(:documentation, :param_type) == 'body' || options.dig(:documentation, :in) == 'body'
+        end
       end
     end
   end

--- a/spec/lib/endpoint/params_parser_spec.rb
+++ b/spec/lib/endpoint/params_parser_spec.rb
@@ -56,13 +56,53 @@ describe GrapeSwagger::Endpoint::ParamsParser do
     end
 
     context 'when param is nested in a param of hash type' do
-      let(:params) { [['param_1', { type: 'Hash' }], ['param_1[param_2]', { type: 'String' }]] }
+      let(:params) { [param_1, param_2] }
+      let(:param_1) { ['param_1', { type: 'Hash' }] }
+      let(:param_2) { ['param_1[param_2]', { type: 'String' }] }
 
       context 'and array_use_braces setting set to true' do
         let(:settings) { { array_use_braces: true } }
 
-        it 'does not add braces to the param key' do
-          expect(parse_request_params.keys.last).to eq 'param_1[param_2]'
+        context 'and param is of simple type' do
+          it 'does not add braces to the param key' do
+            expect(parse_request_params.keys.last).to eq 'param_1[param_2]'
+          end
+        end
+
+        context 'and param is of array type' do
+          let(:param_2) { ['param_1[param_2]', { type: 'Array[String]' }] }
+
+          it 'adds braces to the param key' do
+            expect(parse_request_params.keys.last).to eq 'param_1[param_2][]'
+          end
+
+          context 'and `param_type` option is set to body' do
+            let(:param_2) do
+              ['param_1[param_2]', { type: 'Array[String]', documentation: { param_type: 'body' } }]
+            end
+
+            it 'does not add braces to the param key' do
+              expect(parse_request_params.keys.last).to eq 'param_1[param_2]'
+            end
+          end
+
+          context 'and `in` option is set to body' do
+            let(:param_2) do
+              ['param_1[param_2]', { type: 'Array[String]', documentation: { in: 'body' } }]
+            end
+
+            it 'does not add braces to the param key' do
+              expect(parse_request_params.keys.last).to eq 'param_1[param_2]'
+            end
+          end
+
+          context 'and hash `param_type` option is set to body' do
+            let(:param_1) { ['param_1', { type: 'Hash', documentation: { param_type: 'body' } }] }
+
+            it 'does not add braces to the param key' do
+              expect(parse_request_params.keys.last).to eq 'param_1[param_2]'
+            end
+          end
         end
       end
     end


### PR DESCRIPTION
Previously this is what was generated:
`"attr":{"type":"array","items":{"type":"object","properties":{"":{"type":"string"}}}}`
instead of
`"attr":{"type":"array","items":{"type":"string"}}`
in case this attribute was nested in a Hash attribute with "body" in `param_type`

Definition: 
```ruby
requires :param_1, type: Hash, documentation: { param_type: 'body' } do
  optional :param_2, type: Integer
  optional :param_3, type: Array[String]
end
```

Here is how it looked like it Swagger UI: 
![image](https://user-images.githubusercontent.com/3993468/64125191-81103180-cda9-11e9-8425-d688816664d8.png)

instead of 
![image](https://user-images.githubusercontent.com/3993468/64125229-9d13d300-cda9-11e9-8be9-b951b969bee6.png)

