### PR TITLE
Fix Grape 3.1.0 and grape-swagger-entity 0.7.1 compatibility

### DIFF
--- a/.github/workflows/edge.yml
+++ b/.github/workflows/edge.yml
@@ -1,0 +1,43 @@
+name: Edge
+
+on:
+  schedule:
+    - cron: '0 0 * * 0' # Every Sunday at midnight UTC
+  workflow_dispatch: # Allow manual trigger
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ['3.3', '3.4']
+    name: test (ruby=${{ matrix.ruby }}, grape=HEAD)
+    runs-on: ubuntu-latest
+    env:
+      GRAPE_VERSION: HEAD
+    steps:
+    - name: Check out branch
+      uses: actions/checkout@v6
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Run rspec wo model parser
+      run: |
+        bundle update
+        bundle exec rspec
+    - name: Run rspec w entity parser
+      env:
+        MODEL_PARSER: grape-swagger-entity
+      run: |
+        bundle update
+        bundle exec rspec
+    - name: Run rspec w representable parser
+      env:
+        MODEL_PARSER: grape-swagger-representable
+      run: |
+        bundle update
+        bundle exec rspec

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 #### Fixes
 
 * [#972](https://github.com/ruby-grape/grape-swagger/pull/972): Grape 3.1.0 and grape-swagger-entity 0.7.1 compatibility - [@numbata](https://github.com/numbata).
+* Your contribution here.
 
 ### 2.1.3 (2025-11-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,12 @@
 #### Features
 
 * [#970](https://github.com/ruby-grape/grape-swagger/pull/970): Migrate Danger to use danger-pr-comment workflow - [@dblock](https://github.com/dblock).
+* [#972](https://github.com/ruby-grape/grape-swagger/pull/972): Add weekly scheduled workflow to test against Grape HEAD - [@numbata](https://github.com/numbata).
 * Your contribution here.
+
+#### Fixes
+
+* [#972](https://github.com/ruby-grape/grape-swagger/pull/972): Grape 3.1.0 and grape-swagger-entity 0.7.1 compatibility - [@numbata](https://github.com/numbata).
 
 ### 2.1.3 (2025-11-21)
 

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -155,8 +155,8 @@ module Grape
     end
 
     def produces_object(route, format)
-      return ['application/octet-stream'] if file_response?(route.attributes.success) &&
-                                             !route.attributes.produces.present?
+      return ['application/octet-stream'] if file_response?(route.options[:success]) &&
+                                             !route.options[:produces].present?
 
       mime_types = GrapeSwagger::DocMethods::ProducesConsumes.call(format)
 

--- a/spec/issues/962_polymorphic_entity_with_custom_documentation_spec.rb
+++ b/spec/issues/962_polymorphic_entity_with_custom_documentation_spec.rb
@@ -92,8 +92,6 @@ describe '#962 polymorphic entity with custom documentation' do
     })
   end
 
-  # Hidden attributes should not be included in the required list
-  # See: https://github.com/ruby-grape/grape-swagger-entity/pull/87
   specify do
     expect(hidden_entity_definition).to eql({
       'type' => 'object',

--- a/spec/issues/962_polymorphic_entity_with_custom_documentation_spec.rb
+++ b/spec/issues/962_polymorphic_entity_with_custom_documentation_spec.rb
@@ -92,11 +92,12 @@ describe '#962 polymorphic entity with custom documentation' do
     })
   end
 
+  # Hidden attributes should not be included in the required list
+  # See: https://github.com/ruby-grape/grape-swagger-entity/pull/87
   specify do
     expect(hidden_entity_definition).to eql({
       'type' => 'object',
-      'properties' => {},
-      'required' => ['hidden_prop']
+      'properties' => {}
     })
   end
 

--- a/spec/support/route_helper.rb
+++ b/spec/support/route_helper.rb
@@ -2,7 +2,20 @@
 
 module RouteHelper
   def self.build(method:, pattern:, options:, origin: nil)
-    if GrapeVersion.satisfy?('>= 2.3.0')
+    if GrapeVersion.satisfy?('>= 3.1.0')
+      # Grape 3.1.0+ changed Route constructor to (endpoint, method, pattern, options)
+      # and Pattern now takes keyword arguments
+      pattern_obj = Grape::Router::Pattern.new(
+        origin: origin || pattern,
+        suffix: nil,
+        anchor: options[:anchor] || true,
+        params: options[:params] || {},
+        format: nil,
+        version: nil,
+        requirements: options[:requirements] || {}
+      )
+      Grape::Router::Route.new(nil, method, pattern_obj, options)
+    elsif GrapeVersion.satisfy?('>= 2.3.0')
       Grape::Router::Route.new(method, origin || pattern, pattern, options)
     else
       Grape::Router::Route.new(method, pattern, **options)

--- a/spec/support/route_helper.rb
+++ b/spec/support/route_helper.rb
@@ -8,11 +8,11 @@ module RouteHelper
       pattern_obj = Grape::Router::Pattern.new(
         origin: origin || pattern,
         suffix: nil,
-        anchor: options[:anchor] || true,
-        params: options[:params] || {},
+        anchor: options.fetch(:anchor, true),
+        params: options.fetch(:params, {}),
         format: nil,
         version: nil,
-        requirements: options[:requirements] || {}
+        requirements: options.fetch(:requirements, {})
       )
       Grape::Router::Route.new(nil, method, pattern_obj, options)
     elsif GrapeVersion.satisfy?('>= 2.3.0')

--- a/spec/support/route_helper.rb
+++ b/spec/support/route_helper.rb
@@ -3,8 +3,6 @@
 module RouteHelper
   def self.build(method:, pattern:, options:, origin: nil)
     if GrapeVersion.satisfy?('>= 3.1.0')
-      # Grape 3.1.0+ changed Route constructor to (endpoint, method, pattern, options)
-      # and Pattern now takes keyword arguments
       pattern_obj = Grape::Router::Pattern.new(
         origin: origin || pattern,
         suffix: nil,

--- a/spec/swagger_v2/reference_entity_spec.rb
+++ b/spec/swagger_v2/reference_entity_spec.rb
@@ -101,7 +101,7 @@ describe 'referenceEntity' do
         'properties' => {
           'title' => { 'type' => 'string', 'description' => 'Title of the kind.' },
           'something' => {
-            '$ref' => '#/definitions/SomethingCustom',
+            'allOf' => [{ '$ref' => '#/definitions/SomethingCustom' }],
             'description' => 'Something interesting.'
           }
         },


### PR DESCRIPTION
## Summary

Grape 3.1.0 refactored `BaseRoute` to remove the `attributes` alias, causing `NoMethodError` when generating swagger documentation. This PR fixes the compatibility issue by accessing route options directly via `route.options[:success]` and `route.options[:produces]`, which works consistently across all Grape versions.

Additionally, this PR updates test expectations to align with grape-swagger-entity 0.7.1, which introduced two behavioral changes:
- Hidden entity attributes are now correctly excluded from the `required` array (ruby-grape/grape-swagger-entity#87)
- Entity references with descriptions now use the `allOf` wrapper, which is the correct OpenAPI format since `$ref` cannot have sibling properties (ruby-grape/grape-swagger-entity#90)

A weekly scheduled workflow has been added to catch future compatibility issues with Grape HEAD early.

## Test plan

All tests pass across the full matrix: Ruby 3.1-3.4 + head, Grape 1.8.0-HEAD, with and without grape-swagger-entity parser.

Fixes #971