### PR TITLE
Fixes the regexp used for parsing routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * [#852](https://github.com/ruby-grape/grape-swagger/pull/852): Fix example to work without error - [@takahashim](https://github.com/takahashim)
 * Your contribution here.
 * [#853](https://github.com/ruby-grape/grape-swagger/pull/853): Add webrick gem so that example works in Ruby 3.x - [@takahashim](https://github.com/takahashim)
+* [#844](https://github.com/ruby-grape/grape-swagger/pull/844): Fixes the regexp used for parsing routes - [@senhalil](https://github.com/senhalil)
 
 ### 1.4.2 (October 22, 2021)
 

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -31,8 +31,8 @@ module SwaggerRouting
 
       # want to match emojis … ;)
       # route_match = route_match
-      #   .match('\/([\p{Alnum}|\p{Emoji}|\-|\_]*?)[\.\/\(]') || route_match.match('\/([\p{Alpha}|\p{Emoji}|\-|\_]*)$')
-      route_match = route_match.match('\/([\p{Alnum}|\-|\_]*?)[\.\/\(]') || route_match.match('\/([\p{Alpha}|\-|\_]*)$')
+      #   .match('\/([\p{Alnum}p{Emoji}\-\_]*?)[\.\/\(]') || route_match.match('\/([\p{Alpha}\p{Emoji}\-\_]*)$')
+      route_match = route_match.match('\/([\p{Alnum}\-\_]*?)[\.\/\(]') || route_match.match('\/([\p{Alpha}\-\_]*)$')
       next unless route_match
 
       resource = route_match.captures.first


### PR DESCRIPTION
When called `add_swagger_documentation` raises the following warning which is due to vertical bars `|` since they are parsed as literal characters and not as OR's in a character set `[]` definition.

```
grape-swagger-1.4.2/lib/grape-swagger.rb:35: warning: character class has duplicated range: /\/([\p{Alnum}|\-|\_]*?)[\.\/\(]/
```