### PR TITLE
Ruby 3.5 compatibility: add cgi gem, drop runtime rack‑test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * your contribution
+* [#954](https://github.com/ruby-grape/grape-swagger/pull/954): Ruby 3.5 compatibility: add cgi gem, drop runtime rack‑test - [@numbata](https://github.com/numbata)
 * [#948](https://github.com/ruby-grape/grape-swagger/pull/948): Grape 2.3.0 and Ruby 3.5 compatibility - [@numbata](https://github.com/numbata)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 #### Fixes
 
-* your contribution
-* [#954](https://github.com/ruby-grape/grape-swagger/pull/954): Ruby 3.5 compatibility: add cgi gem, drop runtime rack‑test - [@numbata](https://github.com/numbata)
+* Your contribution here.
+* [#954](https://github.com/ruby-grape/grape-swagger/pull/954): Ruby 3.5 compatibility: add cgi gem, drop runtime rack‑test - [@numbata](https://github.com/numbata).
 * [#948](https://github.com/ruby-grape/grape-swagger/pull/948): Grape 2.3.0 and Ruby 3.5 compatibility - [@numbata](https://github.com/numbata)
 
 

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ group :development, :test do
     gem 'rack', '< 3.0'
   end
 
+  gem 'cgi'
   gem 'rack-cors'
   gem 'rack-test'
   gem 'rake'

--- a/grape-swagger.gemspec
+++ b/grape-swagger.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 3.1'
   s.add_dependency 'grape', '>= 1.7', '< 3.0'
-  s.add_dependency 'rack-test', '~> 2'
 
   s.files = Dir['lib/**/*', '*.md', 'LICENSE.txt', 'grape-swagger.gemspec']
   s.require_paths = ['lib']


### PR DESCRIPTION
Ruby 3.5 retires the `cgi` library from the default gem set ([ruby/ruby#13275](https://github.com/ruby/ruby/pull/13275)), so we add it explicitly. Also the `rack‑test` gem is only used in specs, so it’s been dropped from the gemspec’s runtime deps; it remains in the dev/test Gemfile group.