### PR TITLE
Allow entity_name to be called on parent classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#794](https://github.com/ruby-grape/grape-swagger/pull/794): Allow entity_name to be inherited, fixes #659 - [@urkle](https://githubcom/urkle).
 * Your contribution here.
 * [#793](https://github.com/ruby-grape/grape-swagger/pull/793): Features/inheritance and discriminator - [@MaximeRDY](https://github.com/MaximeRDY).
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -2,7 +2,29 @@
 
 ### Upgrading to >= 1.2.0
 
-Full class name is modified to use `_` separator (e.g. `A_B_C` instead of `A::B::C`).
+- The entity_name class method is now called on parent classes for inherited entities. Now you can do this
+
+```ruby
+module Some::Long::Module
+  class Base < Grape::Entity
+    # ... other shared logic
+    def self.entity_name
+      "V2::#{self.to_s.demodulize}"
+    end
+  end
+
+  def MyEntity < Base
+    # ....
+  end
+
+  def OtherEntity < Base
+    # revert back to the default behavior by hiding the method
+    private_class_method :entity_name
+  end
+end
+```
+
+- Full class name is modified to use `_` separator (e.g. `A_B_C` instead of `A::B::C`).
 
 ### Upgrading to >= 1.1.0
 

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -48,7 +48,7 @@ module GrapeSwagger
         end
 
         def parse_entity_name(model)
-          if model.methods(false).include?(:entity_name)
+          if model.respond_to?(:entity_name)
             model.entity_name
           elsif model.to_s.end_with?('::Entity', '::Entities')
             model.to_s.split('::')[0..-2].join('_')

--- a/spec/issues/430_entity_definitions_spec.rb
+++ b/spec/issues/430_entity_definitions_spec.rb
@@ -55,6 +55,8 @@ describe 'definition names' do
             class Class7
               class SeventhEntity < Class6::SixthEntity
                 expose :seventh_thing
+
+                private_class_method :entity_name
               end
             end
           end

--- a/spec/lib/data_type_spec.rb
+++ b/spec/lib/data_type_spec.rb
@@ -49,6 +49,18 @@ describe GrapeSwagger::DocMethods::DataType do
     it { is_expected.to eq 'MyInteger' }
   end
 
+  describe 'Types in array with inherited entity_name' do
+    before do
+      stub_const 'EntityBase', Class.new
+      allow(EntityBase).to receive(:entity_name).and_return 'MyInteger'
+      stub_const 'MyEntity', Class.new(EntityBase)
+    end
+
+    let(:value) { { type: '[MyEntity]' } }
+
+    it { is_expected.to eq 'MyInteger' }
+  end
+
   describe 'Rack::Multipart::UploadedFile' do
     let(:value) { { type: Rack::Multipart::UploadedFile } }
 


### PR DESCRIPTION
I am unsure why this limitation was done and issue #659 posses the same question.

This PR changes the behavior to allow calling entity_name if a parent class implements it.

My use case for this as follows

```ruby
module Public::V2::Entities
   class Base < Grape::Entity
     # ... other shared logic
     def self.entity_name
       "V2::#{self.to_s.demodulize}"
     end
   end
   
   def MyEntity < Base
     # ....
   end
end
```

And I have ~ 20+ entities all inheriting from base and I don't really want the FULL module tree exposed in the API (in our application it is a little longer than what you see here). And being able to override entity_name once is significantly easier.
