### PR TITLE
Fix example to work without error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * [#850](https://github.com/ruby-grape/grape-swagger/pull/850): Fix value of `enum` to be `Array` - [@takahashim](https://github.com/takahashim)
 * [#846] (https://github.com/ruby-grape/grape-swagger/pull/846): Fixes oapi rake tasks, allows generating sepcs for different API versions.
+* [#852](https://github.com/ruby-grape/grape-swagger/pull/852): Fix example to work without error - [@takahashim](https://github.com/takahashim)
+* Your contribution here.
 
 ### 1.4.2 (October 22, 2021)
 

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,9 @@ group :test do
 
   gem 'ruby-grape-danger', '~> 0.2.0', require: false
   gem 'simplecov', require: false
+end
 
+group :test, :development do
   unless ENV['MODEL_PARSER'] == 'grape-swagger-entity'
     gem 'grape-swagger-entity', git: 'https://github.com/ruby-grape/grape-swagger-entity'
   end

--- a/example/config.ru
+++ b/example/config.ru
@@ -1,4 +1,5 @@
-require 'rack/cors'
+Bundler.require ENV['RACK_ENV']
+
 use Rack::Cors do
   allow do
     origins '*'
@@ -12,7 +13,6 @@ require './api/endpoints'
 require './api/entities'
 
 class Base < Grape::API
-  require 'grape-entity'
   require '../lib/grape-swagger'
   format :json
 


### PR DESCRIPTION
Fix #851.

* load `grape-swagger-entity` gem in `:development` environment
* require gem files with `Bundler.require`

I have a few concerns about this fix.

* We can remove other `require`s in `config.ru` such as `require 'rack/cors'`. Should I remove them?
* Instead of adding the `grape-swagger-entity` gem in `:development` to the common Gemfile, should I add another Gemfile for example as `example/Gemfile` ?
