### PR TITLE
Added super_diff gem for improved diffing in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 #### Features
 
 * your contribution
+* [#953](https://github.com/ruby-grape/grape-swagger/pull/953): Added super_diff gem for improved diffing in tests - [@numbata](https://github.com/numbata)
 
 #### Fixes
 

--- a/Gemfile
+++ b/Gemfile
@@ -45,4 +45,5 @@ end
 
 group :test do
   gem 'simplecov', require: false
+  gem 'super_diff', require: false
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ Bundler.setup :default, :test
 require 'rack'
 require 'rack/test'
 
-require 'super_diff/rspec' if ENV.key?('SUPER_DIFF')
+require 'super_diff/rspec'
 
 RSpec.configure do |config|
   require 'rspec/expectations'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ Bundler.setup :default, :test
 
 require 'rack'
 require 'rack/test'
+require 'super_diff/rspec' if ENV.key?('SUPER_DIFF')
 
 RSpec.configure do |config|
   require 'rspec/expectations'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,6 +19,7 @@ Bundler.setup :default, :test
 
 require 'rack'
 require 'rack/test'
+
 require 'super_diff/rspec' if ENV.key?('SUPER_DIFF')
 
 RSpec.configure do |config|


### PR DESCRIPTION
Leverage the super_diff gem to significantly enhance the clarity of diffs in failing RSpec tests.

Before:
```ruby
       expected: [{"in"=>"header", "name"=>"postMultipleNestedParamsInBody", "required"=>true, "schema"=>{"$ref"=>"#/definitions/postMultipleNestedParamsInBody"}}]
            got: [{"in"=>"body", "name"=>"postMultipleNestedParamsInBody", "required"=>true, "schema"=>{"$ref"=>"#/definitions/postMultipleNestedParamsInBody"}}]

       (compared using eql?)

       Diff:
       @@ -1,4 +1,4 @@
       -[{"in"=>"header",
       +[{"in"=>"body",
          "name"=>"postMultipleNestedParamsInBody",
          "required"=>true,
          "schema"=>{"$ref"=>"#/definitions/postMultipleNestedParamsInBody"}}]
```

After:
```ruby
       expected: [{ "name" => "postMultipleNestedParamsInBody", "in" => "header", "required" => true, "schema" => { "$ref" => "#/definitions/postMultipleNestedParamsInBody" } }]
            got: [{ "name" => "postMultipleNestedParamsInBody", "in" => "body", "required" => true, "schema" => { "$ref" => "#/definitions/postMultipleNestedParamsInBody" } }]

       (compared using eql?)

       Diff:

       ┌ (Key) ──────────────────────────┐
       │ ‹-› in expected, not in actual  │
       │ ‹+› in actual, not in expected  │
       │ ‹ › in both expected and actual │
       └─────────────────────────────────┘

         [
           {
             "name" => "postMultipleNestedParamsInBody",
       -     "in" => "header",
       +     "in" => "body",
             "required" => true,
             "schema" => {
               "$ref" => "#/definitions/postMultipleNestedParamsInBody"
             }
           }
         ]
```