### PR TITLE
Support custom model descriptions and examples

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -26,7 +26,7 @@ Metrics/MethodLength:
 # Offense count: 9
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/PerceivedComplexity:
-  Max: 16
+  Max: 17
 
 # Offense count: 3
 Style/ClassVars:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -26,7 +26,7 @@ Metrics/MethodLength:
 # Offense count: 9
 # Configuration parameters: AllowedMethods, AllowedPatterns.
 Metrics/PerceivedComplexity:
-  Max: 17
+  Max: 16
 
 # Offense count: 3
 Style/ClassVars:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Features
 
+* [#973](https://github.com/ruby-grape/grape-swagger/pull/973): Support custom model descriptions and examples - [@numbata](https://github.com/numbata).
 * [#976](https://github.com/ruby-grape/grape-swagger/pull/976): Ruby 3.4 and refactor swagger documentation modules; deprecate top-level `SwaggerRouting` and `SwaggerDocumentationAdder` aliases in favor of `GrapeSwagger::...` - [@moskvin](https://github.com/moskvin).
 * Your contribution here.
 

--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@
     - [Multiple present Response ](#multiple-present-response-)
 - [Using Grape Entities ](#using-grape-entities-)
   - [Documented class/definition](#documented-classdefinition)
+  - [Custom Model Description and Example](#custom-model-description-and-example)
   - [Relationships](#relationships)
     - [1xN](#1xn)
     - [1x1](#1x1)
@@ -1608,6 +1609,48 @@ Should generate the following definitions in your swagger json:
           "type": "url",
         },
       "description": "LinkedStatus model"
+    }
+  }
+}
+```
+
+### Custom Model Description and Example
+
+By default, a model's `description` in the generated swagger definition falls back to `"#{ModelName} model"`, and no `example` is set. You can override both by defining a `self.documentation` class method on the entity that returns a hash with `:desc` and/or `:example` keys. This is separate from field-level `documentation:` options passed to `expose`, and does not affect them:
+
+```ruby
+module API
+  module Entities
+    class User < Grape::Entity
+      def self.documentation
+        {
+          desc: 'Represents a user account',
+          example: { id: 1, name: 'John Doe', email: 'john@example.com' }
+        }
+      end
+
+      expose :id, documentation: { type: 'integer' }
+      expose :name, documentation: { type: 'string' }
+      expose :email, documentation: { type: 'string' }
+    end
+  end
+end
+```
+
+Should generate the following definition in your swagger json:
+
+```json
+{
+  "definitions": {
+    "API_Entities_User": {
+      "type": "object",
+      "description": "Represents a user account",
+      "example": { "id": 1, "name": "John Doe", "email": "john@example.com" },
+      "properties": {
+        "id": { "type": "integer" },
+        "name": { "type": "string" },
+        "email": { "type": "string" }
+      }
     }
   }
 }

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -219,6 +219,7 @@ module Grape
         next if response_model.start_with?('Swagger_doc')
 
         @definitions[response_model][:description] ||= model_description(value[:model]) || "#{response_model} model"
+        @definitions[response_model][:example] ||= model_example(value[:model])
         build_memo_schema(memo, route, value, response_model, options)
         memo[value[:code]][:examples] = value[:examples] if value[:examples]
       end
@@ -461,6 +462,13 @@ module Grape
 
       doc = model.documentation
       doc[:desc] if doc.is_a?(Hash)
+    end
+
+    def model_example(model)
+      return unless model.respond_to?(:documentation)
+
+      doc = model.documentation
+      doc[:example] if doc.is_a?(Hash)
     end
 
     def success_code_from_entity(route, entity)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -218,7 +218,7 @@ module Grape
         next unless @definitions[response_model]
         next if response_model.start_with?('Swagger_doc')
 
-        @definitions[response_model][:description] ||= "#{response_model} model"
+        @definitions[response_model][:description] ||= model_description(value[:model]) || "#{response_model} model"
         build_memo_schema(memo, route, value, response_model, options)
         memo[value[:code]][:examples] = value[:examples] if value[:examples]
       end
@@ -454,6 +454,13 @@ module Grape
       else
         value.dig(:documentation, :hidden)
       end
+    end
+
+    def model_description(model)
+      return unless model.respond_to?(:documentation)
+
+      doc = model.documentation
+      doc[:desc] if doc.is_a?(Hash)
     end
 
     def success_code_from_entity(route, entity)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -459,23 +459,22 @@ module Grape
     end
 
     def model_description(model)
-      return unless model.respond_to?(:documentation)
-
-      doc = model.documentation
-      desc = doc[:desc] if doc.is_a?(Hash)
+      doc = model_documentation(model)
+      desc = doc[:desc] if doc
       desc if desc.is_a?(String)
     end
 
     def model_example(model)
+      doc = model_documentation(model)
+      doc[:example] if doc
+    end
+
+    def model_documentation(model)
       return unless model.respond_to?(:documentation)
+      return if defined?(Grape::Entity) && model.method(:documentation).owner == Grape::Entity.singleton_class
 
       doc = model.documentation
-      return unless doc.is_a?(Hash)
-
-      example = doc[:example]
-      return if example.is_a?(Hash) && (example.key?(:type) || example.key?(:desc))
-
-      example
+      doc if doc.is_a?(Hash)
     end
 
     def success_code_from_entity(route, entity)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -470,7 +470,12 @@ module Grape
       return unless model.respond_to?(:documentation)
 
       doc = model.documentation
-      doc[:example] if doc.is_a?(Hash)
+      return unless doc.is_a?(Hash)
+
+      example = doc[:example]
+      return if example.is_a?(Hash) && (example.key?(:type) || example.key?(:desc))
+
+      example
     end
 
     def success_code_from_entity(route, entity)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -474,7 +474,23 @@ module Grape
       return if defined?(Grape::Entity) && model.method(:documentation).owner == Grape::Entity.singleton_class
 
       doc = model.documentation
-      doc if doc.is_a?(Hash)
+      return unless doc.is_a?(Hash)
+      return unless (doc.keys - %i[desc example]).empty?
+      return if field_documentation?(doc[:example])
+
+      doc
+    end
+
+    def field_documentation?(value)
+      return false unless value.is_a?(Hash) && value[:type]
+      return false unless value.key?(:desc) || value.key?(:is_array) || value.key?(:required)
+
+      documentation_type?(value[:type])
+    end
+
+    def documentation_type?(value)
+      value.is_a?(Class) || value.is_a?(Module) || value.is_a?(Symbol) ||
+        %w[array boolean file integer link number object string text].include?(value)
     end
 
     def success_code_from_entity(route, entity)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -218,9 +218,7 @@ module Grape
         next unless @definitions[response_model]
         next if response_model.start_with?('Swagger_doc')
 
-        @definitions[response_model][:description] ||= model_description(value[:model]) || "#{response_model} model"
-        example = model_example(value[:model])
-        @definitions[response_model][:example] ||= example unless example.nil?
+        apply_model_documentation(response_model, value[:model])
         build_memo_schema(memo, route, value, response_model, options)
         memo[value[:code]][:examples] = value[:examples] if value[:examples]
       end
@@ -456,6 +454,12 @@ module Grape
       else
         value.dig(:documentation, :hidden)
       end
+    end
+
+    def apply_model_documentation(response_model, model)
+      @definitions[response_model][:description] ||= model_description(model) || "#{response_model} model"
+      example = model_example(model)
+      @definitions[response_model][:example] ||= example unless example.nil?
     end
 
     def model_description(model)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -505,8 +505,10 @@ module Grape
     end
 
     def documentation_type?(value)
-      value.is_a?(Class) || value.is_a?(Module) || value.is_a?(Symbol) ||
-        %w[array boolean file integer link number object string text].include?(value)
+      return true if value.is_a?(Class) || value.is_a?(Module) || value.is_a?(Symbol)
+      return false unless value.is_a?(String)
+
+      %w[array boolean file integer link number object string text].include?(value.downcase)
     end
 
     def success_code_from_entity(route, entity)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -218,7 +218,8 @@ module Grape
         next unless @definitions[response_model]
         next if response_model.start_with?('Swagger_doc')
 
-        apply_model_documentation(response_model, value[:model])
+        model_for_documentation = value[:model].is_a?(String) ? value[:model].constantize : value[:model]
+        apply_model_documentation(response_model, model_for_documentation)
         build_memo_schema(memo, route, value, response_model, options)
         memo[value[:code]][:examples] = value[:examples] if value[:examples]
       end
@@ -457,19 +458,18 @@ module Grape
     end
 
     def apply_model_documentation(response_model, model)
-      @definitions[response_model][:description] ||= model_description(model) || "#{response_model} model"
-      example = model_example(model)
+      doc = model_documentation(model)
+      @definitions[response_model][:description] ||= model_description(doc) || "#{response_model} model"
+      example = model_example(doc)
       @definitions[response_model][:example] ||= example unless example.nil?
     end
 
-    def model_description(model)
-      doc = model_documentation(model)
+    def model_description(doc)
       desc = doc[:desc] if doc
       desc if desc.is_a?(String)
     end
 
-    def model_example(model)
-      doc = model_documentation(model)
+    def model_example(doc)
       doc[:example] if doc
     end
 
@@ -477,7 +477,11 @@ module Grape
       return unless model.respond_to?(:documentation)
       return if defined?(Grape::Entity) && model.method(:documentation).owner == Grape::Entity.singleton_class
 
-      doc = model.documentation
+      doc = begin
+        model.documentation
+      rescue StandardError
+        nil
+      end
       return unless doc.is_a?(Hash)
       return unless (doc.keys - %i[desc example]).empty?
       return if field_documentation?(doc[:example])

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -219,7 +219,8 @@ module Grape
         next if response_model.start_with?('Swagger_doc')
 
         @definitions[response_model][:description] ||= model_description(value[:model]) || "#{response_model} model"
-        @definitions[response_model][:example] ||= model_example(value[:model])
+        example = model_example(value[:model])
+        @definitions[response_model][:example] ||= example unless example.nil?
         build_memo_schema(memo, route, value, response_model, options)
         memo[value[:code]][:examples] = value[:examples] if value[:examples]
       end

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -494,7 +494,10 @@ module Grape
     end
 
     def documentation_keys
-      %i[default desc documentation hidden is_array param_type required type values]
+      %i[
+        collectionFormat default desc description documentation format hidden
+        in is_array param_type required type values
+      ]
     end
 
     def documentation_type?(value)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -462,7 +462,8 @@ module Grape
       return unless model.respond_to?(:documentation)
 
       doc = model.documentation
-      doc[:desc] if doc.is_a?(Hash)
+      desc = doc[:desc] if doc.is_a?(Hash)
+      desc if desc.is_a?(String)
     end
 
     def model_example(model)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -482,10 +482,15 @@ module Grape
     end
 
     def field_documentation?(value)
-      return false unless value.is_a?(Hash) && value[:type]
-      return false unless value.key?(:desc) || value.key?(:is_array) || value.key?(:required)
+      return false unless value.is_a?(Hash)
+      return false unless (value.keys - documentation_keys).empty?
+      return true unless value[:type]
 
       documentation_type?(value[:type])
+    end
+
+    def documentation_keys
+      %i[default desc documentation hidden is_array param_type required type values]
     end
 
     def documentation_type?(value)

--- a/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
@@ -2,38 +2,55 @@
 
 require 'spec_helper'
 
-describe 'custom model description' do
+describe 'custom model documentation' do
   include_context "#{MODEL_PARSER} swagger example"
 
   before :all do
     module Entities
-      class EntityWithCustomDescription < Grape::Entity
+      class EntityWithCustomDocumentation < Grape::Entity
         def self.documentation
-          { desc: 'A custom description for this entity' }
+          {
+            desc: 'A custom description for this entity',
+            example: { id: 123, name: 'Example Name' }
+          }
         end
 
         expose :id, documentation: { type: Integer, desc: 'ID' }
         expose :name, documentation: { type: String, desc: 'Name' }
       end
 
-      class EntityWithoutCustomDescription < Grape::Entity
+      class EntityWithDescriptionOnly < Grape::Entity
+        def self.documentation
+          { desc: 'Description without example' }
+        end
+
+        expose :id, documentation: { type: Integer, desc: 'ID' }
+      end
+
+      class EntityWithoutDocumentation < Grape::Entity
         expose :id, documentation: { type: Integer, desc: 'ID' }
       end
     end
 
     module TheApi
-      class CustomModelDescriptionApi < Grape::API
+      class CustomModelDocumentationApi < Grape::API
         format :json
 
-        desc 'Returns entity with custom description',
-             entity: Entities::EntityWithCustomDescription
-        get '/with-custom-description' do
+        desc 'Returns entity with custom documentation',
+             entity: Entities::EntityWithCustomDocumentation
+        get '/with-custom-documentation' do
           { id: 1, name: 'Test' }
         end
 
-        desc 'Returns entity without custom description',
-             entity: Entities::EntityWithoutCustomDescription
-        get '/without-custom-description' do
+        desc 'Returns entity with description only',
+             entity: Entities::EntityWithDescriptionOnly
+        get '/with-description-only' do
+          { id: 1 }
+        end
+
+        desc 'Returns entity without documentation method',
+             entity: Entities::EntityWithoutDocumentation
+        get '/without-documentation' do
           { id: 1 }
         end
 
@@ -43,7 +60,7 @@ describe 'custom model description' do
   end
 
   def app
-    TheApi::CustomModelDescriptionApi
+    TheApi::CustomModelDocumentationApi
   end
 
   describe 'model definitions' do
@@ -52,14 +69,31 @@ describe 'custom model description' do
       JSON.parse(last_response.body)
     end
 
-    it 'uses custom description from documentation method' do
-      expect(subject['definitions']['EntityWithCustomDescription']['description'])
-        .to eq('A custom description for this entity')
+    context 'with custom description' do
+      it 'uses custom description from documentation method' do
+        expect(subject['definitions']['EntityWithCustomDocumentation']['description'])
+          .to eq('A custom description for this entity')
+      end
+
+      it 'falls back to default description when no documentation method' do
+        expect(subject['definitions']['EntityWithoutDocumentation']['description'])
+          .to eq('EntityWithoutDocumentation model')
+      end
     end
 
-    it 'falls back to default description when no documentation method' do
-      expect(subject['definitions']['EntityWithoutCustomDescription']['description'])
-        .to eq('EntityWithoutCustomDescription model')
+    context 'with custom example' do
+      it 'uses custom example from documentation method' do
+        expect(subject['definitions']['EntityWithCustomDocumentation']['example'])
+          .to eq({ 'id' => 123, 'name' => 'Example Name' })
+      end
+
+      it 'does not include example when not provided' do
+        expect(subject['definitions']['EntityWithDescriptionOnly']['example']).to be_nil
+      end
+
+      it 'does not include example when no documentation method' do
+        expect(subject['definitions']['EntityWithoutDocumentation']['example']).to be_nil
+      end
     end
   end
 end

--- a/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'custom model description' do
+  include_context "#{MODEL_PARSER} swagger example"
+
+  before :all do
+    module Entities
+      class EntityWithCustomDescription < Grape::Entity
+        def self.documentation
+          { desc: 'A custom description for this entity' }
+        end
+
+        expose :id, documentation: { type: Integer, desc: 'ID' }
+        expose :name, documentation: { type: String, desc: 'Name' }
+      end
+
+      class EntityWithoutCustomDescription < Grape::Entity
+        expose :id, documentation: { type: Integer, desc: 'ID' }
+      end
+    end
+
+    module TheApi
+      class CustomModelDescriptionApi < Grape::API
+        format :json
+
+        desc 'Returns entity with custom description',
+             entity: Entities::EntityWithCustomDescription
+        get '/with-custom-description' do
+          { id: 1, name: 'Test' }
+        end
+
+        desc 'Returns entity without custom description',
+             entity: Entities::EntityWithoutCustomDescription
+        get '/without-custom-description' do
+          { id: 1 }
+        end
+
+        add_swagger_documentation
+      end
+    end
+  end
+
+  def app
+    TheApi::CustomModelDescriptionApi
+  end
+
+  describe 'model definitions' do
+    subject do
+      get '/swagger_doc'
+      JSON.parse(last_response.body)
+    end
+
+    it 'uses custom description from documentation method' do
+      expect(subject['definitions']['EntityWithCustomDescription']['description'])
+        .to eq('A custom description for this entity')
+    end
+
+    it 'falls back to default description when no documentation method' do
+      expect(subject['definitions']['EntityWithoutCustomDescription']['description'])
+        .to eq('EntityWithoutCustomDescription model')
+    end
+  end
+end

--- a/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
@@ -39,6 +39,16 @@ describe 'custom model documentation' do
         expose :name, documentation: { type: String, desc: 'Name' }
       end
 
+      class EntityWithExampleDescriptionField < Grape::Entity
+        def self.documentation
+          {
+            example: { type: 'string', description: 'Not real example data', format: 'email', in: 'body' }
+          }
+        end
+
+        expose :type, documentation: { type: String, desc: 'Type' }
+      end
+
       class EntityWithoutDocumentation < Grape::Entity
         expose :id, documentation: { type: Integer, desc: 'ID' }
       end
@@ -96,6 +106,12 @@ describe 'custom model documentation' do
              entity: Entities::EntityWithExampleTypeField
         get '/with-example-type-field' do
           { type: 'admin', desc: 'Administrator', name: 'Jane' }
+        end
+
+        desc 'Returns entity with example description field',
+             entity: Entities::EntityWithExampleDescriptionField
+        get '/with-example-description-field' do
+          { type: 'admin' }
         end
 
         desc 'Returns entity without documentation method',
@@ -183,6 +199,10 @@ describe 'custom model documentation' do
 
       it 'does not use non-entity property documentation as a custom example' do
         expect(subject['definitions']['ModelWithExamplePropertyDocumentation']).not_to have_key('example')
+      end
+
+      it 'does not use field documentation with description/format/in keys as a custom example' do
+        expect(subject['definitions']['EntityWithExampleDescriptionField']).not_to have_key('example')
       end
     end
 

--- a/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
@@ -30,6 +30,11 @@ describe 'custom model documentation' do
       class EntityWithoutDocumentation < Grape::Entity
         expose :id, documentation: { type: Integer, desc: 'ID' }
       end
+
+      class EntityWithFieldLevelDocumentation < Grape::Entity
+        expose :desc, documentation: { type: String, desc: 'Description field' }
+        expose :example, documentation: { type: String, desc: 'Example field' }
+      end
     end
 
     module TheApi
@@ -52,6 +57,12 @@ describe 'custom model documentation' do
              entity: Entities::EntityWithoutDocumentation
         get '/without-documentation' do
           { id: 1 }
+        end
+
+        desc 'Returns entity with field-level documentation',
+             entity: Entities::EntityWithFieldLevelDocumentation
+        get '/with-field-level-documentation' do
+          { desc: 'Description', example: 'Example' }
         end
 
         add_swagger_documentation
@@ -79,6 +90,11 @@ describe 'custom model documentation' do
         expect(subject['definitions']['EntityWithoutDocumentation']['description'])
           .to eq('EntityWithoutDocumentation model')
       end
+
+      it 'does not use field documentation as a custom description' do
+        expect(subject['definitions']['EntityWithFieldLevelDocumentation']['description'])
+          .to eq('EntityWithFieldLevelDocumentation model')
+      end
     end
 
     context 'with custom example' do
@@ -93,6 +109,10 @@ describe 'custom model documentation' do
 
       it 'does not include example when no documentation method' do
         expect(subject['definitions']['EntityWithoutDocumentation']).not_to have_key('example')
+      end
+
+      it 'does not use field documentation as a custom example' do
+        expect(subject['definitions']['EntityWithFieldLevelDocumentation']).not_to have_key('example')
       end
     end
   end

--- a/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
@@ -49,6 +49,16 @@ describe 'custom model documentation' do
         expose :type, documentation: { type: String, desc: 'Type' }
       end
 
+      class EntityWithCapitalizedTypeExampleField < Grape::Entity
+        def self.documentation
+          {
+            example: { type: 'String', desc: 'Not real example data' }
+          }
+        end
+
+        expose :value, documentation: { type: String, desc: 'Value' }
+      end
+
       class EntityWithoutDocumentation < Grape::Entity
         expose :id, documentation: { type: Integer, desc: 'ID' }
       end
@@ -141,6 +151,12 @@ describe 'custom model documentation' do
              entity: Entities::EntityWithExampleDescriptionField
         get '/with-example-description-field' do
           { type: 'admin' }
+        end
+
+        desc 'Returns entity with capitalized string type in example field',
+             entity: Entities::EntityWithCapitalizedTypeExampleField
+        get '/with-capitalized-type-example-field' do
+          { value: 'ok' }
         end
 
         desc 'Returns entity without documentation method',
@@ -250,6 +266,10 @@ describe 'custom model documentation' do
 
       it 'does not use field documentation with description/format/in keys as a custom example' do
         expect(subject['definitions']['EntityWithExampleDescriptionField']).not_to have_key('example')
+      end
+
+      it 'does not use field documentation with a capitalized string type as a custom example' do
+        expect(subject['definitions']['EntityWithCapitalizedTypeExampleField']).not_to have_key('example')
       end
     end
 

--- a/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
@@ -47,7 +47,30 @@ describe 'custom model documentation' do
         expose :desc, documentation: { type: String, desc: 'Description field' }
         expose :example, documentation: { type: String, desc: 'Example field' }
       end
+
+      class ModelWithExamplePropertyDocumentation
+        def self.documentation
+          {
+            example: { type: String, desc: 'Example field' },
+            name: { type: String, desc: 'Name' }
+          }
+        end
+
+        def self.parse(value)
+          value
+        end
+      end
     end
+
+    class ExamplePropertyDocumentationParser
+      def initialize(model, endpoint); end
+
+      def call
+        Entities::ModelWithExamplePropertyDocumentation.documentation
+      end
+    end
+
+    GrapeSwagger.model_parsers.register(ExamplePropertyDocumentationParser, Entities::ModelWithExamplePropertyDocumentation)
 
     module TheApi
       class CustomModelDocumentationApi < Grape::API
@@ -81,6 +104,12 @@ describe 'custom model documentation' do
              entity: Entities::EntityWithFieldLevelDocumentation
         get '/with-field-level-documentation' do
           { desc: 'Description', example: 'Example' }
+        end
+
+        desc 'Returns model with an example property',
+             entity: Entities::ModelWithExamplePropertyDocumentation
+        get '/with-example-property-documentation' do
+          { example: 'Example', name: 'Jane' }
         end
 
         add_swagger_documentation
@@ -136,6 +165,10 @@ describe 'custom model documentation' do
 
       it 'does not use field documentation as a custom example' do
         expect(subject['definitions']['EntityWithFieldLevelDocumentation']).not_to have_key('example')
+      end
+
+      it 'does not use non-entity property documentation as a custom example' do
+        expect(subject['definitions']['ModelWithExamplePropertyDocumentation']).not_to have_key('example')
       end
     end
 

--- a/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
@@ -88,11 +88,11 @@ describe 'custom model documentation' do
       end
 
       it 'does not include example when not provided' do
-        expect(subject['definitions']['EntityWithDescriptionOnly']['example']).to be_nil
+        expect(subject['definitions']['EntityWithDescriptionOnly']).not_to have_key('example')
       end
 
       it 'does not include example when no documentation method' do
-        expect(subject['definitions']['EntityWithoutDocumentation']['example']).to be_nil
+        expect(subject['definitions']['EntityWithoutDocumentation']).not_to have_key('example')
       end
     end
   end

--- a/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
@@ -48,10 +48,14 @@ describe 'custom model documentation' do
         expose :example, documentation: { type: String, desc: 'Example field' }
       end
 
+      class EntityWithUntypedExampleDocumentation < Grape::Entity
+        expose :example, documentation: { desc: 'Example field' }
+      end
+
       class ModelWithExamplePropertyDocumentation
         def self.documentation
           {
-            example: { type: String, desc: 'Example field' },
+            example: { desc: 'Example field' },
             name: { type: String, desc: 'Name' }
           }
         end
@@ -104,6 +108,12 @@ describe 'custom model documentation' do
              entity: Entities::EntityWithFieldLevelDocumentation
         get '/with-field-level-documentation' do
           { desc: 'Description', example: 'Example' }
+        end
+
+        desc 'Returns entity with untyped example documentation',
+             entity: Entities::EntityWithUntypedExampleDocumentation
+        get '/with-untyped-example-documentation' do
+          { example: 'Example' }
         end
 
         desc 'Returns model with an example property',
@@ -165,6 +175,10 @@ describe 'custom model documentation' do
 
       it 'does not use field documentation as a custom example' do
         expect(subject['definitions']['EntityWithFieldLevelDocumentation']).not_to have_key('example')
+      end
+
+      it 'does not use untyped field documentation as a custom example' do
+        expect(subject['definitions']['EntityWithUntypedExampleDocumentation']).not_to have_key('example')
       end
 
       it 'does not use non-entity property documentation as a custom example' do

--- a/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
@@ -115,5 +115,15 @@ describe 'custom model documentation' do
         expect(subject['definitions']['EntityWithFieldLevelDocumentation']).not_to have_key('example')
       end
     end
+
+    context 'with schema properties' do
+      it 'includes documented fields when custom model documentation is defined' do
+        expect(subject['definitions']['EntityWithCustomDocumentation']['properties'])
+          .to eq(
+            'id' => { 'type' => 'integer', 'format' => 'int32', 'description' => 'ID' },
+            'name' => { 'type' => 'string', 'description' => 'Name' }
+          )
+      end
+    end
   end
 end

--- a/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
@@ -27,6 +27,18 @@ describe 'custom model documentation' do
         expose :id, documentation: { type: Integer, desc: 'ID' }
       end
 
+      class EntityWithExampleTypeField < Grape::Entity
+        def self.documentation
+          {
+            example: { type: 'admin', desc: 'Administrator', name: 'Jane' }
+          }
+        end
+
+        expose :type, documentation: { type: String, desc: 'Type' }
+        expose :desc, documentation: { type: String, desc: 'Description' }
+        expose :name, documentation: { type: String, desc: 'Name' }
+      end
+
       class EntityWithoutDocumentation < Grape::Entity
         expose :id, documentation: { type: Integer, desc: 'ID' }
       end
@@ -51,6 +63,12 @@ describe 'custom model documentation' do
              entity: Entities::EntityWithDescriptionOnly
         get '/with-description-only' do
           { id: 1 }
+        end
+
+        desc 'Returns entity with example type field',
+             entity: Entities::EntityWithExampleTypeField
+        get '/with-example-type-field' do
+          { type: 'admin', desc: 'Administrator', name: 'Jane' }
         end
 
         desc 'Returns entity without documentation method',
@@ -101,6 +119,11 @@ describe 'custom model documentation' do
       it 'uses custom example from documentation method' do
         expect(subject['definitions']['EntityWithCustomDocumentation']['example'])
           .to eq({ 'id' => 123, 'name' => 'Example Name' })
+      end
+
+      it 'uses custom example with type and desc fields' do
+        expect(subject['definitions']['EntityWithExampleTypeField']['example'])
+          .to eq({ 'type' => 'admin', 'desc' => 'Administrator', 'name' => 'Jane' })
       end
 
       it 'does not include example when not provided' do

--- a/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_custom_model_description_spec.rb
@@ -53,6 +53,35 @@ describe 'custom model documentation' do
         expose :id, documentation: { type: Integer, desc: 'ID' }
       end
 
+      class EntityOnlyReferencedByString < Grape::Entity
+        def self.documentation
+          { desc: 'Referenced only via a string model name', example: { value: 'ok' } }
+        end
+
+        expose :value, documentation: { type: String, desc: 'Value' }
+      end
+
+      class EntityWithCallCountingDocumentation < Grape::Entity
+        def self.documentation_call_count
+          @documentation_call_count ||= 0
+        end
+
+        def self.documentation
+          @documentation_call_count = documentation_call_count + 1
+          { desc: "Description from call #{documentation_call_count}", example: { call: documentation_call_count } }
+        end
+
+        expose :call, documentation: { type: Integer, desc: 'Call' }
+      end
+
+      class EntityWithRaisingDocumentation < Grape::Entity
+        def self.documentation
+          raise 'boom'
+        end
+
+        expose :id, documentation: { type: Integer, desc: 'ID' }
+      end
+
       class EntityWithFieldLevelDocumentation < Grape::Entity
         expose :desc, documentation: { type: String, desc: 'Description field' }
         expose :example, documentation: { type: String, desc: 'Example field' }
@@ -117,6 +146,24 @@ describe 'custom model documentation' do
         desc 'Returns entity without documentation method',
              entity: Entities::EntityWithoutDocumentation
         get '/without-documentation' do
+          { id: 1 }
+        end
+
+        desc 'Returns entity referenced by a string model name',
+             failure: [{ code: 400, message: 'Error', model: 'Entities::EntityOnlyReferencedByString' }]
+        get '/with-string-model-reference' do
+          { value: 'ok' }
+        end
+
+        desc 'Returns entity with call-counting documentation',
+             entity: Entities::EntityWithCallCountingDocumentation
+        get '/with-call-counting-documentation' do
+          { call: 1 }
+        end
+
+        desc 'Returns entity whose documentation method raises',
+             entity: Entities::EntityWithRaisingDocumentation
+        get '/with-raising-documentation' do
           { id: 1 }
         end
 
@@ -203,6 +250,34 @@ describe 'custom model documentation' do
 
       it 'does not use field documentation with description/format/in keys as a custom example' do
         expect(subject['definitions']['EntityWithExampleDescriptionField']).not_to have_key('example')
+      end
+    end
+
+    context 'with a model referenced by string' do
+      it 'applies custom documentation when the model is referenced by a string class name' do
+        expect(subject['definitions']['EntityOnlyReferencedByString']['description'])
+          .to eq('Referenced only via a string model name')
+        expect(subject['definitions']['EntityOnlyReferencedByString']['example'])
+          .to eq({ 'value' => 'ok' })
+      end
+    end
+
+    context 'with a non-idempotent documentation method' do
+      it 'derives description and example from a single documentation invocation' do
+        description = subject['definitions']['EntityWithCallCountingDocumentation']['description']
+        example = subject['definitions']['EntityWithCallCountingDocumentation']['example']
+
+        expect(description).to eq("Description from call #{example['call']}")
+      end
+    end
+
+    context 'when the documentation method raises' do
+      it 'does not crash swagger doc generation and falls back to the default description' do
+        documentation = subject
+
+        expect(last_response.status).to eq(200)
+        expect(documentation['definitions']['EntityWithRaisingDocumentation']['description'])
+          .to eq('EntityWithRaisingDocumentation model')
       end
     end
 


### PR DESCRIPTION
## Summary

Allow entities to define a `self.documentation` class method to provide custom model descriptions and schema-level examples in the OpenAPI definitions.

## Usage

```ruby
class UserEntity < Grape::Entity
  def self.documentation
    {
      desc: 'Represents a user account',
      example: { id: 1, name: 'John Doe', email: 'john@example.com' }
    }
  end

  expose :id, documentation: { type: Integer }
  expose :name, documentation: { type: String }
  expose :email, documentation: { type: String }
end
```

## Generated Output

```json
{
  "definitions": {
    "User": {
      "type": "object",
      "description": "Represents a user account",
      "example": { "id": 1, "name": "John Doe", "email": "john@example.com" },
      "properties": { ... }
    }
  }
}
```

## Changes

- Add `model_description` method to extract `:desc` from entity's `self.documentation`
- Add `model_example` method to extract `:example` from entity's `self.documentation`
- Apply description and example to model definitions in `response_object`

Fixes ruby-grape/grape-swagger-entity#57
Fixes ruby-grape/grape-swagger-entity#59