### PR TITLE
Set default parameter location based on consumes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#880](https://github.com/ruby-grape/grape-swagger/pull/880): Set default parameter location based on consumes - [@spaceraccoon](https://github.com/spaceraccoon)
 * Your contribution here.
 
 #### Fixes

--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -4,7 +4,7 @@ module GrapeSwagger
   module DocMethods
     class ParseParams
       class << self
-        def call(param, settings, path, route, definitions)
+        def call(param, settings, path, route, definitions, consumes)
           method = route.request_method
           additional_documentation = settings.fetch(:documentation, {})
           settings.merge!(additional_documentation)
@@ -14,7 +14,7 @@ module GrapeSwagger
 
           # required properties
           @parsed_param = {
-            in: param_type(value_type),
+            in: param_type(value_type, consumes),
             name: settings[:full_name] || param
           }
 
@@ -144,14 +144,14 @@ module GrapeSwagger
           @parsed_param[:example] = example if example
         end
 
-        def param_type(value_type)
+        def param_type(value_type, consumes)
           param_type = value_type[:param_type] || value_type[:in]
           if value_type[:path].include?("{#{value_type[:param_name]}}")
             'path'
           elsif param_type
             param_type
           elsif %w[POST PUT PATCH].include?(value_type[:method])
-            DataType.request_primitive?(value_type[:data_type]) ? 'formData' : 'body'
+            consumes.include?('application/x-www-form-urlencoded') || consumes.include?('multipart/form-data') ? 'formData' : 'body'
           else
             'query'
           end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -118,7 +118,7 @@ module Grape
       method[:description] = description_object(route)
       method[:produces]    = produces_object(route, options[:produces] || options[:format])
       method[:consumes]    = consumes_object(route, options[:format])
-      method[:parameters]  = params_object(route, options, path)
+      method[:parameters]  = params_object(route, options, path, method[:consumes])
       method[:security]    = security_object(route)
       method[:responses]   = response_object(route, options)
       method[:tags]        = route.options.fetch(:tags, tag_object(route, path))
@@ -174,7 +174,7 @@ module Grape
       GrapeSwagger::DocMethods::ProducesConsumes.call(route.settings.dig(:description, :consumes) || format)
     end
 
-    def params_object(route, options, path)
+    def params_object(route, options, path, consumes)
       parameters = build_request_params(route, options).each_with_object([]) do |(param, value), memo|
         next if hidden_parameter?(value)
 
@@ -186,7 +186,7 @@ module Grape
         elsif value[:type]
           expose_params(value[:type])
         end
-        memo << GrapeSwagger::DocMethods::ParseParams.call(param, value, path, route, @definitions)
+        memo << GrapeSwagger::DocMethods::ParseParams.call(param, value, path, route, @definitions, consumes)
       end
 
       if GrapeSwagger::DocMethods::MoveParams.can_be_moved?(route.request_method, parameters)

--- a/spec/issues/532_allow_custom_format_spec.rb
+++ b/spec/issues/532_allow_custom_format_spec.rb
@@ -6,6 +6,10 @@ describe '#532 allow custom format' do
   let(:app) do
     Class.new(Grape::API) do
       namespace :issue_532 do
+        desc 'issue_532' do
+          consumes ['application/x-www-form-urlencoded']
+        end
+
         params do
           requires :logs, type: String, documentation: { format: 'log' }
           optional :phone_number, type: Integer, documentation: { format: 'phone_number' }

--- a/spec/issues/553_align_array_put_post_params_spec.rb
+++ b/spec/issues/553_align_array_put_post_params_spec.rb
@@ -6,7 +6,9 @@ describe '#553 array of type in post/put params' do
   let(:app) do
     Class.new(Grape::API) do
       namespace :in_form_data do
-        desc 'create foo'
+        desc 'create foo' do
+          consumes ['application/x-www-form-urlencoded']
+        end
         params do
           requires :guid, type: Array[String]
         end
@@ -14,7 +16,9 @@ describe '#553 array of type in post/put params' do
           # your code goes here
         end
 
-        desc 'put specific foo'
+        desc 'put specific foo' do
+          consumes ['application/x-www-form-urlencoded']
+        end
         params do
           requires :id
           requires :guid, type: Array[String]
@@ -25,7 +29,9 @@ describe '#553 array of type in post/put params' do
       end
 
       namespace :in_body do
-        desc 'create foo'
+        desc 'create foo' do
+          consumes ['application/x-www-form-urlencoded']
+        end
         params do
           requires :guid, type: Array[String], documentation: { param_type: 'body' }
         end
@@ -33,7 +39,9 @@ describe '#553 array of type in post/put params' do
           # your code goes here
         end
 
-        desc 'put specific foo'
+        desc 'put specific foo' do
+          consumes ['application/x-www-form-urlencoded']
+        end
         params do
           requires :id
           requires :guid, type: Array[String], documentation: { param_type: 'body' }

--- a/spec/issues/579_align_put_post_parameters_spec.rb
+++ b/spec/issues/579_align_put_post_parameters_spec.rb
@@ -21,8 +21,9 @@ describe '#579 put / post parameters spec' do
         namespace :implicit do
           namespace :body_parameter do
             desc 'update spec',
-                 success: BodySpec,
-                 params: BodySpec.documentation
+              consumes: ['application/x-www-form-urlencoded'],
+              success: BodySpec,
+              params: BodySpec.documentation
             put ':guid' do
               # your code goes here
             end
@@ -30,8 +31,9 @@ describe '#579 put / post parameters spec' do
 
           namespace :form_parameter do
             desc 'update spec',
-                 success: Spec,
-                 params: Spec.documentation
+              consumes: ['application/x-www-form-urlencoded'],
+              success: Spec,
+              params: Spec.documentation
             put ':guid' do
               # your code goes here
             end
@@ -41,8 +43,9 @@ describe '#579 put / post parameters spec' do
         namespace :explicit do
           namespace :body_parameter do
             desc 'update spec',
-                 success: BodySpec,
-                 params: BodySpec.documentation
+              consumes: ['application/x-www-form-urlencoded'],
+              success: BodySpec,
+              params: BodySpec.documentation
             params do
               requires :guid
             end
@@ -53,8 +56,9 @@ describe '#579 put / post parameters spec' do
 
           namespace :form_parameter do
             desc 'update spec',
-                 success: Spec,
-                 params: Spec.documentation
+              consumes: ['application/x-www-form-urlencoded'],
+              success: Spec,
+              params: Spec.documentation
             params do
               requires :guid
             end
@@ -68,8 +72,9 @@ describe '#579 put / post parameters spec' do
           route_param :guid do
             namespace :body_parameter do
               desc 'update spec',
-                   success: BodySpec,
-                   params: BodySpec.documentation
+                consumes: ['application/x-www-form-urlencoded'],
+                success: BodySpec,
+                params: BodySpec.documentation
               put do
                 # your code goes here
               end
@@ -77,8 +82,9 @@ describe '#579 put / post parameters spec' do
 
             namespace :form_parameter do
               desc 'update spec',
-                   success: Spec,
-                   params: Spec.documentation
+                consumes: ['application/x-www-form-urlencoded'],
+                success: Spec,
+                params: Spec.documentation
               put do
                 # your code goes here
               end

--- a/spec/issues/650_params_array_spec.rb
+++ b/spec/issues/650_params_array_spec.rb
@@ -5,6 +5,9 @@ require 'spec_helper'
 describe '#605 Group Params as Array' do
   let(:app) do
     Class.new(Grape::API) do
+      desc 'array_of_range' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :array_of_range_string, type: [String], values: %w[a b c]
         requires :array_of_range_integer, type: [Integer], values: [1, 2, 3]
@@ -13,6 +16,9 @@ describe '#605 Group Params as Array' do
         { 'declared_params' => declared(params) }
       end
 
+      desc 'array_with_default' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :array_with_default_string, type: [String], default: 'abc'
         requires :array_with_default_integer, type: Array[Integer], default: 123

--- a/spec/issues/721_set_default_parameter_location_based_on_consumes_spec.rb
+++ b/spec/issues/721_set_default_parameter_location_based_on_consumes_spec.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe '#721 set default parameter location based on consumes' do
+  let(:app) do
+    Class.new(Grape::API) do
+      namespace :issue_721 do
+        desc 'create item' do
+          consumes ['application/json']
+        end
+
+        params do
+          requires :logs, type: String
+          optional :phone_number, type: Integer
+        end
+
+        post do
+          present params
+        end
+
+        desc 'modify item' do
+          consumes ['application/x-www-form-urlencoded']
+        end
+
+        params do
+          requires :id, type: Integer
+          requires :logs, type: String
+          optional :phone_number, type: Integer
+        end
+
+        put ':id' do
+          present params
+        end
+      end
+
+      add_swagger_documentation
+    end
+  end
+
+  subject do
+    get '/swagger_doc'
+    JSON.parse(last_response.body)
+  end
+
+  let(:post_parameters) { subject['paths']['/issue_721']['post']['parameters'] }
+  let(:post_schema) { subject['definitions']['postIssue721'] }
+  let(:put_parameters) { subject['paths']['/issue_721/{id}']['put']['parameters'] }
+
+  specify do
+    expect(post_parameters).to eql(
+      [{'in'=>'body', 'name'=>'postIssue721', 'required'=>true, 'schema'=>{'$ref'=>'#/definitions/postIssue721'}}]
+    )
+    expect(post_schema).to eql(
+      {'description'=>'create item', 'properties'=>{'logs'=>{'type'=>'string'}, 'phone_number'=>{'format'=>'int32', 'type'=>'integer'}}, 'required'=>['logs'], 'type'=>'object'}
+    )
+    puts put_parameters
+    expect(put_parameters).to eql(
+      [{'in'=>'path', 'name'=>'id', 'type'=>'integer', 'format'=>'int32', 'required'=>true}, {'in'=>'formData', 'name'=>'logs', 'type'=>'string', 'required'=>true}, {'in'=>'formData', 'name'=>'phone_number', 'type'=>'integer', 'format'=>'int32', 'required'=>false}]
+    )
+  end
+end

--- a/spec/issues/784_extensions_on_params_spec.rb
+++ b/spec/issues/784_extensions_on_params_spec.rb
@@ -6,6 +6,10 @@ describe '#532 allow custom format' do
   let(:app) do
     Class.new(Grape::API) do
       namespace :issue_784 do
+        desc 'issue_784' do
+          consumes ['application/x-www-form-urlencoded']
+        end
+
         params do
           requires :logs, type: String, documentation: { format: 'log', x: { name: 'Log' } }
           optional :phone_number, type: Integer, documentation: { format: 'phone_number', x: { name: 'PhoneNumber' } }

--- a/spec/issues/832_array_hash_float_decimal_spec.rb
+++ b/spec/issues/832_array_hash_float_decimal_spec.rb
@@ -6,6 +6,9 @@ describe '#832 array of objects with nested Float/BigDecimal fields' do
   let(:app) do
     Class.new(Grape::API) do
       resource :issue_832 do
+        desc 'issue_832' do
+          consumes ['application/x-www-form-urlencoded']
+        end
         params do
           requires :array_param, type: Array do
             requires :float_param, type: Float

--- a/spec/support/model_parsers/entity_parser.rb
+++ b/spec/support/model_parsers/entity_parser.rb
@@ -234,7 +234,7 @@ RSpec.shared_context 'entity swagger example' do
           'post' => {
             'description' => 'This creates Thing.',
             'produces' => ['application/json'],
-            'consumes' => ['application/json'],
+            'consumes' => ['application/x-www-form-urlencoded'],
             'parameters' => [
               { 'in' => 'formData', 'name' => 'text', 'description' => 'Content of something.', 'type' => 'string', 'required' => true },
               { 'in' => 'formData', 'name' => 'links', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true }
@@ -256,7 +256,7 @@ RSpec.shared_context 'entity swagger example' do
           'put' => {
             'description' => 'This updates Thing.',
             'produces' => ['application/json'],
-            'consumes' => ['application/json'],
+            'consumes' => ['application/x-www-form-urlencoded'],
             'parameters' => [
               { 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true },
               { 'in' => 'formData', 'name' => 'text', 'description' => 'Content of something.', 'type' => 'string', 'required' => false },

--- a/spec/support/model_parsers/mock_parser.rb
+++ b/spec/support/model_parsers/mock_parser.rb
@@ -242,7 +242,7 @@ RSpec.shared_context 'mock swagger example' do
           'post' => {
             'description' => 'This creates Thing.',
             'produces' => ['application/json'],
-            'consumes' => ['application/json'],
+            'consumes' => ['application/x-www-form-urlencoded'],
             'parameters' => [
               { 'in' => 'formData', 'name' => 'text', 'description' => 'Content of something.', 'type' => 'string', 'required' => true },
               { 'in' => 'formData', 'name' => 'links', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true }
@@ -264,7 +264,7 @@ RSpec.shared_context 'mock swagger example' do
           'put' => {
             'description' => 'This updates Thing.',
             'produces' => ['application/json'],
-            'consumes' => ['application/json'],
+            'consumes' => ['application/x-www-form-urlencoded'],
             'parameters' => [
               { 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true },
               { 'in' => 'formData', 'name' => 'text', 'description' => 'Content of something.', 'type' => 'string', 'required' => false },

--- a/spec/support/model_parsers/representable_parser.rb
+++ b/spec/support/model_parsers/representable_parser.rb
@@ -306,7 +306,7 @@ RSpec.shared_context 'representable swagger example' do
           'post' => {
             'description' => 'This creates Thing.',
             'produces' => ['application/json'],
-            'consumes' => ['application/json'],
+            'consumes' => ['application/x-www-form-urlencoded'],
             'parameters' => [
               { 'in' => 'formData', 'name' => 'text', 'description' => 'Content of something.', 'type' => 'string', 'required' => true },
               { 'in' => 'formData', 'name' => 'links', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => true }
@@ -328,7 +328,7 @@ RSpec.shared_context 'representable swagger example' do
           'put' => {
             'description' => 'This updates Thing.',
             'produces' => ['application/json'],
-            'consumes' => ['application/json'],
+            'consumes' => ['application/x-www-form-urlencoded'],
             'parameters' => [
               { 'in' => 'path', 'name' => 'id', 'type' => 'integer', 'format' => 'int32', 'required' => true },
               { 'in' => 'formData', 'name' => 'text', 'description' => 'Content of something.', 'type' => 'string', 'required' => false },

--- a/spec/swagger_v2/api_swagger_v2_hide_param_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_hide_param_spec.rb
@@ -14,7 +14,9 @@ describe 'hidden flag enables a single endpoint parameter to be excluded from th
         end
 
         namespace :flat_params_endpoint do
-          desc 'This is a endpoint with a flat parameter hierarchy'
+          desc 'This is a endpoint with a flat parameter hierarchy' do
+            consumes ['application/x-www-form-urlencoded']
+          end
           params do
             requires :name, type: String, documentation: { desc: 'name' }
             optional :favourite_color, type: String, documentation: { desc: 'I should not be anywhere', hidden: true }
@@ -28,7 +30,9 @@ describe 'hidden flag enables a single endpoint parameter to be excluded from th
         end
 
         namespace :nested_params_endpoint do
-          desc 'This is a endpoint with a nested parameter hierarchy'
+          desc 'This is a endpoint with a nested parameter hierarchy' do
+            consumes ['application/x-www-form-urlencoded']
+          end
           params do
             optional :name, type: String, documentation: { desc: 'name' }
             optional :hidden_attribute, type: Hash do
@@ -47,7 +51,9 @@ describe 'hidden flag enables a single endpoint parameter to be excluded from th
         end
 
         namespace :required_param_endpoint do
-          desc 'This endpoint has hidden defined for a required parameter'
+          desc 'This endpoint has hidden defined for a required parameter' do
+            consumes ['application/x-www-form-urlencoded']
+          end
           params do
             requires :name, type: String, documentation: { desc: 'name', hidden: true }
           end

--- a/spec/swagger_v2/api_swagger_v2_mounted_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_mounted_spec.rb
@@ -12,6 +12,7 @@ describe 'swagger spec v2.0' do
 
         #  Thing stuff
         desc 'This gets Things.' do
+          consumes ['application/x-www-form-urlencoded']
           params Entities::Something.documentation
           http_codes [{ code: 401, message: 'Unauthorized', model: Entities::ApiError }]
         end
@@ -21,6 +22,7 @@ describe 'swagger spec v2.0' do
         end
 
         desc 'This gets Things.' do
+          consumes ['application/x-www-form-urlencoded']
           http_codes [
             { code: 200, message: 'get Horses', model: Entities::Something },
             { code: 401, message: 'HorsesOutError', model: Entities::ApiError }
@@ -32,6 +34,7 @@ describe 'swagger spec v2.0' do
         end
 
         desc 'This gets Thing.' do
+          consumes ['application/x-www-form-urlencoded']
           http_codes [{ code: 200, message: 'getting a single thing' }, { code: 401, message: 'Unauthorized' }]
         end
         params do
@@ -43,7 +46,8 @@ describe 'swagger spec v2.0' do
         end
 
         desc 'This creates Thing.',
-             success: Entities::Something
+          consumes: ['application/x-www-form-urlencoded'],
+          success: Entities::Something
         params do
           requires :text, type: String, documentation: { type: 'string', desc: 'Content of something.' }
           requires :links, type: Array, documentation: { type: 'link', is_array: true }
@@ -54,7 +58,8 @@ describe 'swagger spec v2.0' do
         end
 
         desc 'This updates Thing.',
-             success: Entities::Something
+          consumes: ['application/x-www-form-urlencoded'],
+          success: Entities::Something
         params do
           requires :id, type: Integer
           optional :text, type: String, desc: 'Content of something.'
@@ -66,7 +71,8 @@ describe 'swagger spec v2.0' do
         end
 
         desc 'This deletes Thing.',
-             entity: Entities::Something
+          consumes: ['application/x-www-form-urlencoded'],
+          entity: Entities::Something
         params do
           requires :id, type: Integer
         end
@@ -76,7 +82,8 @@ describe 'swagger spec v2.0' do
         end
 
         desc 'dummy route.',
-             failure: [{ code: 401, message: 'Unauthorized' }]
+          consumes: ['application/x-www-form-urlencoded'],
+          failure: [{ code: 401, message: 'Unauthorized' }]
         params do
           requires :id, type: Integer
         end
@@ -86,11 +93,12 @@ describe 'swagger spec v2.0' do
 
         namespace :other_thing do
           desc 'nested route inside namespace',
-               entity: Entities::QueryInput,
-               x: {
-                 'amazon-apigateway-auth' => { type: 'none' },
-                 'amazon-apigateway-integration' => { type: 'aws', uri: 'foo_bar_uri', httpMethod: 'get' }
-               }
+            consumes: ['application/x-www-form-urlencoded'],
+            entity: Entities::QueryInput,
+            x: {
+              'amazon-apigateway-auth' => { type: 'none' },
+              'amazon-apigateway-integration' => { type: 'aws', uri: 'foo_bar_uri', httpMethod: 'get' }
+            }
 
           params do
             requires :elements, documentation: {

--- a/spec/swagger_v2/api_swagger_v2_param_type_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_param_type_spec.rb
@@ -10,7 +10,8 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
       class ParamTypeApi < Grape::API
         # using `:param_type`
         desc 'full set of request param types',
-             success: Entities::UseResponse
+          consumes: ['application/x-www-form-urlencoded'],
+          success: Entities::UseResponse
         params do
           optional :in_query, type: String, documentation: { param_type: 'query' }
           optional :in_header, type: String, documentation: { param_type: 'header' }
@@ -21,7 +22,8 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
         end
 
         desc 'full set of request param types',
-             success: Entities::UseResponse
+          consumes: ['application/x-www-form-urlencoded'],
+          success: Entities::UseResponse
         params do
           requires :in_path, type: Integer
           optional :in_query, type: String, documentation: { param_type: 'query' }
@@ -33,7 +35,8 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
         end
 
         desc 'full set of request param types',
-             success: Entities::UseResponse
+          consumes: ['application/x-www-form-urlencoded'],
+          success: Entities::UseResponse
         params do
           optional :in_path, type: Integer
           optional :in_query, type: String, documentation: { param_type: 'query' }
@@ -46,7 +49,8 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
 
         # using `:in`
         desc 'full set of request param types using `:in`',
-             success: Entities::UseResponse
+          consumes: ['application/x-www-form-urlencoded'],
+          success: Entities::UseResponse
         params do
           optional :in_query, type: String, documentation: { in: 'query' }
           optional :in_header, type: String, documentation: { in: 'header' }
@@ -57,7 +61,8 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
         end
 
         desc 'full set of request param types using `:in`',
-             success: Entities::UseResponse
+          consumes: ['application/x-www-form-urlencoded'],
+          success: Entities::UseResponse
         params do
           requires :in_path, type: Integer
           optional :in_query, type: String, documentation: { in: 'query' }
@@ -68,7 +73,8 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
           { 'declared_params' => declared(params) }
         end
 
-        desc 'full set of request param types using `:in`'
+        desc 'full set of request param types using `:in`',
+          consumes: ['application/x-www-form-urlencoded']
         params do
           optional :in_path, type: Integer
           optional :in_query, type: String, documentation: { in: 'query' }
@@ -81,7 +87,8 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
 
         # file
         desc 'file download',
-             success: Entities::UseResponse
+          consumes: ['application/x-www-form-urlencoded'],
+          success: Entities::UseResponse
         params do
           requires :name, type: String
         end
@@ -91,7 +98,8 @@ describe 'setting of param type, such as `query`, `path`, `formData`, `body`, `h
         end
 
         desc 'file upload',
-             success: Entities::UseResponse
+          consumes: ['application/x-www-form-urlencoded'],
+          success: Entities::UseResponse
         params do
           requires :name, type: File
         end

--- a/spec/swagger_v2/api_swagger_v2_request_params_fix_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_request_params_fix_spec.rb
@@ -7,7 +7,9 @@ describe 'additional parameter settings' do
     module TheApi
       class RequestParamFix < Grape::API
         resource :bookings do
-          desc 'Update booking'
+          desc 'Update booking' do
+            consumes ['application/x-www-form-urlencoded']
+          end
           params do
             optional :name, type: String
           end
@@ -15,17 +17,23 @@ describe 'additional parameter settings' do
             { 'declared_params' => declared(params) }
           end
 
-          desc 'Get booking details'
+          desc 'Get booking details' do
+            consumes ['application/x-www-form-urlencoded']
+          end
           get ':id' do
             { 'declared_params' => declared(params) }
           end
 
-          desc 'Get booking details by access_number'
+          desc 'Get booking details by access_number' do
+            consumes ['application/x-www-form-urlencoded']
+          end
           get '/conf/:access_number' do
             { 'declared_params' => declared(params) }
           end
 
-          desc 'Remove booking'
+          desc 'Remove booking' do
+            consumes ['application/x-www-form-urlencoded']
+          end
           delete ':id' do
             { 'declared_params' => declared(params) }
           end

--- a/spec/swagger_v2/api_swagger_v2_response_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_response_spec.rb
@@ -11,33 +11,37 @@ describe 'response' do
         format :json
 
         desc 'This returns something',
-             params: Entities::UseResponse.documentation,
-             failure: [{ code: 400, message: 'NotFound', model: Entities::ApiError }]
+          consumes: ['application/x-www-form-urlencoded'],
+          params: Entities::UseResponse.documentation,
+          failure: [{ code: 400, message: 'NotFound', model: Entities::ApiError }]
         post '/params_given' do
           { 'declared_params' => declared(params) }
         end
 
         desc 'This returns something',
-             entity: Entities::UseResponse,
-             failure: [{ code: 400, message: 'NotFound', model: Entities::ApiError }]
+          consumes: ['application/x-www-form-urlencoded'],
+          entity: Entities::UseResponse,
+          failure: [{ code: 400, message: 'NotFound', model: Entities::ApiError }]
         get '/entity_response' do
           { 'declared_params' => declared(params) }
         end
 
         desc 'This returns something',
-             entity: Entities::UseItemResponseAsType,
-             failure: [{ code: 400, message: 'NotFound', model: Entities::ApiError }]
+          consumes: ['application/x-www-form-urlencoded'],
+          entity: Entities::UseItemResponseAsType,
+          failure: [{ code: 400, message: 'NotFound', model: Entities::ApiError }]
         get '/nested_type' do
           { 'declared_params' => declared(params) }
         end
 
         desc 'This returns something',
-             success: [
-               { code: 200, message: 'Request has succeeded' },
-               { code: 201, message: 'Successful Operation' },
-               { code: 204, message: 'Request was fulfilled' }
-             ],
-             failure: [{ code: 400, message: 'NotFound', model: Entities::ApiError }]
+          consumes: ['application/x-www-form-urlencoded'],
+          success: [
+            { code: 200, message: 'Request has succeeded' },
+            { code: 201, message: 'Successful Operation' },
+            { code: 204, message: 'Request was fulfilled' }
+          ],
+          failure: [{ code: 400, message: 'NotFound', model: Entities::ApiError }]
         get '/multiple-success-responses' do
           { 'declared_params' => declared(params) }
         end
@@ -102,7 +106,7 @@ describe 'response' do
       expect(subject['paths']['/params_given']['post']).to eql(
         'description' => 'This returns something',
         'produces' => ['application/json'],
-        'consumes' => ['application/json'],
+        'consumes' => ['application/x-www-form-urlencoded'],
         'parameters' => [
           { 'in' => 'formData', 'name' => 'description', 'type' => 'string', 'required' => false },
           { 'in' => 'formData', 'name' => '$responses', 'type' => 'array', 'items' => { 'type' => 'string' }, 'required' => false }

--- a/spec/swagger_v2/api_swagger_v2_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_spec.rb
@@ -11,6 +11,7 @@ describe 'swagger spec v2.0' do
 
       #  Thing stuff
       desc 'This gets Things.' do
+        consumes ['application/x-www-form-urlencoded']
         params Entities::Something.documentation
         http_codes [{ code: 401, message: 'Unauthorized', model: Entities::ApiError }]
       end
@@ -20,6 +21,7 @@ describe 'swagger spec v2.0' do
       end
 
       desc 'This gets Things.' do
+        consumes ['application/x-www-form-urlencoded']
         http_codes [
           { code: 200, message: 'get Horses', model: Entities::Something },
           { code: 401, message: 'HorsesOutError', model: Entities::ApiError }
@@ -31,6 +33,7 @@ describe 'swagger spec v2.0' do
       end
 
       desc 'This gets Thing.' do
+        consumes ['application/x-www-form-urlencoded']
         http_codes [{ code: 200, message: 'getting a single thing' }, { code: 401, message: 'Unauthorized' }]
       end
       params do
@@ -42,7 +45,8 @@ describe 'swagger spec v2.0' do
       end
 
       desc 'This creates Thing.',
-           success: Entities::Something
+        consumes: ['application/x-www-form-urlencoded'],
+        success: Entities::Something
       params do
         requires :text, type: String, documentation: { type: 'string', desc: 'Content of something.' }
         requires :links, type: Array, documentation: { type: 'link', is_array: true }
@@ -53,7 +57,8 @@ describe 'swagger spec v2.0' do
       end
 
       desc 'This updates Thing.',
-           success: Entities::Something
+        consumes: ['application/x-www-form-urlencoded'],
+        success: Entities::Something
       params do
         requires :id, type: Integer
         optional :text, type: String, desc: 'Content of something.'
@@ -65,7 +70,8 @@ describe 'swagger spec v2.0' do
       end
 
       desc 'This deletes Thing.',
-           entity: Entities::Something
+        consumes: ['application/x-www-form-urlencoded'],
+        entity: Entities::Something
       params do
         requires :id, type: Integer
       end
@@ -75,7 +81,8 @@ describe 'swagger spec v2.0' do
       end
 
       desc 'dummy route.',
-           failure: [{ code: 401, message: 'Unauthorized' }]
+        consumes: ['application/x-www-form-urlencoded'],
+        failure: [{ code: 401, message: 'Unauthorized' }]
       params do
         requires :id, type: Integer
       end
@@ -85,11 +92,12 @@ describe 'swagger spec v2.0' do
 
       namespace :other_thing do
         desc 'nested route inside namespace',
-             entity: Entities::QueryInput,
-             x: {
-               'amazon-apigateway-auth' => { type: 'none' },
-               'amazon-apigateway-integration' => { type: 'aws', uri: 'foo_bar_uri', httpMethod: 'get' }
-             }
+          consumes: ['application/x-www-form-urlencoded'],
+          entity: Entities::QueryInput,
+          x: {
+            'amazon-apigateway-auth' => { type: 'none' },
+            'amazon-apigateway-integration' => { type: 'aws', uri: 'foo_bar_uri', httpMethod: 'get' }
+          }
 
         params do
           requires :elements, documentation: {

--- a/spec/swagger_v2/api_swagger_v2_type-format_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_type-format_spec.rb
@@ -28,7 +28,8 @@ describe 'type format settings' do
     module TheApi
       class TypeFormatApi < Grape::API
         desc 'full set of request data types',
-             success: Entities::TypedDefinition
+          consumes: ['application/x-www-form-urlencoded'],
+          success: Entities::TypedDefinition
 
         params do
           # grape supported data types

--- a/spec/swagger_v2/boolean_params_spec.rb
+++ b/spec/swagger_v2/boolean_params_spec.rb
@@ -7,6 +7,9 @@ describe 'Boolean Params' do
     Class.new(Grape::API) do
       format :json
 
+      desc 'splines' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :a_boolean, type: Grape::API::Boolean
         optional :another_boolean, type: Grape::API::Boolean, default: false

--- a/spec/swagger_v2/float_api_spec.rb
+++ b/spec/swagger_v2/float_api_spec.rb
@@ -7,6 +7,9 @@ describe 'Float Params' do
     Class.new(Grape::API) do
       format :json
 
+      desc 'splines' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :a_float, type: Float
       end

--- a/spec/swagger_v2/form_params_spec.rb
+++ b/spec/swagger_v2/form_params_spec.rb
@@ -7,6 +7,9 @@ describe 'Form Params' do
     Class.new(Grape::API) do
       format :json
 
+      desc 'get items' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :name, type: String, desc: 'name of item'
       end
@@ -14,6 +17,9 @@ describe 'Form Params' do
         {}
       end
 
+      desc 'get item' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :id, type: Integer, desc: 'id of item'
         requires :name, type: String, desc: 'name of item'
@@ -32,6 +38,9 @@ describe 'Form Params' do
         {}
       end
 
+      desc 'create item' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :id, type: Integer, desc: 'id of item'
         requires :name, type: String, desc: 'name of item'

--- a/spec/swagger_v2/param_multi_type_spec.rb
+++ b/spec/swagger_v2/param_multi_type_spec.rb
@@ -7,6 +7,9 @@ describe 'Params Multi Types' do
     Class.new(Grape::API) do
       format :json
 
+      desc 'action' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         if Grape::VERSION < '0.14'
           requires :input, type: [String, Integer]
@@ -52,7 +55,9 @@ describe 'Params Multi Types' do
       Class.new(Grape::API) do
         format :json
 
-        desc 'Some API', headers: { 'My-Header' => { required: true, description: 'Set this!' } }
+        desc 'Some API', 
+          consumes: ['application/x-www-form-urlencoded'],
+          headers: { 'My-Header' => { required: true, description: 'Set this!' } }
         params do
           if Grape::VERSION < '0.14'
             requires :input, type: [String, Integer]

--- a/spec/swagger_v2/param_type_spec.rb
+++ b/spec/swagger_v2/param_type_spec.rb
@@ -7,6 +7,9 @@ describe 'Params Types' do
     Class.new(Grape::API) do
       format :json
 
+      desc 'action' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :input, type: String
       end
@@ -14,6 +17,9 @@ describe 'Params Types' do
         { message: 'hi' }
       end
 
+      desc 'action_with_doc' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :input, type: String, default: '14', documentation: { type: 'email', default: '42' }
       end
@@ -46,7 +52,9 @@ describe 'Params Types' do
         Class.new(Grape::API) do
           format :json
 
-          desc 'Some API', headers: { 'My-Header' => { required: true, description: 'Set this!' } }
+          desc 'Some API',
+            consumes: ['application/x-www-form-urlencoded'],
+            headers: { 'My-Header' => { required: true, description: 'Set this!' } }
           params do
             requires :input, type: String
           end

--- a/spec/swagger_v2/param_values_spec.rb
+++ b/spec/swagger_v2/param_values_spec.rb
@@ -8,6 +8,9 @@ describe 'Convert values to enum or Range' do
     Class.new(Grape::API) do
       format :json
 
+      desc 'plain_array' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :letter, type: String, values: %w[a b c]
       end
@@ -15,6 +18,9 @@ describe 'Convert values to enum or Range' do
         { message: 'hi' }
       end
 
+      desc 'array_in_proc' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :letter, type: String, values: proc { %w[d e f] }
       end
@@ -22,6 +28,9 @@ describe 'Convert values to enum or Range' do
         { message: 'hi' }
       end
 
+      desc 'range_letter' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :letter, type: String, values: 'a'..'z'
       end
@@ -29,6 +38,9 @@ describe 'Convert values to enum or Range' do
         { message: 'hi' }
       end
 
+      desc 'range_integer' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :integer, type: Integer, values: -5..5
       end
@@ -107,6 +119,9 @@ describe 'Convert values to enum for float range and not arrays inside a proc', 
     Class.new(Grape::API) do
       format :json
 
+      desc 'non_array_in_proc' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :letter, type: String, values: proc { 'string' }
       end
@@ -114,6 +129,9 @@ describe 'Convert values to enum for float range and not arrays inside a proc', 
         { message: 'hi' }
       end
 
+      desc 'range_float' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :float, type: Float, values: -5.0..5.0
       end

--- a/spec/swagger_v2/params_array_spec.rb
+++ b/spec/swagger_v2/params_array_spec.rb
@@ -13,6 +13,9 @@ describe 'Group Params as Array' do
         Class.new(Grape::API) do
           format :json
 
+          desc 'groups' do
+            consumes ['application/x-www-form-urlencoded']
+          end
           params do
             requires :required_group, type: Array do
               requires :required_param_1
@@ -23,6 +26,9 @@ describe 'Group Params as Array' do
             { 'declared_params' => declared(params) }
           end
 
+          desc 'type_given' do
+            consumes ['application/x-www-form-urlencoded']
+          end
           params do
             requires :typed_group, type: Array do
               requires :id, type: Integer, desc: 'integer given'
@@ -38,6 +44,10 @@ describe 'Group Params as Array' do
           # as body parameters it would be interpreted a bit different,
           # cause it could not be distinguished anymore, so this would be translated to one array,
           # see also next example for the difference
+          desc 'array_of_type' do
+            consumes ['application/x-www-form-urlencoded']
+          end
+
           params do
             requires :array_of_string, type: Array[String], documentation: { param_type: 'body', desc: 'nested array of strings' }
             requires :array_of_integer, type: Array[Integer], documentation: { param_type: 'body', desc: 'nested array of integers' }
@@ -45,6 +55,10 @@ describe 'Group Params as Array' do
 
           post '/array_of_type' do
             { 'declared_params' => declared(params) }
+          end
+
+          desc 'object_and_array' do
+            consumes ['application/x-www-form-urlencoded']
           end
 
           params do
@@ -56,6 +70,10 @@ describe 'Group Params as Array' do
             { 'declared_params' => declared(params) }
           end
 
+          desc 'array_of_type_in_form' do
+            consumes ['application/x-www-form-urlencoded']
+          end
+
           params do
             requires :array_of_string, type: Array[String]
             requires :array_of_integer, type: Array[Integer]
@@ -63,6 +81,10 @@ describe 'Group Params as Array' do
 
           post '/array_of_type_in_form' do
             { 'declared_params' => declared(params) }
+          end
+
+          desc 'array_of_entities' do
+            consumes ['application/x-www-form-urlencoded']
           end
 
           params do

--- a/spec/swagger_v2/params_hash_spec.rb
+++ b/spec/swagger_v2/params_hash_spec.rb
@@ -7,6 +7,9 @@ describe 'Group Params as Hash' do
     Class.new(Grape::API) do
       format :json
 
+      desc 'use groups' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :required_group, type: Hash do
           requires :required_param_1
@@ -17,6 +20,9 @@ describe 'Group Params as Hash' do
         { 'declared_params' => declared(params) }
       end
 
+      desc 'use given type' do
+        consumes ['application/x-www-form-urlencoded']
+      end
       params do
         requires :typed_group, type: Hash do
           requires :id, type: Integer, desc: 'integer given'

--- a/spec/swagger_v2/params_nested_spec.rb
+++ b/spec/swagger_v2/params_nested_spec.rb
@@ -10,6 +10,9 @@ describe 'nested group params' do
         Class.new(Grape::API) do
           format :json
 
+          desc 'nested array' do
+            consumes ['application/x-www-form-urlencoded']
+          end
           params do
             requires :a_array, type: Array do
               requires :param_1, type: Integer
@@ -26,6 +29,9 @@ describe 'nested group params' do
             { 'declared_params' => declared(params) }
           end
 
+          desc 'nested hash' do
+            consumes ['application/x-www-form-urlencoded']
+          end
           params do
             requires :a_hash, type: Hash do
               requires :param_1, type: Integer

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -9,20 +9,23 @@ describe 'a simple mounted api' do
     # rubocop:enable Lint/EmptyClass
 
     class SimpleMountedApi < Grape::API
-      desc 'Document root'
+      desc 'Document root',
+        consumes: ['application/x-www-form-urlencoded']
       get do
         { message: 'hi' }
       end
 
       desc 'This gets something.',
-           notes: '_test_'
+        consumes: ['application/x-www-form-urlencoded'],
+        notes: '_test_'
 
       get '/simple' do
         { bla: 'something' }
       end
 
       desc 'This gets something for URL using - separator.',
-           notes: '_test_'
+        consumes: ['application/x-www-form-urlencoded'],
+        notes: '_test_'
 
       get '/simple-test' do
         { bla: 'something' }
@@ -37,32 +40,35 @@ describe 'a simple mounted api' do
       end
 
       desc 'this gets something else',
-           headers: {
-             'XAuthToken' => { description: 'A required header.', required: true },
-             'XOtherHeader' => { description: 'An optional header.', required: false }
-           },
-           http_codes: [
-             { code: 403, message: 'invalid pony' },
-             { code: 405, message: 'no ponies left!' }
-           ]
+        consumes: ['application/x-www-form-urlencoded'],
+        headers: {
+          'XAuthToken' => { description: 'A required header.', required: true },
+          'XOtherHeader' => { description: 'An optional header.', required: false }
+        },
+        http_codes: [
+          { code: 403, message: 'invalid pony' },
+          { code: 405, message: 'no ponies left!' }
+        ]
 
       get '/simple_with_headers' do
         { bla: 'something_else' }
       end
 
       desc 'this takes an array of parameters',
-           params: {
-             'items[]' => { description: 'array of items', is_array: true }
-           }
+        consumes: ['application/x-www-form-urlencoded'],
+        params: {
+          'items[]' => { description: 'array of items', is_array: true }
+        }
 
       post '/items' do
         {}
       end
 
       desc 'this uses a custom parameter',
-           params: {
-             'custom' => { type: CustomType, description: 'array of items', is_array: true }
-           }
+        consumes: ['application/x-www-form-urlencoded'],
+        params: {
+          'custom' => { type: CustomType, description: 'array of items', is_array: true }
+        }
 
       get '/custom' do
         {}
@@ -166,7 +172,7 @@ describe 'a simple mounted api' do
             'post' => {
               'description' => 'this takes an array of parameters',
               'produces' => ['application/json'],
-              'consumes' => ['application/json'],
+              'consumes' => ['application/x-www-form-urlencoded'],
               'parameters' => [{ 'in' => 'formData', 'name' => 'items[]', 'description' => 'array of items', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'string' } }],
               'tags' => ['items'],
               'operationId' => 'postItems',
@@ -290,7 +296,7 @@ describe 'a simple mounted api' do
             'post' => {
               'description' => 'this takes an array of parameters',
               'produces' => ['application/json'],
-              'consumes' => ['application/json'],
+              'consumes' => ['application/x-www-form-urlencoded'],
               'parameters' => [{ 'in' => 'formData', 'name' => 'items[]', 'description' => 'array of items', 'required' => false, 'type' => 'array', 'items' => { 'type' => 'string' } }],
               'tags' => ['items'],
               'operationId' => 'postItems',


### PR DESCRIPTION
As per #721, `grape-swagger` sets the default `consumes` to `['application/json']` in `lib/grape-swagger/doc_methods/produces_consumes.rb`:

```
return ['application/json'] unless args.flatten.present?
```

However, it also sets the default `in` of parameters to `formData` in `lib/grape-swagger/doc_methods/parse_params.rb`:

```
def document_array_param(value_type, definitions)
...
  @parsed_param[:in] = param_type || 'formData'

def param_type(value_type)
...
  elsif %w[POST PUT PATCH].include?(value_type[:method])
    DataType.request_primitive?(value_type[:data_type]) ? 'formData' : 'body'
```

Here, `DataType.request_primitive` simply checks if the parameter's data type is one of `integer long float double byte date dateTime binary password email uuid object string boolean file json array`, in which case its location is set to `formData`. As such, this leads to a situation where most parameters are set to `formData` by default while their endpoint is also set to `consumes` `application/json` by default:

```
      consumes:
        - application/json
      parameters:
        - in: formData
```

However, as described in the [OpenAPI V2 documentation](https://swagger.io/specification/v2/#parameter-object) (also [here](https://swagger.io/docs/specification/2-0/describing-request-body/)), `the payload of the application/x-www-form-urlencoded and multipart/form-data requests is described by using form parameters, not body parameters` and `formData` should only be used for `application/x-www-form-urlencoded` and `multipart/form-data` requests. Currently, the default output of `grape-swagger` will lead to OpenAPI validation errors.

This MR adds logic to set the default parameter location (`in`) based on the `consumes` object, setting it to `formData` if `consumes` is `application/x-www-form-urlencoded` or `multipart/form-data` and `body` if otherwise for `PUT POST PATCH` requests. This can still be overriden by endpoint-specific options as is the usual behaviour.

However, since several specs relied on this invalid output previously, it is necessary to make some changes to ensure passing.