### PR TITLE
Allow range be Float

### DIFF
--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -162,7 +162,7 @@ module GrapeSwagger
           when Proc
             parse_enum_or_range_values(values.call) if values.parameters.empty?
           when Range
-            parse_range_values(values) if values.first.is_a?(Integer)
+            parse_range_values(values) if values.first.is_a?(Integer) || values.first.is_a?(Float)
           when Array
             { enum: values }
           else


### PR DESCRIPTION
https://github.com/ruby-grape/grape-swagger/issues/904#issue-1881746890

As described in https://docs.swagger.io/spec.html

minimum | string | number, integer | The minimum valid value for the type, inclusive. If this field is used in conjunction with the defaultValue field, then the default value MUST be higher than or equal to this value. The value type is string and should represent the minimum numeric value. Note: This will change to a numeric value in the future.

The values may be number (float or double)?