### PR TITLE
Examples in body params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#833](https://github.com/ruby-grape/grape-swagger/pull/833): Fixes issue of examples not showing for `in: 'body'` parameters - [@stevenou](https://github.com/stevenou)
 
 
 ### 1.4.0 (March 20, 2021)

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -181,7 +181,7 @@ module GrapeSwagger
         end
 
         def property_keys
-          %i[type format description minimum maximum items enum default additionalProperties]
+          %i[type format description minimum maximum items enum default additionalProperties example]
         end
 
         def deletable?(param)

--- a/spec/support/the_paths_definitions.rb
+++ b/spec/support/the_paths_definitions.rb
@@ -8,7 +8,7 @@ RSpec.shared_context 'the api paths/defs' do
           produces: ['application/json'],
           consumes: ['application/json'],
           parameters: [
-            { in: 'body', name: 'in_body_1', description: 'in_body_1', type: 'integer', format: 'int32', required: true },
+            { in: 'body', name: 'in_body_1', description: 'in_body_1', type: 'integer', format: 'int32', required: true, example: 23 },
             { in: 'body', name: 'in_body_2', description: 'in_body_2', type: 'string', required: false },
             { in: 'body', name: 'in_body_3', description: 'in_body_3', type: 'string', required: false }
           ],
@@ -31,7 +31,7 @@ RSpec.shared_context 'the api paths/defs' do
             { in: 'path', name: 'key', description: nil, type: 'integer', format: 'int32', required: true },
             { in: 'body', name: 'in_body_1', description: 'in_body_1', type: 'integer', format: 'int32', required: true },
             { in: 'body', name: 'in_body_2', description: 'in_body_2', type: 'string', required: false },
-            { in: 'body', name: 'in_body_3', description: 'in_body_3', type: 'string', required: false }
+            { in: 'body', name: 'in_body_3', description: 'in_body_3', type: 'string', required: false, example: 'my example string' }
           ],
           responses: { 200 => { description: 'put in body /wo entity', schema: { '$ref' => '#/definitions/InBody' } } },
           tags: ['in_body'],
@@ -85,7 +85,7 @@ RSpec.shared_context 'the api paths/defs' do
     {
       type: 'object',
       properties: {
-        in_body_1: { type: 'integer', format: 'int32', description: 'in_body_1' },
+        in_body_1: { type: 'integer', format: 'int32', description: 'in_body_1', example: 23 },
         in_body_2: { type: 'string', description: 'in_body_2' },
         in_body_3: { type: 'string', description: 'in_body_3' }
       },
@@ -99,7 +99,7 @@ RSpec.shared_context 'the api paths/defs' do
       properties: {
         in_body_1: { type: 'integer', format: 'int32', description: 'in_body_1' },
         in_body_2: { type: 'string', description: 'in_body_2' },
-        in_body_3: { type: 'string', description: 'in_body_3' }
+        in_body_3: { type: 'string', description: 'in_body_3', example: 'my example string' }
       },
       required: [:in_body_1]
     }


### PR DESCRIPTION
When a parameter is `in: 'body'`, it appears to drop the example associated. So it will show: 
```
{
  email: 'string',
  password: 'string'
}
``` 
instead of 
```
{
  email: 'example@esp.com',
  password: 'wowthispasswordissosecure!'
}
```

I took a look at https://github.com/ruby-grape/grape-swagger/issues/762 and https://github.com/ruby-grape/grape-swagger/pull/821 which purportedly fix the issue, but it still wasn't working for me.

I'm really not familiar with this codebase, but I think the issue is within `GrapeSwagger::DocMethods::MoveParams` which has a `property_keys` that appears to limit which properties are retained when creating an "`in: body` object". I added the `example` key to that array and it seems to be working.

Would appreciate confirmation whether this is correct fix. Thanks!