### PR TITLE
Fix params extension does not work when param_type is body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 #### Fixes
 
-* Your contribution here.
+* [#918](https://github.com/ruby-grape/grape-swagger/pull/918): Fix params extension does not work when param_type is body - [@numbata](https://github.com/numbata)
 
 ### 2.0.1 (Januar 2, 2024)
 

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -86,6 +86,7 @@ module GrapeSwagger
                                else
                                  document_as_property(param)
                                end
+            add_extension_properties(properties[name], param)
 
             required << name if deletable?(param) && param[:required]
           end
@@ -99,6 +100,12 @@ module GrapeSwagger
             property[:description] = param.delete(:description) unless param[:description].nil?
             property[:example] = param.delete(:example) unless param[:example].nil?
             property[:items] = document_as_property(param)[:items]
+          end
+        end
+
+        def add_extension_properties(definition, values)
+          values.each do |key, value|
+            definition[key] = value if key.start_with?('x-')
           end
         end
 

--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -108,6 +108,10 @@ module GrapeSwagger
           set_additional_properties, additional_properties = parse_additional_properties(definitions, value_type)
           array_items[:additionalProperties] = additional_properties if set_additional_properties
 
+          if value_type.key?(:items)
+            GrapeSwagger::DocMethods::Extensions.add_extensions_to_root(value_type[:items], array_items)
+          end
+
           array_items
         end
 

--- a/spec/issues/901_extensions_on_body_params_spec.rb
+++ b/spec/issues/901_extensions_on_body_params_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe '#901 params extension does not work when param_type is body' do
+  let(:app) do
+    Class.new(Grape::API) do
+      namespace :issue_901 do
+        params do
+          requires :user_id, type: Integer, documentation: { type: 'integer', param_type: 'body', x: { nullable: true } }
+          requires :friend_ids, type: [Integer], documentation: { type: 'integer', is_array: true, param_type: 'body', x: { type: 'array' }, items: { x: { type: 'item' } } }
+          requires :address, type: Hash, documentation: { type: 'object', param_type: 'body', x: { type: 'address' } } do
+            requires :city_id, type: Integer, documentation: { type: 'integer', x: { type: 'city' } }
+          end
+        end
+        post do
+          present params
+        end
+      end
+
+      add_swagger_documentation format: :json
+    end
+  end
+
+  subject do
+    get '/swagger_doc'
+    JSON.parse(last_response.body)
+  end
+
+  let(:definition) { subject['definitions']['postIssue901'] }
+
+  specify do
+    expect(definition['properties']).to match(
+      'user_id' => hash_including('type' => 'integer', 'x-nullable' => true),
+      'address' => hash_including(
+        'type' => 'object',
+        'x-type' => 'address',
+        'properties' => {
+          'city_id' => hash_including('type' => 'integer', 'x-type' => 'city')
+        }
+      ),
+      'friend_ids' => hash_including(
+        'type' => 'array',
+        'x-type' => 'array',
+        'items' => hash_including('type' => 'integer', 'x-type' => 'item')
+      )
+    )
+  end
+end


### PR DESCRIPTION
This pull request resolves issue #901 by implementing the `add_extension_properties` method in `MoveParams`. The issue caused custom extension properties in body parameters to be excluded from the generated Swagger documentation.

 This new method ensures that any key/value pairs prefixed with 'x-' in the schema definition of the body parameter are correctly processed and included in the Swagger output. The processing of parameters in both `MoveParams` and `ParseParams` has been updated to use this new functionality.

These changes ensure that custom extensions, such as `x: { some: 'stuff' }`, are accurately documented in the Swagger output, resulting in comprehensive and precise API documentation.

A new test case has also been added to verify the accurate reflection of custom extension properties in the Swagger documentation. The test case can be found at `spec/issues/901_extensions_on_body_params_spec.rb`.









