### PR TITLE
Allow passing class name as a string for oapi rake task initializer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 #### Features
 
 * Your contribution here.
+* [#782](https://github.com/ruby-grape/grape-swagger/pull/782): Allow passing class name as string for rake task initializer - [@misdoro](https://github.com/misdoro).
+
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -1486,11 +1486,17 @@ end
 
 ## Rake Tasks <a name="rake"></a>
 
-Add these lines to your Rakefile, and initialize the Task class with your Api class – be sure your Api class is available.
+Add these lines to your Rakefile, and initialize the Task class with your Api class.
 
 ```ruby
 require 'grape-swagger/rake/oapi_tasks'
 GrapeSwagger::Rake::OapiTasks.new(::Api::Base)
+```
+
+You may initialize with the class name as a string if the class is not yet loaded at the time Rakefile is parsed:
+```ruby
+require 'grape-swagger/rake/oapi_tasks'
+GrapeSwagger::Rake::OapiTasks.new('::Api::Base')
 ```
 
 #### OpenApi/Swagger Documentation

--- a/lib/grape-swagger/rake/oapi_tasks.rb
+++ b/lib/grape-swagger/rake/oapi_tasks.rb
@@ -10,16 +10,24 @@ module GrapeSwagger
       include Rack::Test::Methods
 
       attr_reader :oapi
-      attr_reader :api_class
 
       def initialize(api_class)
         super()
 
-        @api_class = api_class
+        if api_class.is_a? String
+          @api_class_name = api_class
+        else
+          @api_class = api_class
+        end
+
         define_tasks
       end
 
       private
+
+      def api_class
+        @api_class ||= @api_class_name.constantize
+      end
 
       def define_tasks
         namespace :oapi do

--- a/spec/lib/oapi_tasks_spec.rb
+++ b/spec/lib/oapi_tasks_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 RSpec.describe GrapeSwagger::Rake::OapiTasks do
-  let(:api) do
-    item = Class.new(Grape::API) do
+  module Api
+    class Item < Grape::API
       version 'v1', using: :path
 
       namespace :item do
@@ -16,14 +16,24 @@ RSpec.describe GrapeSwagger::Rake::OapiTasks do
       end
     end
 
-    Class.new(Grape::API) do
+    class Base < Grape::API
       prefix :api
-      mount item
+      mount Api::Item
       add_swagger_documentation add_version: true
     end
   end
 
-  subject { described_class.new(api) }
+  subject { described_class.new(Api::Base) }
+
+  describe '.new' do
+    it 'accepts class name as a constant' do
+      expect(described_class.new(::Api::Base).send(:api_class)).to eq(Api::Base)
+    end
+
+    it 'accepts class name as a string' do
+      expect(described_class.new('::Api::Base').send(:api_class)).to eq(Api::Base)
+    end
+  end
 
   describe '#make_request' do
     describe 'complete documentation' do


### PR DESCRIPTION
It may be possible that API classes are not yet loaded when the oapi rake tasks are initialized in Rakefile.

Add a possibility to pass class name as a string to not mess with class loader configuration.