### PR TITLE
Allow false value for boolean parameter documentation examples

### DIFF
--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -141,7 +141,7 @@ module GrapeSwagger
 
         def document_example(settings)
           example = settings[:example]
-          @parsed_param[:example] = example if example
+          @parsed_param[:example] = example if !example.nil?
         end
 
         def param_type(value_type)

--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -141,7 +141,7 @@ module GrapeSwagger
 
         def document_example(settings)
           example = settings[:example]
-          @parsed_param[:example] = example if !example.nil?
+          @parsed_param[:example] = example unless example.nil?
         end
 
         def param_type(value_type)

--- a/spec/swagger_v2/params_example_spec.rb
+++ b/spec/swagger_v2/params_example_spec.rb
@@ -11,6 +11,8 @@ describe 'Param example' do
         requires :id, type: Integer, documentation: { example: 123 }
         optional :name, type: String, documentation: { example: 'Person' }
         optional :obj, type: 'Object', documentation: { example: { 'foo' => 'bar' } }
+        optional :boolean_true, type: Grape::API::Boolean, documentation: { example: true }
+        optional :boolean_false, type: Grape::API::Boolean, documentation: { example: false }
       end
 
       get '/endpoint_with_examples' do
@@ -32,7 +34,9 @@ describe 'Param example' do
         [
           { 'in' => 'query', 'name' => 'id', 'type' => 'integer', 'example' => 123, 'format' => 'int32', 'required' => true },
           { 'in' => 'query', 'name' => 'name', 'type' => 'string', 'example' => 'Person', 'required' => false },
-          { 'in' => 'query', 'name' => 'obj', 'type' => 'Object', 'example' => { 'foo' => 'bar' }, 'required' => false }
+          { 'in' => 'query', 'name' => 'obj', 'type' => 'Object', 'example' => { 'foo' => 'bar' }, 'required' => false },
+          { 'in' => 'query', 'name' => 'boolean_true', 'type' => 'boolean', 'example' => true, 'required' => false},
+          { 'in' => 'query', 'name' => 'boolean_false', 'type' => 'boolean', 'example' => false, 'required' => false }
         ]
       )
     end

--- a/spec/swagger_v2/params_example_spec.rb
+++ b/spec/swagger_v2/params_example_spec.rb
@@ -35,7 +35,7 @@ describe 'Param example' do
           { 'in' => 'query', 'name' => 'id', 'type' => 'integer', 'example' => 123, 'format' => 'int32', 'required' => true },
           { 'in' => 'query', 'name' => 'name', 'type' => 'string', 'example' => 'Person', 'required' => false },
           { 'in' => 'query', 'name' => 'obj', 'type' => 'Object', 'example' => { 'foo' => 'bar' }, 'required' => false },
-          { 'in' => 'query', 'name' => 'boolean_true', 'type' => 'boolean', 'example' => true, 'required' => false},
+          { 'in' => 'query', 'name' => 'boolean_true', 'type' => 'boolean', 'example' => true, 'required' => false },
           { 'in' => 'query', 'name' => 'boolean_false', 'type' => 'boolean', 'example' => false, 'required' => false }
         ]
       )


### PR DESCRIPTION
This PR updates the grape-swagger library to allow for the `false` value to be passed as an example for `boolean` parameters. Previously, only `true` values were allowed as examples for `boolean` parameters, as the existence of the example was checked using a simple truthiness check. This PR modifies the check to specifically look for `nil` values, allowing both `true` and `false` values to be used as examples.

