### PR TITLE
Fix NameError (uninitialized constant Grape::ContentTypes::CONTENT_TYPES) for Grape 2.2.0 release

### DIFF
--- a/lib/grape-swagger/doc_methods/produces_consumes.rb
+++ b/lib/grape-swagger/doc_methods/produces_consumes.rb
@@ -7,7 +7,7 @@ module GrapeSwagger
         def call(*args)
           return ['application/json'] unless args.flatten.present?
 
-          args.flatten.map { |x| Grape::ContentTypes::CONTENT_TYPES[x] || x }.uniq
+          args.flatten.map { |x| Grape::ContentTypes::DEFAULTS[x] || x }.uniq
         end
       end
     end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -12,7 +12,7 @@ module Grape
       if content_types.empty?
         formats       = [target_class.format, target_class.default_format].compact.uniq
         formats       = Grape::Formatter.formatters(**{}).keys if formats.empty?
-        content_types = Grape::ContentTypes::CONTENT_TYPES.select do |content_type, _mime_type|
+        content_types = Grape::ContentTypes::DEFAULTS.select do |content_type, _mime_type|
           formats.include? content_type
         end.values
       end


### PR DESCRIPTION
I prepare simple fix for renamed `Grape::ContentTypes::CONTENT_TYPES` to `Grape::ContentTypes::DEFAULTS` from Grape 2.2.0

NameError (uninitialized constant Grape::ContentTypes::CONTENT_TYPES):
  
grape-swagger (a5e2575a02e4) lib/grape-swagger/doc_methods/produces_consumes.rb:10:in `block in call'
grape-swagger (a5e2575a02e4) lib/grape-swagger/doc_methods/produces_consumes.rb:10:in `map'
grape-swagger (a5e2575a02e4) lib/grape-swagger/doc_methods/produces_consumes.rb:10:in `call'
grape-swagger (a5e2575a02e4) lib/grape-swagger/endpoint.rb:160:in `produces_object'
grape-swagger (a5e2575a02e4) lib/grape-swagger/endpoint.rb:120:in `method_object'
grape-swagger (a5e2575a02e4) lib/grape-swagger/endpoint.rb:104:in `block in path_item'