### PR TITLE
Corrected the related parameter lookup on request params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 #### Fixes
 
 * Your contribution here.
-
+* [#822](https://github.com/ruby-grape/grape-swagger/pull/822): Corrected the related parameter lookup on request params - [@Jack12816](https://github.com/Jack12816).
 
 ### 1.3.1 (November 1, 2020)
 

--- a/lib/grape-swagger/doc_methods/format_data.rb
+++ b/lib/grape-swagger/doc_methods/format_data.rb
@@ -7,7 +7,7 @@ module GrapeSwagger
         def to_format(parameters)
           parameters.reject { |parameter| parameter[:in] == 'body' }.each do |b|
             related_parameters = parameters.select do |p|
-              p[:name] != b[:name] && p[:name].to_s.include?("#{b[:name].to_s.gsub(/\[\]\z/, '')}[")
+              p[:name] != b[:name] && p[:name].to_s.start_with?("#{b[:name].to_s.gsub(/\[\]\z/, '')}[")
             end
             parameters.reject! { |p| p[:name] == b[:name] } if move_down(b, related_parameters)
           end

--- a/spec/lib/format_data_spec.rb
+++ b/spec/lib/format_data_spec.rb
@@ -87,5 +87,29 @@ describe GrapeSwagger::DocMethods::FormatData do
         expect(subject.to_format(params)).to eq expected_params
       end
     end
+
+    context 'when array params are not related' do
+      let(:params) do
+        [
+          { name: 'id', required: true, type: 'string' },
+          { name: 'description', required: false, type: 'string' },
+          { name: 'ids[]', required: true, type: 'array', items: { type: 'string' } },
+          { name: 'user_ids[]', required: true, type: 'array', items: { type: 'string' } }
+        ]
+      end
+
+      let(:expected_params) do
+        [
+          { name: 'id', required: true, type: 'string' },
+          { name: 'description', required: false, type: 'string' },
+          { name: 'ids[]', required: true, type: 'array', items: { type: 'string' } },
+          { name: 'user_ids[]', required: true, type: 'array', items: { type: 'string' } }
+        ]
+      end
+
+      it 'parses params correctly and adds array type all concerned elements' do
+        expect(subject.to_format(params)).to eq expected_params
+      end
+    end
   end
 end


### PR DESCRIPTION
**- What is it good for**

There is a nasty bug while using grape-swagger on request parameters that share the same base name in any way (eg. `ids` and `user_ids`) which results in a missing parameter and a badly named on (eg. `ids` is missing, while `user_ids[][]` is renamed to). An example Grape API class looks like this:

```ruby
class Search < Grape::API
  params do
    with(allow_blank: false) do
      optional :ids, type: [String]
      optional :user_ids, type: [String]
    end
  end
  # [..]
end          
```

**- What I did**

I just changed the related parameter matching to use `start_with?` instead of `include?` to be sure that the related parameter is not accidentally matched while respecting actual matches. (eg. `user_id` and `user_id[id]`)

**- A picture of a cute animal (not mandatory but encouraged)**

![download](https://user-images.githubusercontent.com/2496275/111176202-69725580-85a9-11eb-8801-ce9b36e1961f.jpeg)
