### PR TITLE
Search for routes that contain swagger_doc

### DIFF
--- a/lib/grape-swagger/rake/oapi_tasks.rb
+++ b/lib/grape-swagger/rake/oapi_tasks.rb
@@ -95,7 +95,7 @@ module GrapeSwagger
       def urls_for(api_class)
         api_class.routes
                  .map(&:path)
-                 .select { |e| e.include?('doc') }
+                 .select { |e| e.include?('swagger_doc') }
                  .reject { |e| e.include?(':name') }
                  .map { |e| format_path(e) }
                  .map { |e| [e, ENV.fetch('resource', nil)].join('/').chomp('/') }


### PR DESCRIPTION
If a client-defined route contains `doc` word, then the call to that URL will be unexpectedly performed

Let's filter the routes using `swagger_doc` instead