### PR TITLE
Fix value of `enum` to be `Array`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#850](https://github.com/ruby-grape/grape-swagger/pull/850): Fix value of `enum` to be `Array` - [@takahashim](https://github.com/takahashim)
 * Your contribution here.
 
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -3,6 +3,7 @@
 ### Upgrading to >= 1.4.2
 
 - `additionalProperties` has been deprecated and will be removed in a future version of `grape-swagger`. It has been replaced with `additional_properties`.
+- The value of the `enum` attribute is now always an Array. If it has only one value, it will be a one-element Array.
 
 ### Upgrading to >= 1.4.0
 

--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -163,8 +163,10 @@ module GrapeSwagger
             parse_enum_or_range_values(values.call) if values.parameters.empty?
           when Range
             parse_range_values(values) if values.first.is_a?(Integer)
+          when Array
+            { enum: values }
           else
-            { enum: values } if values
+            { enum: [values] } if values
           end
         end
 

--- a/spec/swagger_v2/param_values_spec.rb
+++ b/spec/swagger_v2/param_values_spec.rb
@@ -141,7 +141,7 @@ describe 'Convert values to enum for float range and not arrays inside a proc', 
         'name' => 'letter',
         'type' => 'string',
         'required' => true,
-        'enum' => 'string'
+        'enum' => %w[string]
       }]
     end
   end


### PR DESCRIPTION
I am trying to use grape-swagger and other OpenAPI tools, but currently there seems to be a problem with the schema generated by grape-swagger.

In the OpenAPI 2.0 specification, `enum` uses the JSON Schema `enum`.

* https://github.com/OAI/OpenAPI-Specification/blob/f6f9ab3d88ad6ff0b235d5f4dc1a8ab28941d895/schemas/v2.0/schema.json#L1001-L1003
* https://swagger.io/specification/v2/

In JSON Schema, the value of an `enum` is expected to be an `Array`.

* https://datatracker.ietf.org/doc/html/draft-fge-json-schema-validation-00#section-5.5.1

However, in grape-swagger, an `enum` value can be a `String` literal.

This pull request fixes that and returns an `Array`.

I hope this change can be accepted.
