### PR TITLE
Fix route_param documentation and type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 #### Fixes
 
+* [#943](https://github.com/ruby-grape/grape-swagger/pull/943): Fix route_param documentation and type - [@4ndv](https://github.com/4ndv)
 * Your contribution here.
 
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -377,7 +377,7 @@ module Grape
         route_params[key] = path.merge(params)
       end
 
-      route.params.delete_if { |key| key.is_a?(String) && param_keys.include?(key.to_sym) }.to_a
+      route_params.delete_if { |key| key.is_a?(String) && param_keys.include?(key.to_sym) }.to_a
     end
 
     # Iterates over namespaces recursively

--- a/spec/issues/942_route_params.rb
+++ b/spec/issues/942_route_params.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe '#942 route param documentation' do
+  let(:documentation) { { format: 'uuid' } }
+
+  let(:app) do
+    docs = documentation
+
+    another_app = Class.new(Grape::API) do
+      get '/list' do
+        []
+      end
+    end
+
+    Class.new(Grape::API) do
+      route_param :account_id, type: String, desc: 'id of account', documentation: docs do
+        mount another_app
+
+        get '/another-list' do
+          []
+        end
+      end
+
+      add_swagger_documentation
+    end
+  end
+
+  subject do
+    get '/swagger_doc'
+    JSON.parse(last_response.body)
+  end
+
+  context 'when documenting route_param of mounted endpoint' do
+    let(:parameters) { subject['paths']['/{account_id}/list']['get']['parameters'] }
+
+    specify do
+      account_id_param = parameters.find { |param| param['name'] == 'account_id' }
+      expect(account_id_param['type']).to eq 'string'
+      expect(account_id_param['format']).to eq 'uuid'
+      expect(account_id_param['description']).to eq 'id of account'
+    end
+  end
+
+  context 'when documenting route_param of nested endpoint' do
+    let(:parameters) { subject['paths']['/{account_id}/another-list']['get']['parameters'] }
+
+    specify do
+      account_id_param = parameters.find { |param| param['name'] == 'account_id' }
+      expect(account_id_param['type']).to eq 'string'
+      expect(account_id_param['format']).to eq 'uuid'
+      expect(account_id_param['description']).to eq 'id of account'
+    end
+  end
+
+  context 'when documentation overrides description' do
+    let(:documentation) { { desc: 'another description' } }
+
+    let(:parameters) { subject['paths']['/{account_id}/list']['get']['parameters'] }
+
+    specify do
+      account_id_param = parameters.find { |param| param['name'] == 'account_id' }
+      expect(account_id_param['type']).to eq 'string'
+      expect(account_id_param['description']).to eq 'another description'
+    end
+  end
+end


### PR DESCRIPTION
`Grape::Entity#merge_params` returns `route.params`, which effectively discards result of code above this line, because `route.params` produces new object each time it's called

Fixes #942 and (potentially) #325

Side note: I think filter condition in `delete_if` at least requires an explanation comment/revision, because it's a little bit cryptic