### PR TITLE
Handle cases where a route's prefix is a nested URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#758](https://github.com/ruby-grape/grape-swagger/pull/758): Handle cases where a route's prefix is a nested URL - [@SimonKaluza](https://github.com/simonkaluza).
 * [#757](https://github.com/ruby-grape/grape-swagger/pull/757): Fix `array_use_braces` for nested body params - [@bikolya](https://github.com/bikolya).
 * [#756](https://github.com/ruby-grape/grape-swagger/pull/756): Fix reference creation when custom type for documentation is provided - [@bikolya](https://github.com/bikolya).
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -251,10 +251,10 @@ module Grape
     def tag_object(route, path)
       version = GrapeSwagger::DocMethods::Version.get(route)
       version = [version] unless version.is_a?(Array)
-
+      prefix = route.prefix.to_s.split('/').reject(&:empty?)
       Array(
         path.split('{')[0].split('/').reject(&:empty?).delete_if do |i|
-          i == route.prefix.to_s || version.map(&:to_s).include?(i)
+          prefix.include?(i) || version.map(&:to_s).include?(i)
         end.first
       ).presence
     end

--- a/spec/swagger_v2/namespace_tags_prefix_spec.rb
+++ b/spec/swagger_v2/namespace_tags_prefix_spec.rb
@@ -29,12 +29,25 @@ describe 'namespace tags check while using prefix and version' do
           end
         end
       end
+
+      class NestedPrefixApi < Grape::API
+        version :v1
+        prefix 'nested_prefix/api'
+
+        namespace :deep_namespace do
+          desc 'This gets something within a deeply nested resource'
+          get '/deep' do
+            { bla: 'something' }
+          end
+        end
+      end
     end
 
     class TagApi < Grape::API
       prefix :api
       mount TheApi::CascadingVersionApi
       mount TheApi::NamespaceApi
+      mount TheApi::NestedPrefixApi
       add_swagger_documentation
     end
   end
@@ -55,7 +68,8 @@ describe 'namespace tags check while using prefix and version' do
           { 'name' => 'hudson', 'description' => 'Operations about hudsons' },
           { 'name' => 'colorado', 'description' => 'Operations about colorados' },
           { 'name' => 'thames', 'description' => 'Operations about thames' },
-          { 'name' => 'niles', 'description' => 'Operations about niles' }
+          { 'name' => 'niles', 'description' => 'Operations about niles' },
+          { 'name' => 'deep_namespace', 'description' => 'Operations about deep_namespaces' }
         ]
       )
 


### PR DESCRIPTION
Nested prefixes (any prefix containing a '/' character) prior to this commit would incorrectly get tagged as the first segment of the URL prefix.

E.g. a route like "api/beta/v1/patients" would incorrectly get tagged as "api" instead of "patients"