### PR TITLE
Modify full entity name to be RFC3986 compliant #797

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Fixes
 
 * Your contribution here.
-* [#798](https://github.com/ruby-grape/grape-swagger/pull/798): Modify entity name separator #797 - [@GarrettB71](https://github.com/GarrettB71).
+* [#798](https://github.com/ruby-grape/grape-swagger/pull/798): Modify full entity name separator - [@GarrettB71](https://github.com/GarrettB71).
 * [#796](https://github.com/ruby-grape/grape-swagger/pull/796): Support grape 1.4.0 - [@thedanielhanke](https://github.com/thedanielhanke).
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * Your contribution here.
+* [#798](https://github.com/ruby-grape/grape-swagger/pull/798): Modify entity name separator #797 - [@GarrettB71](https://github.com/GarrettB71).
 * [#796](https://github.com/ruby-grape/grape-swagger/pull/796): Support grape 1.4.0 - [@thedanielhanke](https://github.com/thedanielhanke).
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,6 +1,6 @@
 ## Upgrading Grape-swagger
 
-### Upgrading to >= 1.1.1
+### Upgrading to >= 1.2.0
 
 Full class name is modified to use `_` separator (e.g. `A_B_C` instead of `A::B::C`).
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,9 @@
 ## Upgrading Grape-swagger
 
+### Upgrading to >= 1.1.1
+
+Full class name is modified to use `_` separator (e.g. `A_B_C` instead of `A::B::C`).
+
 ### Upgrading to >= 1.1.0
 
 Full class name is used for referencing entity by default (e.g. `A::B::C` instead of just `C`). `Entity` and `Entities` suffixes and prefixes are omitted (e.g. if entity name is `Entities::SomeScope::MyFavourite::Entity` only `SomeScope::MyFavourite` will be used).

--- a/lib/grape-swagger/doc_methods/data_type.rb
+++ b/lib/grape-swagger/doc_methods/data_type.rb
@@ -51,11 +51,11 @@ module GrapeSwagger
           if model.methods(false).include?(:entity_name)
             model.entity_name
           elsif model.to_s.end_with?('::Entity', '::Entities')
-            model.to_s.split('::')[0..-2].join('::')
+            model.to_s.split('::')[0..-2].join('_')
           elsif model.to_s.start_with?('Entity::', 'Entities::', 'Representable::')
-            model.to_s.split('::')[1..-1].join('::')
+            model.to_s.split('::')[1..-1].join('_')
           else
-            model.to_s
+            model.to_s.split('::').join('_')
           end
         end
 

--- a/spec/issues/427_entity_as_string_spec.rb
+++ b/spec/issues/427_entity_as_string_spec.rb
@@ -35,5 +35,5 @@ describe '#427 nested entity given as string' do
     JSON.parse(last_response.body)['definitions']
   end
 
-  specify { expect(subject.keys).to include 'RoleEntity', 'Permission::WithoutRole' }
+  specify { expect(subject.keys).to include 'RoleEntity', 'Permission_WithoutRole' }
 end

--- a/spec/issues/430_entity_definitions_spec.rb
+++ b/spec/issues/430_entity_definitions_spec.rb
@@ -82,11 +82,11 @@ describe 'definition names' do
     JSON.parse(last_response.body)['definitions']
   end
 
-  specify { expect(subject).to include 'TestDefinition::DummyEntities::WithVeryLongName::AnotherGroupingModule::Class1' }
-  specify { expect(subject).to include 'TestDefinition::DummyEntities::WithVeryLongName::AnotherGroupingModule::Class2' }
+  specify { expect(subject).to include 'TestDefinition_DummyEntities_WithVeryLongName_AnotherGroupingModule_Class1' }
+  specify { expect(subject).to include 'TestDefinition_DummyEntities_WithVeryLongName_AnotherGroupingModule_Class2' }
   specify { expect(subject).to include 'FooKlass' }
-  specify { expect(subject).to include 'TestDefinition::DummyEntities::WithVeryLongName::AnotherGroupingModule::Class4::FourthEntity' }
-  specify { expect(subject).to include 'TestDefinition::DummyEntities::WithVeryLongName::AnotherGroupingModule::Class5::FithEntity' }
+  specify { expect(subject).to include 'TestDefinition_DummyEntities_WithVeryLongName_AnotherGroupingModule_Class4_FourthEntity' }
+  specify { expect(subject).to include 'TestDefinition_DummyEntities_WithVeryLongName_AnotherGroupingModule_Class5_FithEntity' }
   specify { expect(subject).to include 'BarKlass' }
-  specify { expect(subject).to include 'TestDefinition::DummyEntities::WithVeryLongName::AnotherGroupingModule::Class7::SeventhEntity' }
+  specify { expect(subject).to include 'TestDefinition_DummyEntities_WithVeryLongName_AnotherGroupingModule_Class7_SeventhEntity' }
 end

--- a/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_param_type_body_spec.rb
@@ -189,7 +189,7 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
         'type' => 'object',
         'properties' => {
           'data' => {
-            '$ref' => '#/definitions/NestedModule::ApiResponse',
+            '$ref' => '#/definitions/NestedModule_ApiResponse',
             'description' => 'request data'
           }
         },
@@ -207,7 +207,7 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
     end
 
     specify do
-      expect(subject['definitions']['NestedModule::ApiResponse']).not_to be_nil
+      expect(subject['definitions']['NestedModule_ApiResponse']).not_to be_nil
     end
 
     specify do

--- a/spec/swagger_v2/inheritance_and_discriminator_spec.rb
+++ b/spec/swagger_v2/inheritance_and_discriminator_spec.rb
@@ -48,9 +48,9 @@ describe 'Inheritance and Discriminator' do
     end
 
     specify do
-      subject['InheritanceTest::Entities::Pet'].key?('discriminator')
-      subject['InheritanceTest::Entities::Pet']['discriminator'] = 'type'
-      subject['InheritanceTest::Entities::Cat'].key?('allOf')
+      subject['InheritanceTest_Entities_Pet'].key?('discriminator')
+      subject['InheritanceTest_Entities_Pet']['discriminator'] = 'type'
+      subject['InheritanceTest_Entities_Cat'].key?('allOf')
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: Garrett Blehm <garrett.blehm@cerner.com>

Addresses issue #797.

Updated `parse_entity_name` method to use RFC3986 compliant `_` instead of `::` as separator. 