### PR TITLE
Fix issue where array params are sometimes omitted when array_use_braces is true

### DIFF
--- a/lib/grape-swagger/doc_methods/parse_params.rb
+++ b/lib/grape-swagger/doc_methods/parse_params.rb
@@ -17,6 +17,7 @@ module GrapeSwagger
             in: param_type(value_type, consumes),
             name: settings[:full_name] || param
           }
+          fix_name_of_body_array_param(value_type)
 
           # optional properties
           document_description(settings)
@@ -34,6 +35,12 @@ module GrapeSwagger
         end
 
         private
+
+        def fix_name_of_body_array_param(value_type)
+          return unless @parsed_param[:in] == 'body' && value_type[:is_array]
+
+          @parsed_param[:name] = @parsed_param[:name].delete_suffix('[]')
+        end
 
         def document_description(settings)
           description = settings[:desc] || settings[:description]


### PR DESCRIPTION
Fixes #952.

The fix consists of removing the `[]` suffix at the end of a parameter's name if the parameter is an array and it's a body param.

This fix is very hacky: ideally, `[]` shouldn't be added in the first place. But I don't think that can be achieved without significantly refactoring the code.

@dblock @numbata Curious if you have any thoughts on this approach.