### PR TITLE
GrapeSwagger::DocMethods::Extensions breaks the contract of Kernel#method

### DIFF
--- a/lib/grape-swagger/doc_methods/extensions.rb
+++ b/lib/grape-swagger/doc_methods/extensions.rb
@@ -87,7 +87,12 @@ module GrapeSwagger
           part.select { |x| x == identifier }
         end
 
-        def method
+        def method(*args)
+          # We're shadowing Object.method(:symbol) here so we provide
+          # a compatibility layer for code that introspects the methods
+          # of this class
+          return super if args.size.positive?
+
           @route.request_method.downcase.to_sym
         end
       end

--- a/spec/lib/extensions_spec.rb
+++ b/spec/lib/extensions_spec.rb
@@ -3,6 +3,16 @@
 require 'spec_helper'
 
 describe GrapeSwagger::DocMethods::Extensions do
+  context 'it should not break method introspection' do
+    describe '.method' do
+      describe 'method introspection' do
+        specify do
+          expect(described_class.method(described_class.methods.first)).to be_a(Method)
+        end
+      end
+    end
+  end
+
   describe '#find_definition' do
     subject { described_class }
 

--- a/spec/swagger_v2/api_swagger_v2_hash_and_array_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_hash_and_array_spec.rb
@@ -10,7 +10,9 @@ describe 'document hash and array' do
       class TestApi < Grape::API
         format :json
 
-        documentation = ::Entities::DocumentedHashAndArrayModel.documentation if ::Entities::DocumentedHashAndArrayModel.respond_to?(:documentation)
+        if ::Entities::DocumentedHashAndArrayModel.respond_to?(:documentation)
+          documentation = ::Entities::DocumentedHashAndArrayModel.documentation
+        end
 
         desc 'This returns something'
         namespace :arbitrary do


### PR DESCRIPTION
This causes code inspection tools and development workflows to break
and may cause developers to choose not to use the gem.

One such tool that breaks is https://sorbet.org/