### PR TITLE
handle multiple presents

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -54,7 +54,7 @@ Metrics/BlockLength:
     - spec/**/*
 
 Metrics/ClassLength:
-  Max: 300
+  Max: 350
 
 Metrics/CyclomaticComplexity:
   Max: 17

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -28,7 +28,7 @@ Metrics/MethodLength:
 
 # Offense count: 7
 Metrics/PerceivedComplexity:
-  Max: 14
+  Max: 16
 
 # Offense count: 3
 Style/ClassVars:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * Your contribution here.
+* [#813](https://github.com/ruby-grape/grape-swagger/pull/813): Handle multiple presents - [@AntoineGuestin](https://github.com/AntoineGuestin).
 
 #### Fixes
 

--- a/README.md
+++ b/README.md
@@ -458,6 +458,7 @@ add_swagger_documentation \
 * [Response examples documentation](#response-examples)
 * [Response headers documentation](#response-headers)
 * [Adding root element to responses](#response-root)
+* [Multiple present Response](#multiple-response)
 
 #### Swagger Header Parameters  <a name="headers"></a>
 
@@ -1258,6 +1259,75 @@ The result will look like following:
       "schema": {
         "type": "object",
         "properties": { "type": "array", "items": { "kittens": { "$ref": "#/definitions/Kitten" } } }
+      }
+    }
+  }
+```
+#### Multiple present Response <a name="multiple-response"></a>
+
+You can specify a custom multiple response by using the `as` key:
+```ruby
+desc 'Multiple response',
+  success: [
+    { model: Entities::EnumValues, as: :gender },
+    { model: Entities::Something, as: :somethings }
+  ]
+end
+
+get '/things' do
+  ...
+end
+```
+The result will look like following:
+```
+  "responses": {
+    "200": {
+      "description": "Multiple response",
+      "schema":{
+        "type":"object",
+        "properties":{
+          "gender":{
+            "$ref":"#/definitions/EnumValues"
+          },
+          "somethings":{
+            "$ref":"#/definitions/Something"
+          }
+        }
+      }
+    }
+  }
+```
+You can also specify if the response is an array, with the `is_array` key:
+```ruby
+desc 'Multiple response with array',
+  success: [
+    { model: Entities::EnumValues, as: :gender },
+    { model: Entities::Something, as: :somethings, is_array: true }
+  ]
+end
+
+get '/things' do
+  ...
+end
+```
+The result will look like following:
+```
+  "responses": {
+    "200": {
+      "description": "Multiple response with array",
+      "schema":{
+        "type":"object",
+        "properties":{
+          "gender":{
+            "$ref":"#/definitions/EnumValues"
+          },
+          "somethings":{
+            "type":"array",
+            "items":{
+                "$ref":"#/definitions/Something"
+            }
+          }
+        }
       }
     }
   }

--- a/spec/issues/776_multiple_presents_spec.rb
+++ b/spec/issues/776_multiple_presents_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe '#776 multiple presents spec' do
+  include_context "#{MODEL_PARSER} swagger example"
+
+  let(:app) do
+    Class.new(Grape::API) do
+      namespace :issue_776 do
+        desc 'Get multiple presents',
+             success: [
+               { model: Entities::EnumValues, as: :gender },
+               { model: Entities::Something, as: :somethings, is_array: true }
+             ]
+
+        get do
+          present :gender, { number: 1, gender: 'Male' }, with: Entities::EnumValues
+          present :somethings, [
+            { id: 1, text: 'element_1', links: %w[link1 link2] },
+            { id: 2, text: 'element_2', links: %w[link1 link2] }
+          ], with: Entities::Something, is_array: true
+        end
+      end
+
+      add_swagger_documentation format: :json
+    end
+  end
+
+  subject do
+    get '/swagger_doc'
+    JSON.parse(last_response.body)
+  end
+
+  let(:definitions) { subject['definitions'] }
+  let(:schema) { subject['paths']['/issue_776']['get']['responses']['200']['schema'] }
+
+  specify { expect(definitions.keys).to include 'EnumValues', 'Something' }
+
+  specify do
+    expect(schema).to eql({
+      'properties' => {
+        'somethings' => {
+          'items' => {
+            '$ref' => '#/definitions/Something'
+          },
+          'type' => 'array'
+        },
+        'gender' => {
+          '$ref' => '#/definitions/EnumValues'
+        }
+      },
+      'type' => 'object'
+    })
+  end
+end


### PR DESCRIPTION
Handle the multiple present with swagger.
relates to : https://github.com/ruby-grape/grape-swagger/issues/776


**Exemple :**
You need to pass `as` parameter, to correctly generate the properties :
```ruby
desc 'Get multiple presents',
             success: [
               { model: Entities::EnumValues, as: :gender },
               { model: Entities::Something, as: :somethings, is_array: true }
             ]
```
And this generate the swagger schema like this : 
```json
{
   "schema":{
      "type":"object",
      "properties":{
         "gender":{
            "$ref":"#/definitions/EnumValues"
         },
         "somethings":{
            "type":"array",
            "items":{
               "$ref":"#/definitions/Something"
            }
         }
      }
   }
}
```
