### PR TITLE
show that rake oapi:fetch generates wrong output filename

### DIFF
--- a/spec/lib/oapi_tasks_spec.rb
+++ b/spec/lib/oapi_tasks_spec.rb
@@ -137,7 +137,7 @@ RSpec.describe GrapeSwagger::Rake::OapiTasks do
       it 'returns swagger_doc.json' do
         expect(subject.send(:file, docs_url)).to end_with 'swagger_doc.json'
       end
-      
+
       context 'api has version' do
         it 'returns versioned swagger_doc.json' do
           expect(File.basename(subject.send(:file, docs_url))).to eq('swagger_doc_v1.json')
@@ -154,6 +154,12 @@ RSpec.describe GrapeSwagger::Rake::OapiTasks do
         it 'returns swagger_doc.json' do
           expect(subject.send(:file, docs_url)).to end_with 'swagger_doc.json'
         end
+
+        context 'api has version' do
+          it 'returns versioned swagger_doc.json' do
+            expect(File.basename(subject.send(:file, docs_url))).to eq('swagger_doc_v1.json')
+          end
+        end
       end
 
       describe 'name given' do
@@ -162,6 +168,12 @@ RSpec.describe GrapeSwagger::Rake::OapiTasks do
 
         it 'returns swagger_doc.json' do
           expect(subject.send(:file, docs_url)).to include(name.split('.')[0])
+        end
+
+        context 'api has version' do
+          it 'returns versioned oapi_doc.json' do
+            expect(File.basename(subject.send(:file, docs_url))).to eq('oapi_doc_v1.json')
+          end
         end
       end
     end

--- a/spec/lib/oapi_tasks_spec.rb
+++ b/spec/lib/oapi_tasks_spec.rb
@@ -137,6 +137,12 @@ RSpec.describe GrapeSwagger::Rake::OapiTasks do
       it 'returns swagger_doc.json' do
         expect(subject.send(:file, docs_url)).to end_with 'swagger_doc.json'
       end
+      
+      context 'api has version' do
+        it 'returns versioned swagger_doc.json' do
+          expect(File.basename(subject.send(:file, docs_url))).to eq('swagger_doc_v1.json')
+        end
+      end
     end
 
     describe 'store given' do


### PR DESCRIPTION
So when I do `rake oapi:fetch` (regardless of `store` parameter value) the generated swagger doc is called `swagger_doc_swagger_doc.json` which looks weird and is probably incorrect.

```
Failures:

  1) GrapeSwagger::Rake::OapiTasks#file store given boolean true api has version returns versioned swagger_doc.json
     Failure/Error: expect(File.basename(subject.send(:file, docs_url))).to eq('swagger_doc_v1.json')

       expected: "swagger_doc_v1.json"
            got: "swagger_doc_swagger_doc.json"

       (compared using ==)
     # ./spec/lib/oapi_tasks_spec.rb:160:in `block (6 levels) in <top (required)>'

  2) GrapeSwagger::Rake::OapiTasks#file store given name given api has version returns versioned oapi_doc.json
     Failure/Error: expect(File.basename(subject.send(:file, docs_url))).to eq('oapi_doc_v1.json')

       expected: "oapi_doc_v1.json"
            got: "oapi_doc_swagger_doc.json"

       (compared using ==)
     # ./spec/lib/oapi_tasks_spec.rb:175:in `block (6 levels) in <top (required)>'

  3) GrapeSwagger::Rake::OapiTasks#file no store given api has version returns versioned swagger_doc.json
     Failure/Error: expect(File.basename(subject.send(:file, docs_url))).to eq('swagger_doc_v1.json')

       expected: "swagger_doc_v1.json"
            got: "swagger_doc_swagger_doc.json"
```