### PR TITLE
Document the min/max Items/Length fields if the attribute uses the length validator

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,13 @@ group :development, :test do
   gem 'pry', platforms: [:mri]
   gem 'pry-byebug', platforms: [:mri]
 
-  gem 'rack'
+  grape_version = ENV.fetch('GRAPE_VERSION', '2.1.0')
+  if grape_version == 'HEAD' || Gem::Version.new(grape_version) >= Gem::Version.new('2.0.0')
+    gem 'rack', '>= 3.0'
+  else
+    gem 'rack', '< 3.0'
+  end
+
   gem 'rack-cors'
   gem 'rack-test'
   gem 'rake'

--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -25,6 +25,7 @@ module GrapeSwagger
           document_default_value(settings) unless value_type[:is_array]
           document_range_values(settings) unless value_type[:is_array]
           document_required(settings)
+          document_length_limits(value_type)
           document_additional_properties(definitions, settings) unless value_type[:is_array]
           document_add_extensions(settings)
           document_example(settings)
@@ -160,6 +161,16 @@ module GrapeSwagger
             'formData'
           else
             'query'
+          end
+        end
+
+        def document_length_limits(value_type)
+          if value_type[:is_array]
+            @parsed_param[:minItems] = value_type[:min_length] if value_type.key?(:min_length)
+            @parsed_param[:maxItems] = value_type[:max_length] if value_type.key?(:max_length)
+          else
+            @parsed_param[:minLength] = value_type[:min_length] if value_type.key?(:min_length)
+            @parsed_param[:maxLength] = value_type[:max_length] if value_type.key?(:max_length)
           end
         end
 

--- a/spec/issues/533_specify_status_code_spec.rb
+++ b/spec/issues/533_specify_status_code_spec.rb
@@ -26,6 +26,7 @@ describe '#533 specify status codes' do
              success: { code: 204, message: 'a changed status code' }
         patch do
           status 204
+          body false
         end
 
         desc 'Delete some stuff',

--- a/spec/swagger_v2/param_type_spec.rb
+++ b/spec/swagger_v2/param_type_spec.rb
@@ -27,9 +27,51 @@ describe 'Params Types' do
         { message: 'hi' }
       end
 
+      if Gem::Version.new(Grape::VERSION) >= Gem::Version.new('2.1.0')
+        desc 'other_action' do
+          consumes ['application/x-www-form-urlencoded']
+        end
+        params do
+          requires :input, type: String, length: { min: 1, max: 12 }
+          requires :arr, type: [Integer], length: { min: 1, max: 12 }
+        end
+        post :other_action do
+          { message: 'hi' }
+        end
+      end
+
       add_swagger_documentation
     end
   end
+
+  context 'when length validator is used', if: Gem::Version.new(Grape::VERSION) >= Gem::Version.new('2.1.0') do
+    subject do
+      get '/swagger_doc/other_action'
+    end
+
+    it 'documents the length/item limits correctly' do
+      subject
+
+      expect(last_response.status).to eq 200
+      expect(JSON.parse(last_response.body)['paths']['/other_action']['post']['parameters']).to eq([{
+        'in' => 'formData',
+        'maxLength' => 12,
+        'minLength' => 1,
+        'name' => 'input',
+        'required' => true,
+        'type' => 'string'
+      }, {
+        'in' => 'formData',
+        'items' => { 'format' => 'int32', 'type' => 'integer' },
+        'maxItems' => 12,
+        'minItems' => 1,
+        'name' => 'arr',
+        'required' => true,
+        'type' => 'array'
+      }])
+    end
+  end
+
   context 'with no documentation hash' do
     subject do
       get '/swagger_doc/action'


### PR DESCRIPTION
Grape 2.1.0 Introduced the [length validator ](https://github.com/ruby-grape/grape/pull/2437). We can now use the length validator to specify the `min/maxItems` (for array types) and `min/maxLength` (for String types) for the attributes that use the validator in the generated swagger document.

Fixed test that was broken with rack 3 and restricted `rack < 3` for `grape < 2`