### PR TITLE
Add consumes and produces options to add_swagger_documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#872](https://github.com/ruby-grape/grape-swagger/pull/872): Add `consumes` and `produces` options to `add_swagger_documentation` - [@spaceraccoon](https://github.com/spaceraccoon)
 * Your contribution here.
 
 #### Fixes

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ end
 * [array_use_braces](#array_use_braces)
 * [api_documentation](#api_documentation)
 * [specific_api_documentation](#specific_api_documentation)
+* [consumes](#consumes)
+* [produces](#produces)
 
 You can pass a hash with optional configuration settings to ```add_swagger_documentation```.
 The examples show the default value.
@@ -430,6 +432,24 @@ Customize the Swagger API specific documentation route, typically contains a `de
 ```ruby
 add_swagger_documentation \
    specific_api_documentation: { desc: 'Reticulated splines API swagger-compatible endpoint documentation.' }
+```
+
+#### consumes
+
+Customize the Swagger API default global `consumes` field value.
+
+```ruby
+add_swagger_documentation \
+   consumes: ['application/json', 'application/x-www-form-urlencoded']
+```
+
+#### produces
+
+Customize the Swagger API default global `produces` field value.
+
+```ruby
+add_swagger_documentation \
+   produces: ['text/plain']
 ```
 
 ## Routes Configuration <a name="routes"></a>

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -27,7 +27,8 @@ module Grape
       object = {
         info: info_object(options[:info].merge(version: options[:doc_version])),
         swagger: '2.0',
-        produces: content_types_for(target_class),
+        produces: options[:produces] || content_types_for(target_class),
+        consumes: options[:consumes],
         authorizations: options[:authorizations],
         securityDefinitions: options[:security_definitions],
         security: options[:security],
@@ -117,7 +118,7 @@ module Grape
       method[:summary]     = summary_object(route)
       method[:description] = description_object(route)
       method[:produces]    = produces_object(route, options[:produces] || options[:format])
-      method[:consumes]    = consumes_object(route, options[:format])
+      method[:consumes]    = consumes_object(route, options[:consumes] || options[:format])
       method[:parameters]  = params_object(route, options, path)
       method[:security]    = security_object(route)
       method[:responses]   = response_object(route, options)

--- a/spec/issues/677_consumes_produces_add_swagger_documentation_options_spec.rb
+++ b/spec/issues/677_consumes_produces_add_swagger_documentation_options_spec.rb
@@ -1,0 +1,100 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe '#677 consumes and produces options are included in add_swagger_documentation options' do
+  describe 'no override' do
+    let(:app) do
+      Class.new(Grape::API) do
+        resource :accounts do
+          route_param :account_number, type: String do
+            resource :records do
+              route_param :id do
+                post do
+                  { message: 'hello world' }
+                end
+              end
+            end
+          end
+        end
+
+        add_swagger_documentation \
+          format: :json
+      end
+    end
+
+    subject do
+      get '/swagger_doc'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/accounts/{account_number}/records/{id}']['post']['produces']).to eq ['application/json']
+      expect(subject['paths']['/accounts/{account_number}/records/{id}']['post']['consumes']).to eq ['application/json']
+    end
+  end
+
+  describe 'override produces' do
+    let(:app) do
+      Class.new(Grape::API) do
+        resource :accounts do
+          route_param :account_number, type: String do
+            resource :records do
+              route_param :id do
+                post do
+                  { message: 'hello world' }
+                end
+              end
+            end
+          end
+        end
+
+        add_swagger_documentation \
+          format: :json,
+          produces: ['text/plain']
+      end
+    end
+
+    subject do
+      get '/swagger_doc'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/accounts/{account_number}/records/{id}']['post']['produces']).to eq ['text/plain']
+      expect(subject['paths']['/accounts/{account_number}/records/{id}']['post']['consumes']).to eq ['application/json']
+    end
+  end
+
+  describe 'override consumes' do
+    let(:app) do
+      Class.new(Grape::API) do
+        resource :accounts do
+          route_param :account_number, type: String do
+            resource :records do
+              route_param :id do
+                post do
+                  { message: 'hello world' }
+                end
+              end
+            end
+          end
+        end
+
+        add_swagger_documentation \
+          format: :json, \
+          consumes: ['application/json', 'application/x-www-form-urlencoded']
+      end
+    end
+
+    subject do
+      get '/swagger_doc'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/accounts/{account_number}/records/{id}']['post']['produces']).to eq ['application/json']
+      expect(subject['paths']['/accounts/{account_number}/records/{id}']['post']['consumes']).to eq ['application/json', 'application/x-www-form-urlencoded']
+    end
+  end
+end


### PR DESCRIPTION
As per issues #677 and #623, there is demand to allow for setting the global/default `consumes` and `produces` field value via `add_swagger_documentation`. In any case, the global fields are officially supported in the [OpenAPI spec](https://swagger.io/specification/v2/#swaggerConsumes).

This will make it a lot easier to support non-JSON content-types at the global level, since the current default is `application/json`, forcing affected users to set the type at each endpoint instead of globally/by default.