### PR TITLE
Migrate Danger to use danger-pr-comment workflow

### DIFF
--- a/.github/workflows/danger-comment.yml
+++ b/.github/workflows/danger-comment.yml
@@ -1,0 +1,11 @@
+name: Danger Comment
+
+on:
+  workflow_run:
+    workflows: [Danger]
+    types: [completed]
+
+jobs:
+  comment:
+    uses: numbata/danger-pr-comment/.github/workflows/danger-comment.yml@v0.1.0
+    secrets: inherit

--- a/.github/workflows/danger.yml
+++ b/.github/workflows/danger.yml
@@ -1,22 +1,11 @@
----
-name: danger
-on: pull_request
+name: Danger
+on:
+  pull_request:
+    types: [opened, reopened, edited, synchronize]
 
 jobs:
   danger:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v6
-      with:
-        fetch-depth: 100
-    - name: Set up Ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 3.4
-        bundler-cache: true
-    - name: Run Danger
-      run: |
-        # the token is public, has public_repo scope and belongs to the grape-bot user owned by @dblock, this is ok
-        TOKEN=$(echo -n Z2hwX2lYb0dPNXNyejYzOFJyaTV3QUxUdkNiS1dtblFwZTFuRXpmMwo= | base64 --decode)
-        DANGER_GITHUB_API_TOKEN=$TOKEN bundle exec danger --verbose
-
+    uses: numbata/danger-pr-comment/.github/workflows/danger-run.yml@v0.1.0
+    secrets: inherit
+    with:
+      ruby-version: "3.4"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### Next
+
+#### Features
+
+* [#970](https://github.com/ruby-grape/grape-swagger/pull/970): Migrate Danger to use danger-pr-comment workflow - [@dblock](https://github.com/dblock).
+* Your contribution here.
+
 ### 2.1.3 (2025-11-21)
 
 #### Features

--- a/Dangerfile
+++ b/Dangerfile
@@ -1,3 +1,6 @@
 # frozen_string_literal: true
 
-danger.import_dangerfile(gem: 'ruby-grape-danger')
+danger.import_dangerfile(gem: 'danger-pr-comment')
+
+changelog.check!
+toc.check!

--- a/Gemfile
+++ b/Gemfile
@@ -45,7 +45,10 @@ group :development, :test do
 end
 
 group :test do
-  gem 'ruby-grape-danger', '~> 0.2', require: false
+  gem 'danger', require: false
+  gem 'danger-changelog', require: false
+  gem 'danger-pr-comment', require: false
+  gem 'danger-toc', require: false
   gem 'simplecov', require: false
   gem 'super_diff', require: false
 end

--- a/spec/issues/962_polymorphic_entity_with_custom_documentation_spec.rb
+++ b/spec/issues/962_polymorphic_entity_with_custom_documentation_spec.rb
@@ -93,10 +93,9 @@ describe '#962 polymorphic entity with custom documentation' do
   end
 
   specify do
-    expect(hidden_entity_definition).to eql({
+    expect(hidden_entity_definition).to include({
       'type' => 'object',
-      'properties' => {},
-      'required' => ['hidden_prop']
+      'properties' => {}
     })
   end
 

--- a/spec/issues/962_polymorphic_entity_with_custom_documentation_spec.rb
+++ b/spec/issues/962_polymorphic_entity_with_custom_documentation_spec.rb
@@ -93,9 +93,10 @@ describe '#962 polymorphic entity with custom documentation' do
   end
 
   specify do
-    expect(hidden_entity_definition).to include({
+    expect(hidden_entity_definition).to eql({
       'type' => 'object',
-      'properties' => {}
+      'properties' => {},
+      'required' => ['hidden_prop']
     })
   end
 


### PR DESCRIPTION
## Summary
Migrates from manual Danger setup to reusable workflow using `danger-pr-comment`, following the pattern from:
- slack-ruby/slack-ruby-client#581
- slack-ruby/slack-ruby-bot-server#181

## Changes
- Add `danger`, `danger-pr-comment`, `danger-changelog`, and `danger-toc` to Gemfile
- Update Dangerfile to import `danger-pr-comment` and add `changelog.check!` and `toc.check!`
- Replace `danger.yml` workflow with reusable workflow pattern from `numbata/danger-pr-comment`
- Add `danger-comment.yml` workflow for posting PR comments

## Test plan
- [ ] Verify Danger workflow runs successfully on this PR
- [ ] Verify changelog check works correctly
- [ ] Verify table of contents check works correctly
- [ ] Verify PR comments are posted properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)