### PR TITLE
Allow using Grape v2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,38 @@ jobs:
         bundle update
         bundle exec rspec
 
+  grape-20:
+    runs-on: ubuntu-latest
+    needs: ['rubocop']
+    env:
+      GRAPE_VERSION: '2.0.0'
+    strategy:
+      matrix:
+        ruby-version: ['3.1', '3.2', 'head']
+    steps:
+    - name: Check out branch
+      uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Run rspec wo model parser
+      run: |
+        bundle update
+        bundle exec rspec
+    - name: Run rspec w entity parser
+      env:
+        MODEL_PARSER: grape-swagger-entity
+      run: |
+        bundle update
+        bundle exec rspec
+    - name: Run rspec w representable parser
+      env:
+        MODEL_PARSER: grape-swagger-representable
+      run: |
+        bundle update
+        bundle exec rspec
+
   grape-HEAD:
     runs-on: ubuntu-latest
     needs: ['rubocop']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#910](https://github.com/ruby-grape/grape-swagger/pull/910): Allow using Grape v2 - [@ninoseki](https://github.com/ninoseki)
 * Your contribution here.
 
 #### Fixes

--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.metadata['rubygems_mfa_required'] = 'true'
 
   s.required_ruby_version = '>= 2.7'
-  s.add_runtime_dependency 'grape', '~> 1.3'
+  s.add_runtime_dependency 'grape', '>= 1.3', '< 3.0'
   s.add_runtime_dependency 'rack-test', '~> 2'
 
   s.files = Dir['lib/**/*', '*.md', 'LICENSE.txt', 'grape-swagger.gemspec']


### PR DESCRIPTION
Allow using Grape v2.

As far as I know, v2 does not introduce any breaking changes to this gem. So it's safe to relax the version requirement.