### PR TITLE
Remove unused methods in `GrapeSwagger::DocMethods::BuildModelDefinition`

### DIFF
--- a/lib/grape-swagger/doc_methods/build_model_definition.rb
+++ b/lib/grape-swagger/doc_methods/build_model_definition.rb
@@ -4,13 +4,8 @@ module GrapeSwagger
   module DocMethods
     class BuildModelDefinition
       class << self
-        def build(model, properties, required, other_def_properties = {})
+        def build(_model, properties, required, other_def_properties = {})
           definition = { type: 'object', properties: properties }.merge(other_def_properties)
-
-          if required.nil?
-            required_attrs = required_attributes(model)
-            definition[:required] = required_attrs unless required_attrs.blank?
-          end
 
           definition[:required] = required if required.is_a?(Array) && required.any?
 
@@ -66,20 +61,6 @@ module GrapeSwagger
               GrapeSwagger::DocMethods::BuildModelDefinition.build(model, properties, required)
             end
           end
-        end
-
-        private
-
-        def required_attributes(model)
-          parse_entity(model) || parse_representable(model)
-        end
-
-        def parse_entity(model)
-          return unless model.respond_to?(:documentation)
-        end
-
-        def parse_representable(model)
-          return unless model.respond_to?(:map)
         end
       end
     end


### PR DESCRIPTION
I was reading the code for `GrapeSwagger::DocMethods::BuildModelDefinition` and noticed that `parse_entity()` and `parse_representable()` return only `nil`.
Then, since `required_attributes()` also returns only `nil`, the `if` statement in `build()` would also be unnecessary since `required_attrs.blank?` would always be true.

Based on this code reading, I've tried to remove the unused code.
