### PR TITLE
Use full entity name as a default (fixes #779)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 * [#785](https://github.com/ruby-grape/grape-swagger/pull/785): Add extensions for params - [@MaximeRDY](https://github.com/MaximeRDY).
 * [#782](https://github.com/ruby-grape/grape-swagger/pull/782): Allow passing class name as string for rake task initializer - [@misdoro](https://github.com/misdoro).
 
-
 #### Fixes
+* [#786](https://github.com/ruby-grape/grape-swagger/pull/786): Use full entity name as a default - [@mrexox](https://github.com/mrexox)
 
 ### 1.0.0 (February 10, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 * Your contribution here.
 * [#785](https://github.com/ruby-grape/grape-swagger/pull/785): Add extensions for params - [@MaximeRDY](https://github.com/MaximeRDY).
 * [#782](https://github.com/ruby-grape/grape-swagger/pull/782): Allow passing class name as string for rake task initializer - [@misdoro](https://github.com/misdoro).
+* [#786](https://github.com/ruby-grape/grape-swagger/pull/786): Use full entity name as a default - [@mrexox](https://github.com/mrexox)
 
 #### Fixes
-* [#786](https://github.com/ruby-grape/grape-swagger/pull/786): Use full entity name as a default - [@mrexox](https://github.com/mrexox)
 
 ### 1.0.0 (February 10, 2020)
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,9 @@
 ## Upgrading Grape-swagger
 
+### Upgrading to >= 1.1.0
+
+Full class name is used for referencing entity by default (e.g. `A::B::C` instead of just `C`). `Entity` and `Entities` suffixes and prefixes are omitted (e.g. if entity name is `Entities::SomeScope::MyFavourite::Entity` only `SomeScope::MyFavourite` will be used).
+
 ### Upgrading to >= 0.26.1
 
 The format can now be specified,

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -52,7 +52,7 @@ module GrapeSwagger
             model.entity_name
           elsif model.to_s.end_with?('::Entity', '::Entities')
             model.to_s.split('::')[0..-2].join('::')
-          elsif model.to_s.start_with?('Entity::', 'Entities::')
+          elsif model.to_s.start_with?('Entity::', 'Entities::', 'Representable::')
             model.to_s.split('::')[1..-1].join('::')
           else
             model.to_s

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -53,7 +53,7 @@ module GrapeSwagger
           elsif model.to_s.end_with?('::Entity', '::Entities')
             model.to_s.split('::')[0..-2].join('::')
           elsif model.to_s.start_with?('Entity::', 'Entities::')
-            model.to_s.split('::')[1..].join('::')
+            model.to_s.split('::')[1..-1].join('::')
           else
             model.to_s
           end

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -51,11 +51,11 @@ module GrapeSwagger
           if model.methods(false).include?(:entity_name)
             model.entity_name
           elsif model.to_s.end_with?('::Entity', '::Entities')
-            model.to_s.split('::')[-2]
-          elsif model.respond_to?(:name)
-            model.name.demodulize.camelize
+            model.to_s.split('::')[0..-2].join('::')
+          elsif model.to_s.start_with?('Entity::', 'Entities::')
+            model.to_s.split('::')[1..].join('::')
           else
-            model.to_s.split('::').last
+            model.to_s
           end
         end
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -345,7 +345,6 @@ module Grape
         raise GrapeSwagger::Errors::SwaggerSpec,
               "Empty model #{model_name}, swagger 2.0 doesn't support empty definitions."
       end
-
       @definitions[model_name] = GrapeSwagger::DocMethods::BuildModelDefinition.build(model, properties, required)
 
       model_name

--- a/spec/issues/427_entity_as_string_spec.rb
+++ b/spec/issues/427_entity_as_string_spec.rb
@@ -35,5 +35,5 @@ describe '#427 nested entity given as string' do
     JSON.parse(last_response.body)['definitions']
   end
 
-  specify { expect(subject.keys).to include 'RoleEntity', 'WithoutRole' }
+  specify { expect(subject.keys).to include 'RoleEntity', 'Permission::WithoutRole' }
 end

--- a/spec/issues/430_entity_definitions_spec.rb
+++ b/spec/issues/430_entity_definitions_spec.rb
@@ -82,11 +82,11 @@ describe 'definition names' do
     JSON.parse(last_response.body)['definitions']
   end
 
-  specify { expect(subject).to include 'Class1' }
-  specify { expect(subject).to include 'Class2' }
+  specify { expect(subject).to include 'TestDefinition::DummyEntities::WithVeryLongName::AnotherGroupingModule::Class1' }
+  specify { expect(subject).to include 'TestDefinition::DummyEntities::WithVeryLongName::AnotherGroupingModule::Class2' }
   specify { expect(subject).to include 'FooKlass' }
-  specify { expect(subject).to include 'FourthEntity' }
-  specify { expect(subject).to include 'FithEntity' }
+  specify { expect(subject).to include 'TestDefinition::DummyEntities::WithVeryLongName::AnotherGroupingModule::Class4::FourthEntity' }
+  specify { expect(subject).to include 'TestDefinition::DummyEntities::WithVeryLongName::AnotherGroupingModule::Class5::FithEntity' }
   specify { expect(subject).to include 'BarKlass' }
-  specify { expect(subject).to include 'SeventhEntity' }
+  specify { expect(subject).to include 'TestDefinition::DummyEntities::WithVeryLongName::AnotherGroupingModule::Class7::SeventhEntity' }
 end

--- a/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
@@ -189,7 +189,7 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
         'type' => 'object',
         'properties' => {
           'data' => {
-            '$ref' => '#/definitions/ApiResponse',
+            '$ref' => '#/definitions/NestedModule::ApiResponse',
             'description' => 'request data'
           }
         },
@@ -207,7 +207,7 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
     end
 
     specify do
-      expect(subject['definitions']['ApiResponse']).not_to be_nil
+      expect(subject['definitions']['NestedModule::ApiResponse']).not_to be_nil
     end
 
     specify do


### PR DESCRIPTION
In this PR I just wanted to end with this:

```
- model.to_s.split('::').last
+ model.to_s
```

But I met a problem that it receives Class type in here
https://github.com/ruby-grape/grape-swagger/blob/8abddd5f2ce5fe29238990b136625f34371b0be0/lib/grape-swagger/endpoint.rb#L354
But String type in the another place. So, splitting by `::` and taking the last word actually returns the same as `name` method of the class. This is fine, but...

For example, if we use such constructions, we end up with just `V1` and `V2` from the `A::B` module as it is parsed first:

```ruby
module A
  module B
    class V1 < Grape::Entity
     ...

    class V2 < Grape::Entity
     ...

module A
  module C
    class V1 < Grape::Entity
      ...

    class V2 < Grape::Entity
      ...
```

This PR fixes this [issue](https://github.com/ruby-grape/grape-swagger/issues/779).