### PR TITLE
Refactor gemspec files to include just the necessary

### DIFF
--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path('lib', __dir__)
-require 'grape-swagger/version'
+require_relative 'lib/grape-swagger/version'
 
 Gem::Specification.new do |s|
   s.name        = 'grape-swagger'

--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -18,6 +18,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7'
   s.add_runtime_dependency 'grape', '~> 1.3'
 
-  s.files = Dir['lib/**/*', 'CHANGELOG.md', 'CONTRIBUTING.md', 'README.md', 'RELEASING.md', 'UPGRADING.md', 'LICENSE.txt', 'grape-swagger.gemspec']
+  s.files = Dir['lib/**/*', '*.md', 'LICENSE.txt', 'grape-swagger.gemspec']
   s.require_paths = ['lib']
 end

--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path('lib', __dir__)
-require 'grape-swagger/version'
+require 'lib/grape-swagger/version'
 
 Gem::Specification.new do |s|
   s.name        = 'grape-swagger'
@@ -18,6 +17,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.7'
   s.add_runtime_dependency 'grape', '~> 1.3'
 
-  s.files         = `git ls-files`.split("\n")
+  s.files = Dir['lib/**/*', 'CHANGELOG.md', 'CONTRIBUTING.md', 'README.md', 'RELEASING.md', 'UPGRADING.md', 'LICENSE.txt', 'grape-swagger.gemspec']
   s.require_paths = ['lib']
 end

--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'lib/grape-swagger/version'
+$LOAD_PATH.push File.expand_path('lib', __dir__)
+require 'grape-swagger/version'
 
 Gem::Specification.new do |s|
   s.name        = 'grape-swagger'


### PR DESCRIPTION
Hi, while installing the gems, I've noticed that spec files are included when installed. I've refactored the `files` from your gemspec just to include the necessary.