### PR TITLE
Grape 2.2.0 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,70 @@ jobs:
         bundle update
         bundle exec rspec
 
+  grape-21:
+    runs-on: ubuntu-latest
+    needs: ['rubocop']
+    env:
+      GRAPE_VERSION: '2.1.3'
+    strategy:
+      matrix:
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', 'head']
+    steps:
+    - name: Check out branch
+      uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Run rspec wo model parser
+      run: |
+        bundle update
+        bundle exec rspec
+    - name: Run rspec w entity parser
+      env:
+        MODEL_PARSER: grape-swagger-entity
+      run: |
+        bundle update
+        bundle exec rspec
+    - name: Run rspec w representable parser
+      env:
+        MODEL_PARSER: grape-swagger-representable
+      run: |
+        bundle update
+        bundle exec rspec
+
+  grape-22:
+    runs-on: ubuntu-latest
+    needs: ['rubocop']
+    env:
+      GRAPE_VERSION: '2.2.0'
+    strategy:
+      matrix:
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', 'head']
+    steps:
+    - name: Check out branch
+      uses: actions/checkout@v4
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+    - name: Run rspec wo model parser
+      run: |
+        bundle update
+        bundle exec rspec
+    - name: Run rspec w entity parser
+      env:
+        MODEL_PARSER: grape-swagger-entity
+      run: |
+        bundle update
+        bundle exec rspec
+    - name: Run rspec w representable parser
+      env:
+        MODEL_PARSER: grape-swagger-representable
+      run: |
+        bundle update
+        bundle exec rspec
+
   grape-HEAD:
     runs-on: ubuntu-latest
     needs: ['rubocop']

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,182 +22,52 @@ jobs:
           bundler-cache: true
       - name: Run rubocop
         run: bundle exec rubocop --parallel --format progress
-
-  grape-17:
+  test:
+    strategy:
+      matrix:
+        entry:
+          - { ruby: '3.0', grape: '1.7.1' }
+          - { ruby: '3.1', grape: '1.7.1' }
+          - { ruby: '3.2', grape: '1.7.1' }
+          - { ruby: '3.3', grape: '1.7.1' }
+          - { ruby: 'head', grape: '1.7.1' }
+          - { ruby: '3.0', grape: '1.8.0' }
+          - { ruby: '3.1', grape: '1.8.0' }
+          - { ruby: '3.2', grape: '1.8.0' }
+          - { ruby: '3.3', grape: '1.8.0' }
+          - { ruby: 'head', grape: '1.8.0' }
+          - { ruby: '3.0', grape: '2.0.0' }
+          - { ruby: '3.1', grape: '2.0.0' }
+          - { ruby: '3.2', grape: '2.0.0' }
+          - { ruby: '3.3', grape: '2.0.0' }
+          - { ruby: 'head', grape: '2.0.0' }
+          - { ruby: '3.0', grape: '2.1.3' }
+          - { ruby: '3.1', grape: '2.1.3' }
+          - { ruby: '3.2', grape: '2.1.3' }
+          - { ruby: '3.3', grape: '2.1.3' }
+          - { ruby: 'head', grape: '2.1.3' }
+          - { ruby: '3.0', grape: '2.2.0' }
+          - { ruby: '3.1', grape: '2.2.0' }
+          - { ruby: '3.2', grape: '2.2.0' }
+          - { ruby: '3.3', grape: '2.2.0' }
+          - { ruby: 'head', grape: '2.2.0' }
+          - { ruby: '3.0', grape: 'HEAD' }
+          - { ruby: '3.1', grape: 'HEAD' }
+          - { ruby: '3.2', grape: 'HEAD' }
+          - { ruby: '3.3', grape: 'HEAD' }
+          - { ruby: 'head', grape: 'HEAD' }
+    name: test (ruby=${{ matrix.entry.ruby }}, grape=${{ matrix.entry.grape }})
     runs-on: ubuntu-latest
     needs: ['rubocop']
     env:
-      GRAPE_VERSION: '1.7.1'
-    strategy:
-      matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3', 'head']
+      GRAPE_VERSION: ${{ matrix.entry.grape }}
     steps:
     - name: Check out branch
       uses: actions/checkout@v4
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
-    - name: Run rspec wo model parser
-      run: |
-        bundle update
-        bundle exec rspec
-    - name: Run rspec w entity parser
-      env:
-        MODEL_PARSER: grape-swagger-entity
-      run: |
-        bundle update
-        bundle exec rspec
-    - name: Run rspec w representable parser
-      env:
-        MODEL_PARSER: grape-swagger-representable
-      run: |
-        bundle update
-        bundle exec rspec
-
-  grape-18:
-    runs-on: ubuntu-latest
-    needs: ['rubocop']
-    env:
-      GRAPE_VERSION: '1.8.0'
-    strategy:
-      matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3', 'head']
-    steps:
-    - name: Check out branch
-      uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-    - name: Run rspec wo model parser
-      run: |
-        bundle update
-        bundle exec rspec
-    - name: Run rspec w entity parser
-      env:
-        MODEL_PARSER: grape-swagger-entity
-      run: |
-        bundle update
-        bundle exec rspec
-    - name: Run rspec w representable parser
-      env:
-        MODEL_PARSER: grape-swagger-representable
-      run: |
-        bundle update
-        bundle exec rspec
-
-  grape-20:
-    runs-on: ubuntu-latest
-    needs: ['rubocop']
-    env:
-      GRAPE_VERSION: '2.0.0'
-    strategy:
-      matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3', 'head']
-    steps:
-    - name: Check out branch
-      uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-    - name: Run rspec wo model parser
-      run: |
-        bundle update
-        bundle exec rspec
-    - name: Run rspec w entity parser
-      env:
-        MODEL_PARSER: grape-swagger-entity
-      run: |
-        bundle update
-        bundle exec rspec
-    - name: Run rspec w representable parser
-      env:
-        MODEL_PARSER: grape-swagger-representable
-      run: |
-        bundle update
-        bundle exec rspec
-
-  grape-21:
-    runs-on: ubuntu-latest
-    needs: ['rubocop']
-    env:
-      GRAPE_VERSION: '2.1.3'
-    strategy:
-      matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3', 'head']
-    steps:
-    - name: Check out branch
-      uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-    - name: Run rspec wo model parser
-      run: |
-        bundle update
-        bundle exec rspec
-    - name: Run rspec w entity parser
-      env:
-        MODEL_PARSER: grape-swagger-entity
-      run: |
-        bundle update
-        bundle exec rspec
-    - name: Run rspec w representable parser
-      env:
-        MODEL_PARSER: grape-swagger-representable
-      run: |
-        bundle update
-        bundle exec rspec
-
-  grape-22:
-    runs-on: ubuntu-latest
-    needs: ['rubocop']
-    env:
-      GRAPE_VERSION: '2.2.0'
-    strategy:
-      matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3', 'head']
-    steps:
-    - name: Check out branch
-      uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
-    - name: Run rspec wo model parser
-      run: |
-        bundle update
-        bundle exec rspec
-    - name: Run rspec w entity parser
-      env:
-        MODEL_PARSER: grape-swagger-entity
-      run: |
-        bundle update
-        bundle exec rspec
-    - name: Run rspec w representable parser
-      env:
-        MODEL_PARSER: grape-swagger-representable
-      run: |
-        bundle update
-        bundle exec rspec
-
-  grape-HEAD:
-    runs-on: ubuntu-latest
-    needs: ['rubocop']
-    env:
-      GRAPE_VERSION: 'HEAD'
-    strategy:
-      matrix:
-        ruby-version: ['3.0', '3.1', '3.2', '3.3', 'head']
-    steps:
-    - name: Check out branch
-      uses: actions/checkout@v4
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: ${{ matrix.ruby-version }}
+        ruby-version: ${{ matrix.entry.ruby }}
     - name: Run rspec wo model parser
       run: |
         bundle update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#940](https://github.com/ruby-grape/grape-swagger/pull/940): Grape 2.2.0 compatibility - [@padde](https://github.com/padde)
 * Your contribution here.
 
 

--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -15,8 +15,8 @@ Gem::Specification.new do |s|
   s.metadata['rubygems_mfa_required'] = 'true'
 
   s.required_ruby_version = '>= 3.0'
-  s.add_runtime_dependency 'grape', '>= 1.7', '< 3.0'
-  s.add_runtime_dependency 'rack-test', '~> 2'
+  s.add_dependency 'grape', '>= 1.7', '< 3.0'
+  s.add_dependency 'rack-test', '~> 2'
 
   s.files = Dir['lib/**/*', '*.md', 'LICENSE.txt', 'grape-swagger.gemspec']
   s.require_paths = ['lib']

--- a/lib/grape-swagger.rb
+++ b/lib/grape-swagger.rb
@@ -18,6 +18,24 @@ module GrapeSwagger
     end
   end
   autoload :Rake, 'grape-swagger/rake/oapi_tasks'
+
+  # Copied from https://github.com/ruby-grape/grape/blob/v2.2.0/lib/grape/formatter.rb
+  FORMATTER_DEFAULTS = {
+    json: Grape::Formatter::Json,
+    jsonapi: Grape::Formatter::Json,
+    serializable_hash: Grape::Formatter::SerializableHash,
+    txt: Grape::Formatter::Txt,
+    xml: Grape::Formatter::Xml
+  }.freeze
+
+  # Copied from https://github.com/ruby-grape/grape/blob/v2.2.0/lib/grape/content_types.rb
+  CONTENT_TYPE_DEFAULTS = {
+    xml: 'application/xml',
+    serializable_hash: 'application/json',
+    json: 'application/json',
+    binary: 'application/octet-stream',
+    txt: 'text/plain'
+  }.freeze
 end
 
 module SwaggerRouting

--- a/lib/grape-swagger/doc_methods/produces_consumes.rb
+++ b/lib/grape-swagger/doc_methods/produces_consumes.rb
@@ -7,7 +7,7 @@ module GrapeSwagger
         def call(*args)
           return ['application/json'] unless args.flatten.present?
 
-          args.flatten.map { |x| Grape::ContentTypes::CONTENT_TYPES[x] || x }.uniq
+          args.flatten.map { |x| GrapeSwagger::CONTENT_TYPE_DEFAULTS[x] || x }.uniq
         end
       end
     end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -11,8 +11,8 @@ module Grape
 
       if content_types.empty?
         formats       = [target_class.format, target_class.default_format].compact.uniq
-        formats       = Grape::Formatter.formatters(**{}).keys if formats.empty?
-        content_types = Grape::ContentTypes::CONTENT_TYPES.select do |content_type, _mime_type|
+        formats       = GrapeSwagger::FORMATTER_DEFAULTS.keys if formats.empty?
+        content_types = GrapeSwagger::CONTENT_TYPE_DEFAULTS.select do |content_type, _mime_type|
           formats.include? content_type
         end.values
       end


### PR DESCRIPTION
Running on grape 2.0.2 resulted in the following exceptions:

    NameError:
      uninitialized constant Grape::ContentTypes::CONTENT_TYPES
    # ./lib/grape-swagger/endpoint.rb:15:in `content_types_for'

    NoMethodError:
      undefined method `formatters' for module Grape::Formatter
    # ./lib/grape-swagger/endpoint.rb:14:in `content_types_for'

This is due to internal refactorings in grape as of v2.2.0, specifically https://github.com/ruby-grape/grape/commit/fb67ea99

Fixes #939