### PR TITLE
Support Grape 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#796](https://github.com/ruby-grape/grape-swagger/pull/796): Support grape 1.4.0 - [@thedanielhanke](https://github.com/thedanielhanke).
 
 
 ### 1.1.0 (April 20, 2020)

--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.license     = 'MIT'
 
   s.required_ruby_version = '>= 2.4'
-  s.add_runtime_dependency 'grape', '~> 1.3.0'
+  s.add_runtime_dependency 'grape', '~> 1.3'
 
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec}/*`.split("\n")


### PR DESCRIPTION
dont call me impatient, but it came to my attention that grapes master-branch version is > 1.3.0

Not quite sure about desired version handling, so i guessed the closest to ~> 1.3.0 while supporting 1.4.0 too, is to go >= 1.3.0 < 1.5.0.

