### PR TITLE
Add Support for default response.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * [#872](https://github.com/ruby-grape/grape-swagger/pull/872): Add `consumes` and `produces` options to `add_swagger_documentation` - [@spaceraccoon](https://github.com/spaceraccoon)
+* [#868](https://github.com/ruby-grape/grape-swagger/pull/868): Add `default` endpoint option to specify default response - [@dhruvCW](https://github.com/dhruvCW)
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -1042,6 +1042,50 @@ end
 }
 ```
 
+#### Default response <a name="default-response"></a>
+
+By setting the `default` option you can also define a default response that is the result returned for all unspecified status codes.
+The definition supports the same syntax as `success` or `failure`.
+
+In the following cases, the schema ref would be taken from route.
+
+```ruby
+desc 'thing', default: { message: 'the default response' }
+get '/thing' do
+  # ...
+end
+```
+The generated swagger section will be something like
+
+```json
+"responses": {
+  "default": {
+    "description": "the default response"
+  }
+},
+```
+Just like with `success` or `failure` you can also provide a `model` parameter.
+
+```ruby
+desc 'Get a list of stuff',
+    default: { model: Entities::UseResponse, message: 'the default response' }
+get do
+  # your code comes here
+end
+```
+The generated swagger document will then correctly reference the model schema.
+
+```json
+"responses": {
+  "default": {
+    "description": "the default response",
+    "schema": {
+      "$ref": "#/definitions/UseResponse"
+    }
+  }
+},
+```
+
 
 #### Extensions <a name="extensions"></a>
 

--- a/spec/swagger_v2/api_swagger_v2_response_with_models_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_with_models_spec.rb
@@ -15,7 +15,8 @@ describe 'response' do
              failure: [
                { code: 400, message: 'NotFound', model: '' },
                { code: 404, message: 'BadRequest', model: Entities::ApiError }
-             ]
+             ],
+             default_response: { message: 'Error', model: Entities::ApiError }
         get '/use-response' do
           { 'declared_params' => declared(params) }
         end
@@ -42,7 +43,8 @@ describe 'response' do
         'responses' => {
           '200' => { 'description' => 'This returns something', 'schema' => { '$ref' => '#/definitions/UseResponse' } },
           '400' => { 'description' => 'NotFound' },
-          '404' => { 'description' => 'BadRequest', 'schema' => { '$ref' => '#/definitions/ApiError' } }
+          '404' => { 'description' => 'BadRequest', 'schema' => { '$ref' => '#/definitions/ApiError' } },
+          'default' => { 'description' => 'Error', 'schema' => { '$ref' => '#/definitions/ApiError' } }
         },
         'tags' => ['use-response'],
         'operationId' => 'getUseResponse'


### PR DESCRIPTION
add support for `default` as a response code as specified in https://swagger.io/docs/specification/2-0/describing-responses/ Default Response section.

thus allowing for specifying a model that corresponds to all http status codes that are not specifically mentioned.