### PR TITLE
Don't overwrite model description with the route description.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 #### Fixes
 
 * Your contribution here.
-
+* [#804](https://github.com/ruby-grape/grape-swagger/pull/804): Don't overwrite model description with the route description. - [@Bhacaz](https://github.com/Bhacaz)
 
 ### 1.2.1 (July 15, 2020)
 

--- a/README.md
+++ b/README.md
@@ -859,10 +859,11 @@ get '/thing', failure: [
 end
 ```
 
-By adding a `model` key, e.g. this would be taken.
+By adding a `model` key, e.g. this would be taken. Setting an empty string will act like an empty body.
 ```ruby
 get '/thing', failure: [
   { code: 400, message: 'General error' },
+  { code: 403, message: 'Forbidden error', model: '' },
   { code: 422, message: 'Invalid parameter entry', model: Entities::ApiError }
 ] do
   # ...

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,5 +1,9 @@
 ## Upgrading Grape-swagger
 
+### Upgrading to >= 1.3.0
+
+- The model (entity) description no longer comes from the route description. It will have a default value: `<<EntityName>> model`.
+
 ### Upgrading to >= 1.2.0
 
 - The entity_name class method is now called on parent classes for inherited entities. Now you can do this

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -145,23 +145,23 @@ RSpec.shared_context 'entity swagger example' do
 
   let(:swagger_nested_type) do
     {
-      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } }, 'description' => 'This returns something' },
+      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } }, 'description' => 'ApiError model' },
       'ResponseItem' => { 'type' => 'object', 'properties' => { 'id' => { 'type' => 'integer', 'format' => 'int32' }, 'name' => { 'type' => 'string' } } },
-      'UseItemResponseAsType' => { 'type' => 'object', 'properties' => { 'description' => { 'type' => 'string' }, 'responses' => { '$ref' => '#/definitions/ResponseItem' } }, 'description' => 'This returns something' }
+      'UseItemResponseAsType' => { 'type' => 'object', 'properties' => { 'description' => { 'type' => 'string' }, 'responses' => { '$ref' => '#/definitions/ResponseItem' } }, 'description' => 'UseItemResponseAsType model' }
     }
   end
 
   let(:swagger_entity_as_response_object) do
     {
-      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } }, 'description' => 'This returns something' },
+      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } }, 'description' => 'ApiError model' },
       'ResponseItem' => { 'type' => 'object', 'properties' => { 'id' => { 'type' => 'integer', 'format' => 'int32' }, 'name' => { 'type' => 'string' } } },
-      'UseResponse' => { 'type' => 'object', 'properties' => { 'description' => { 'type' => 'string' }, '$responses' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/ResponseItem' } } }, 'description' => 'This returns something' }
+      'UseResponse' => { 'type' => 'object', 'properties' => { 'description' => { 'type' => 'string' }, '$responses' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/ResponseItem' } } }, 'description' => 'UseResponse model' }
     }
   end
 
   let(:swagger_params_as_response_object) do
     {
-      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'description' => 'status code', 'type' => 'integer', 'format' => 'int32' }, 'message' => { 'description' => 'error message', 'type' => 'string' } }, 'description' => 'This returns something' }
+      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'description' => 'status code', 'type' => 'integer', 'format' => 'int32' }, 'message' => { 'description' => 'error message', 'type' => 'string' } }, 'description' => 'ApiError model' }
     }
   end
 
@@ -300,7 +300,7 @@ RSpec.shared_context 'entity swagger example' do
           'type' => 'object',
           'required' => ['elements'],
           'properties' => { 'elements' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/QueryInputElement' }, 'description' => 'Set of configuration' } },
-          'description' => 'nested route inside namespace'
+          'description' => 'QueryInput model'
         },
         'QueryInputElement' => {
           'type' => 'object',
@@ -310,7 +310,7 @@ RSpec.shared_context 'entity swagger example' do
         'ApiError' => {
           'type' => 'object',
           'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } },
-          'description' => 'This gets Things.'
+          'description' => 'ApiError model'
         },
         'Something' => {
           'type' => 'object',
@@ -320,7 +320,7 @@ RSpec.shared_context 'entity swagger example' do
             'links' => { 'type' => 'array', 'items' => { 'type' => 'link' } },
             'others' => { 'type' => 'text' }
           },
-          'description' => 'This gets Things.'
+          'description' => 'Something model'
         }
       }
     }

--- a/spec/support/model_parsers/mock_parser.rb
+++ b/spec/support/model_parsers/mock_parser.rb
@@ -112,7 +112,7 @@ RSpec.shared_context 'mock swagger example' do
             'description' => "it's a mock"
           }
         },
-        'description' => 'This returns something'
+        'description' => 'ApiError model'
       },
       'UseItemResponseAsType' => {
         'type' => 'object',
@@ -122,7 +122,7 @@ RSpec.shared_context 'mock swagger example' do
             'description' => "it's a mock"
           }
         },
-        'description' => 'This returns something'
+        'description' => 'UseItemResponseAsType model'
       }
     }
   end
@@ -137,7 +137,7 @@ RSpec.shared_context 'mock swagger example' do
             'description' => "it's a mock"
           }
         },
-        'description' => 'This returns something'
+        'description' => 'UseResponse model'
       },
       'ApiError' => {
         'type' => 'object',
@@ -147,7 +147,7 @@ RSpec.shared_context 'mock swagger example' do
             'description' => "it's a mock"
           }
         },
-        'description' => 'This returns something'
+        'description' => 'ApiError model'
       }
     }
   end
@@ -162,7 +162,7 @@ RSpec.shared_context 'mock swagger example' do
             'description' => "it's a mock"
           }
         },
-        'description' => 'This returns something'
+        'description' => 'ApiError model'
       }
     }
   end
@@ -296,7 +296,7 @@ RSpec.shared_context 'mock swagger example' do
               'description' => "it's a mock"
             }
           },
-          'description' => 'nested route inside namespace'
+          'description' => 'QueryInput model'
         },
         'ApiError' => {
           'type' => 'object',
@@ -306,7 +306,7 @@ RSpec.shared_context 'mock swagger example' do
               'description' => "it's a mock"
             }
           },
-          'description' => 'This gets Things.'
+          'description' => 'ApiError model'
         },
         'Something' => {
           'type' => 'object',
@@ -316,7 +316,7 @@ RSpec.shared_context 'mock swagger example' do
               'description' => "it's a mock"
             }
           },
-          'description' => 'This gets Things.'
+          'description' => 'Something model'
         }
       }
     }

--- a/spec/support/model_parsers/representable_parser.rb
+++ b/spec/support/model_parsers/representable_parser.rb
@@ -218,22 +218,22 @@ RSpec.shared_context 'representable swagger example' do
 
   let(:swagger_nested_type) do
     {
-      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'description' => 'status code', 'type' => 'integer', 'format' => 'int32' }, 'message' => { 'description' => 'error message', 'type' => 'string' } }, 'description' => 'This returns something' },
-      'UseItemResponseAsType' => { 'type' => 'object', 'properties' => { 'description' => { 'description' => '', 'type' => 'string' }, 'responses' => { 'description' => '', 'type' => 'ResponseItem' } }, 'description' => 'This returns something' }
+      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'description' => 'status code', 'type' => 'integer', 'format' => 'int32' }, 'message' => { 'description' => 'error message', 'type' => 'string' } }, 'description' => 'ApiError model' },
+      'UseItemResponseAsType' => { 'type' => 'object', 'properties' => { 'description' => { 'description' => '', 'type' => 'string' }, 'responses' => { 'description' => '', 'type' => 'ResponseItem' } }, 'description' => 'UseItemResponseAsType model' }
     }
   end
 
   let(:swagger_entity_as_response_object) do
     {
-      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'description' => 'status code', 'type' => 'integer', 'format' => 'int32' }, 'message' => { 'description' => 'error message', 'type' => 'string' } }, 'description' => 'This returns something' },
+      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'description' => 'status code', 'type' => 'integer', 'format' => 'int32' }, 'message' => { 'description' => 'error message', 'type' => 'string' } }, 'description' => 'ApiError model' },
       'ResponseItem' => { 'type' => 'object', 'properties' => { 'id' => { 'description' => '', 'type' => 'integer', 'format' => 'int32' }, 'name' => { 'description' => '', 'type' => 'string' } } },
-      'UseResponse' => { 'type' => 'object', 'properties' => { 'description' => { 'description' => '', 'type' => 'string' }, '$responses' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/ResponseItem' }, 'description' => '' } }, 'description' => 'This returns something' }
+      'UseResponse' => { 'type' => 'object', 'properties' => { 'description' => { 'description' => '', 'type' => 'string' }, '$responses' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/ResponseItem' }, 'description' => '' } }, 'description' => 'UseResponse model' }
     }
   end
 
   let(:swagger_params_as_response_object) do
     {
-      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'description' => 'status code', 'type' => 'integer', 'format' => 'int32' }, 'message' => { 'description' => 'error message', 'type' => 'string' } }, 'description' => 'This returns something' }
+      'ApiError' => { 'type' => 'object', 'properties' => { 'code' => { 'description' => 'status code', 'type' => 'integer', 'format' => 'int32' }, 'message' => { 'description' => 'error message', 'type' => 'string' } }, 'description' => 'ApiError model' }
     }
   end
 
@@ -372,7 +372,7 @@ RSpec.shared_context 'representable swagger example' do
           'type' => 'object',
           'required' => ['elements'],
           'properties' => { 'elements' => { 'type' => 'array', 'items' => { '$ref' => '#/definitions/QueryInputElement' }, 'description' => 'Set of configuration' } },
-          'description' => 'nested route inside namespace'
+          'description' => 'QueryInput model'
         },
         'QueryInputElement' => {
           'type' => 'object',
@@ -382,7 +382,7 @@ RSpec.shared_context 'representable swagger example' do
         'ApiError' => {
           'type' => 'object',
           'properties' => { 'code' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'status code' }, 'message' => { 'type' => 'string', 'description' => 'error message' } },
-          'description' => 'This gets Things.'
+          'description' => 'ApiError model'
         },
         'Something' => {
           'type' => 'object',
@@ -392,7 +392,7 @@ RSpec.shared_context 'representable swagger example' do
             'links' => { 'type' => 'array', 'items' => { 'description' => '', 'type' => 'link' } },
             'others' => { 'description' => '', 'type' => 'text' }
           },
-          'description' => 'This gets Things.'
+          'description' => 'Something model'
         }
       }
     }

--- a/spec/swagger_v2/api_swagger_v2_response_with_models_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_with_models_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'response' do
+  include_context "#{MODEL_PARSER} swagger example"
+
+  before :all do
+    module TheApi
+      class ResponseApiModels < Grape::API
+        format :json
+
+        desc 'This returns something',
+             success: [{ code: 200 }],
+             failure: [
+               { code: 400, message: 'NotFound', model: '' },
+               { code: 404, message: 'BadRequest', model: Entities::ApiError }
+             ]
+        get '/use-response' do
+          { 'declared_params' => declared(params) }
+        end
+
+        add_swagger_documentation(models: [Entities::UseResponse])
+      end
+    end
+  end
+
+  def app
+    TheApi::ResponseApiModels
+  end
+
+  describe 'uses entity as response object implicitly with route name' do
+    subject do
+      get '/swagger_doc/use-response'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/use-response']['get']).to eql(
+        'description' => 'This returns something',
+        'produces' => ['application/json'],
+        'responses' => {
+          '200' => { 'description' => 'This returns something', 'schema' => { '$ref' => '#/definitions/UseResponse' } },
+          '400' => { 'description' => 'NotFound' },
+          '404' => { 'description' => 'BadRequest', 'schema' => { '$ref' => '#/definitions/ApiError' } }
+        },
+        'tags' => ['use-response'],
+        'operationId' => 'getUseResponse'
+      )
+      expect(subject['definitions']).to eql(swagger_entity_as_response_object)
+    end
+  end
+end

--- a/spec/swagger_v2/reference_entity_spec.rb
+++ b/spec/swagger_v2/reference_entity_spec.rb
@@ -103,7 +103,7 @@ describe 'referenceEntity' do
             'description' => 'Something interesting.'
           }
         },
-        'description' => 'This returns kind and something or an error'
+        'description' => 'KindCustom model'
       )
     end
   end
@@ -122,7 +122,7 @@ describe 'referenceEntity' do
           'title' => { 'type' => 'string', 'description' => 'Title of the parent.' },
           'child' => { 'type' => 'string', 'description' => 'Child property.' }
         },
-        'description' => 'This returns a child entity'
+        'description' => 'MyAPI::Child model'
       )
     end
   end


### PR DESCRIPTION
This PR have 3 features around the API response documentation.

1. Removing the assignation of the model description from route description. Some work was already started in this PR https://github.com/ruby-grape/grape-swagger/pull/629.
2. Generate models documentation before the routes.
3. Add the ability to specified no model (or empty body).

### 1. Removing the assignation of the model description from route description.

I face the same problem explain in:
* https://github.com/ruby-grape/grape-swagger/pull/629
* https://github.com/ruby-grape/grape-swagger/issues/578

And I try to continued to resolved it.

Following the PR comments and the bug suggestion, the change in this PR will set a description to the model only if it doesn't have one and with a generic sentence.

### 2. Generate models documentation before the routes.

When I was generating my documentation I observe that sometimes `Grape::Endpoint#response_object` try to find the model definition without succeed with `Grape::Endpoint#expose_params_from_model` simply because the route documentation was generated before the model definition.

### 3. Add the ability to specified no model (or empty body).

The last thing I add was the ability explicitly set no model (or an empty body) in the response, for example in the failures. The problem was that when none is explicitly passed, `Grape::Endpoint#response_object` is really good to found a model from the path and add it to the documentation.

I hope it will be satisfying.

