### PR TITLE
Enable Schema definitions for DELETE request body params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * Your contribution here.
 * [#922](https://github.com/ruby-grape/grape-swagger/pull/922): Force request body to be an schema object - [@numbata](https://github.com/numbata)
+* [#923](https://github.com/ruby-grape/grape-swagger/pull/923): Enabled schema definitions for body parameters in DELETE requests - [@numbata](https://github.com/numbata)
 
 ### 2.0.2 (Februar 2, 2024)
 

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -186,7 +186,7 @@ module GrapeSwagger
         end
 
         def move_methods
-          [:post, :put, :patch, 'POST', 'PUT', 'PATCH']
+          [:delete, :post, :put, :patch, 'DELETE', 'POST', 'PUT', 'PATCH']
         end
 
         def includes_body_param?(params)

--- a/spec/issues/923_params_schema_definition_for_delete_action_spec.rb
+++ b/spec/issues/923_params_schema_definition_for_delete_action_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe '#923 Body params for DELETE action' do
+  let(:app) do
+    Class.new(Grape::API) do
+      params do
+        requires :post_id, type: Integer
+        requires :query, type: String, documentation: { type: 'string', param_type: 'body' }
+      end
+      delete '/posts/:post_id/comments' do
+        { 'declared_params' => declared(params) }
+      end
+      add_swagger_documentation format: :json
+    end
+  end
+
+  describe 'retrieves the documentation for delete parameters as a schema defintion' do
+    subject do
+      get '/swagger_doc'
+      JSON.parse(last_response.body)
+    end
+
+    specify do
+      expect(subject['paths']['/posts/{post_id}/comments']['delete']['parameters']).to match(
+        [
+          {
+            'format' => 'int32',
+            'in' => 'path',
+            'name' => 'post_id',
+            'type' => 'integer',
+            'required' => true
+          },
+          {
+            'name' => 'deletePostsPostIdComments',
+            'in' => 'body',
+            'required' => true,
+            'schema' => { '$ref' => '#/definitions/deletePostsPostIdComments' }
+          }
+        ]
+      )
+
+      expect(subject['definitions']['deletePostsPostIdComments']).to match(
+        'type' => 'object',
+        'properties' => {
+          'query' => {
+            'type' => 'string'
+          }
+        },
+        'required' => ['query']
+      )
+    end
+  end
+end

--- a/spec/lib/move_params_spec.rb
+++ b/spec/lib/move_params_spec.rb
@@ -30,11 +30,11 @@ describe GrapeSwagger::DocMethods::MoveParams do
     end
 
     let(:allowed_verbs) do
-      [:post, :put, :patch, 'POST', 'PUT', 'PATCH']
+      [:post, :put, :patch, :delete, 'POST', 'PUT', 'PATCH', 'DELETE']
     end
 
     let(:not_allowed_verbs) do
-      [:get, :delete, 'GET', 'DELETE']
+      [:get, 'GET']
     end
 
     describe 'movable params' do

--- a/spec/support/mock_parser.rb
+++ b/spec/support/mock_parser.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'ostruct'
+
 module GrapeSwagger
   class MockParser
     attr_reader :model, :endpoint


### PR DESCRIPTION
This PR allows grape-swagger to document body parameters with schema definitions for DELETE requests.
The change aligns DELETE requests with POST, PUT, and PATCH, which already support this. 