### PR TITLE
Add params model in route options

### DIFF
--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -38,8 +38,9 @@ module GrapeSwagger
         end
 
         def parent_definition_of_params(params, path, route)
-          definition_name = OperationId.manipulate(parse_model(path))
-          referenced_definition = build_definition(definition_name, params, route.request_method.downcase)
+          has_params_model_name = route.options[:params_model_name].present?
+          definition_name = has_params_model_name ? route.options[:params_model_name] : OperationId.manipulate(parse_model(path))
+          referenced_definition = build_definition(definition_name, params, has_params_model_name ? nil : route.request_method.downcase)
           definition = @definitions[referenced_definition]
 
           move_params_to_new(definition, params)


### PR DESCRIPTION
See https://github.com/ruby-grape/grape-swagger/issues/657#issuecomment-581653945 for the reason behind this PR.

This solution is not the cleanest but it actually give us a way to have a decent model name in the documentation. It can be temporary.

I didn't read the source code all over, but I don't understand why the params key doesn't have the same behavior as the success one. I think it could be a permanent solution.