### PR TITLE
Pass request object to path_string

### DIFF
--- a/lib/grape-swagger/doc_methods.rb
+++ b/lib/grape-swagger/doc_methods.rb
@@ -50,7 +50,7 @@ module GrapeSwagger
         options
       )
 
-      paths, definitions   = endpoint.path_and_definition_objects(combi_routes, options)
+      paths, definitions   = endpoint.path_and_definition_objects(combi_routes, options, endpoint.request)
       tags                 = tags_from(paths, options)
 
       output[:tags]        = tags unless tags.empty? || paths.blank?

--- a/lib/grape-swagger/doc_methods/path_string.rb
+++ b/lib/grape-swagger/doc_methods/path_string.rb
@@ -4,7 +4,7 @@ module GrapeSwagger
   module DocMethods
     class PathString
       class << self
-        def build(route, options = {})
+        def build(route, options = {}, request = nil)
           path = route.path.dup
           # always removing format
           path.sub!(/\(\.\w+?\)$/, '')
@@ -25,7 +25,7 @@ module GrapeSwagger
             path.sub!('/{version}', '')
           end
 
-          path = "#{OptionalObject.build(:base_path, options)}#{path}" if options[:add_base_path]
+          path = "#{OptionalObject.build(:base_path, options, request)}#{path}" if options[:add_base_path]
 
           [item, path.start_with?('/') ? path : "/#{path}"]
         end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -76,12 +76,12 @@ module Grape
     end
 
     # building path and definitions objects
-    def path_and_definition_objects(namespace_routes, options)
+    def path_and_definition_objects(namespace_routes, options, request = nil)
       @paths = {}
       @definitions = {}
       add_definitions_from options[:models]
       namespace_routes.each_value do |routes|
-        path_item(routes, options)
+        path_item(routes, options, request)
       end
 
       [@paths, @definitions]
@@ -94,11 +94,11 @@ module Grape
     end
 
     # path object
-    def path_item(routes, options)
+    def path_item(routes, options, request = nil)
       routes.each do |route|
         next if hidden?(route, options)
 
-        @item, path = GrapeSwagger::DocMethods::PathString.build(route, options)
+        @item, path = GrapeSwagger::DocMethods::PathString.build(route, options, request)
         @entity = route.entity || route.options[:success]
 
         verb, method_object = method_object(route, options, path)


### PR DESCRIPTION
This changes allow configuring `base_path` using the `request` context.

```
add_swagger_documentation base_path: lambda { |request| request.path }
```

fix: #935