### PR TITLE
Dependencies update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * your contribution
+* [#948](https://github.com/ruby-grape/grape-swagger/pull/948): Grape 2.3.0 and Ruby 3.5 compatibility - [@numbata](https://github.com/numbata)
 
 
 ### 2.1.2 (Jan 7, 2025)

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,9 @@ group :development, :test do
   unless ENV['MODEL_PARSER'] == 'grape-swagger-entity'
     gem 'grape-swagger-entity', git: 'https://github.com/ruby-grape/grape-swagger-entity'
   end
+
+  # Conditionally load 'ostruct' only if Ruby >= 3.5.0
+  gem 'ostruct' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.5.0')
 end
 
 group :test do

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -12,7 +12,7 @@ module Grape
       if content_types.empty?
         formats       = [target_class.format, target_class.default_format].compact.uniq
         formats       = GrapeSwagger::FORMATTER_DEFAULTS.keys if formats.empty?
-        content_types = GrapeSwagger::CONTENT_TYPE_DEFAULTS.select do |content_type, _mime_type|
+        content_types = GrapeSwagger::CONTENT_TYPE_DEFAULTS.select do |content_type, _mime_type| # rubocop:disable Style/HashSlice
           formats.include? content_type
         end.values
       end

--- a/spec/lib/move_params_spec.rb
+++ b/spec/lib/move_params_spec.rb
@@ -97,7 +97,7 @@ describe GrapeSwagger::DocMethods::MoveParams do
     let(:route_options) { { requirements: {} } }
     describe 'POST' do
       let(:params) { paths[path][:post][:parameters] }
-      let(:route) { Grape::Router::Route.new('POST', path.dup, **route_options) }
+      let(:route) { RouteHelper.build(method: 'POST', pattern: path.dup, options: route_options) }
 
       specify do
         subject.to_definition(path, params, route, definitions)
@@ -128,7 +128,7 @@ describe GrapeSwagger::DocMethods::MoveParams do
 
     describe 'PUT' do
       let(:params) { paths['/in_body/{key}'][:put][:parameters] }
-      let(:route) { Grape::Router::Route.new('PUT', path.dup, **route_options) }
+      let(:route) { RouteHelper.build(method: 'PUT', pattern: path.dup, options: route_options) }
 
       specify do
         subject.to_definition(path, params, route, definitions)

--- a/spec/lib/operation_id_spec.rb
+++ b/spec/lib/operation_id_spec.rb
@@ -9,7 +9,7 @@ describe GrapeSwagger::DocMethods::OperationId do
   specify { expect(subject).to respond_to :build }
 
   describe 'build' do
-    let(:route) { Grape::Router::Route.new(method, '/path', requirements: {}) }
+    let(:route) { RouteHelper.build(method: method, pattern: '/path', options: { requirements: {} }) }
 
     describe 'GET' do
       let(:method) { 'GET' }

--- a/spec/support/route_helper.rb
+++ b/spec/support/route_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module RouteHelper
+  def self.build(method:, pattern:, options:, origin: nil)
+    if GrapeVersion.satisfy?('>= 2.3.0')
+      Grape::Router::Route.new(method, origin || pattern, pattern, options)
+    else
+      Grape::Router::Route.new(method, pattern, **options)
+    end
+  end
+end


### PR DESCRIPTION
This PR does not affect any primary gem functionality but introduces two changes to improve the test environment:

 - `ostruct` gem added into Gemfile
    Starting with Ruby 3.5.0, ostruct has been promoted to a bundled default gem. For more information, see:
        [Ruby Issue #20309](https://bugs.ruby-lang.org/issues/20309)
        [Ruby NEWS (commit cfca348)](https://github.com/ruby/ruby/blob/cfca348436e0a9da2bb2d4402a4003601501ef0e/NEWS.md?plain=1#L24)

 - Helper for Grape gem Router::Route initializer
    In Grape version 2.3.0, the Router::Route initialize signature changed ([PR #2513](https://github.com/ruby-grape/grape/pull/2513)). To allow our tests to run against both old and new Grape versions, a spec-specific route helper was added.

These updates ensure compatibility with newer Ruby and Grape releases while leaving the core gem code unchanged.