### PR TITLE
allow token_owner to be passed to the hidden proc for parameters as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Your contribution here.
 
+* [#775](https://github.com/ruby-grape/grape-swagger/pull/775): Add in token_owner support to param hidden procs - [@urkle](https://github.com/urkle).
+
 #### Fixes
 
 ### 0.34.2 (January 20, 2020)

--- a/README.md
+++ b/README.md
@@ -743,9 +743,12 @@ end
 Exclude single optional parameter from the documentation
 
 ```ruby
+not_admins = lambda { |token_owner = nil| token_owner.nil? || !token_owner.admin? }
+
 params do
   optional :one, documentation: { hidden: true }
-  optional :two, documentation: { hidden: -> { true } }
+  optional :two, documentation: { hidden: -> { |t=nil| true } }
+  optional :three, documentation: { hidden: not_admins }
 end
 post :act do
   ...

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -301,7 +301,7 @@ module Grape
       default_type(required)
 
       request_params = unless declared_params.nil? && route.headers.nil?
-                         GrapeSwagger::Endpoint::ParamsParser.parse_request_params(required, settings)
+                         GrapeSwagger::Endpoint::ParamsParser.parse_request_params(required, settings, self)
                        end || {}
 
       request_params.empty? ? required : request_params

--- a/lib/grape-swagger/endpoint/params_parser.rb
+++ b/lib/grape-swagger/endpoint/params_parser.rb
@@ -3,15 +3,16 @@
 module GrapeSwagger
   module Endpoint
     class ParamsParser
-      attr_reader :params, :settings
+      attr_reader :params, :settings, :endpoint
 
-      def self.parse_request_params(params, settings)
-        new(params, settings).parse_request_params
+      def self.parse_request_params(params, settings, endpoint)
+        new(params, settings, endpoint).parse_request_params
       end
 
-      def initialize(params, settings)
+      def initialize(params, settings, endpoint)
         @params = params
         @settings = settings
+        @endpoint = endpoint
       end
 
       def parse_request_params
@@ -55,7 +56,13 @@ module GrapeSwagger
         return true unless param_options.key?(:documentation) && !param_options[:required]
 
         param_hidden = param_options[:documentation].fetch(:hidden, false)
-        param_hidden = param_hidden.call if param_hidden.is_a?(Proc)
+        if param_hidden.is_a?(Proc)
+          param_hidden = if settings[:token_owner]
+                           param_hidden.call(endpoint.send(settings[:token_owner].to_sym))
+                         else
+                           param_hidden.call
+                         end
+        end
         !param_hidden
       end
 

--- a/spec/lib/endpoint/params_parser_spec.rb
+++ b/spec/lib/endpoint/params_parser_spec.rb
@@ -5,8 +5,9 @@ require 'spec_helper'
 describe GrapeSwagger::Endpoint::ParamsParser do
   let(:settings) { {} }
   let(:params) { [] }
+  let(:endpoint) { nil }
 
-  let(:parser) { described_class.new(params, settings) }
+  let(:parser) { described_class.new(params, settings, endpoint) }
 
   describe '#parse_request_params' do
     subject(:parse_request_params) { parser.parse_request_params }

--- a/spec/lib/endpoint_spec.rb
+++ b/spec/lib/endpoint_spec.rb
@@ -49,7 +49,7 @@ describe Grape::Endpoint do
   describe 'parse_request_params' do
     let(:subject) { GrapeSwagger::Endpoint::ParamsParser }
     before do
-      subject.send(:parse_request_params, params, {})
+      subject.send(:parse_request_params, params, {}, nil)
     end
 
     context 'when params do not contain an array' do


### PR DESCRIPTION
This allows the same functionality that is offered by the route-level hidden procs.

