### PR TITLE
Use endpoint.endpoints instead of endpoint.options[:app]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 * [#978](https://github.com/ruby-grape/grape-swagger/pull/978): Fix Grape 3.2+ compatibility: desc kwargs, custom types, multi-type param recovery; bump Grape to `>= 2.1, < 5.0`. See [UPGRADING](UPGRADING.md) - [@numbata](https://github.com/numbata).
 * [#982](https://github.com/ruby-grape/grape-swagger/pull/982): Fix test suite compatibility with Grape 4.0 (grape=HEAD CI) - [@numbata](https://github.com/numbata).
+* [#981](https://github.com/ruby-grape/grape-swagger/pull/981): Use `endpoint.endpoints` instead of `endpoint.options[:app]` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.1.4 (2026-02-02)

--- a/lib/grape-swagger/swagger_documentation_adder.rb
+++ b/lib/grape-swagger/swagger_documentation_adder.rb
@@ -47,7 +47,8 @@ module GrapeSwagger
       while endpoints.any?
         endpoint = endpoints.shift
 
-        endpoints.push(*endpoint.endpoints) if endpoint.endpoints
+        nested_endpoints = endpoint.endpoints
+        endpoints.push(*nested_endpoints) if nested_endpoints
         namespace_stackable = endpoint.inheritable_setting.namespace_stackable
         ns = (namespace_stackable[:namespace] || []).last
         next unless ns

--- a/lib/grape-swagger/swagger_documentation_adder.rb
+++ b/lib/grape-swagger/swagger_documentation_adder.rb
@@ -47,7 +47,7 @@ module GrapeSwagger
       while endpoints.any?
         endpoint = endpoints.shift
 
-        endpoints.push(*endpoint.options[:app].endpoints) if endpoint.options[:app]
+        endpoints.push(*endpoint.endpoints) if endpoint.endpoints
         namespace_stackable = endpoint.inheritable_setting.namespace_stackable
         ns = (namespace_stackable[:namespace] || []).last
         next unless ns

--- a/spec/lib/swagger_routing_spec.rb
+++ b/spec/lib/swagger_routing_spec.rb
@@ -48,7 +48,7 @@ describe GrapeSwagger::SwaggerRouting do
         namespace_stackable[:mount_path] = ['//foo/', '/bar']
         endpoint = instance_double(
           'endpoint',
-          options: {},
+          endpoints: nil,
           namespace: '/bar/widgets',
           inheritable_setting: instance_double('inheritable_setting', namespace_stackable: namespace_stackable)
         )

--- a/spec/lib/swagger_routing_spec.rb
+++ b/spec/lib/swagger_routing_spec.rb
@@ -60,6 +60,43 @@ describe GrapeSwagger::SwaggerRouting do
         expect(app.send(:combine_namespaces, app)).to eq('foo/bar/bar/widgets' => namespace)
       end
     end
+
+    context 'when an endpoint exposes nested endpoints' do
+      it 'processes sub-endpoints returned by the endpoint accessor' do
+        parent_namespace_stackable = Grape::Util::StackableValues.new
+        parent_namespace_stackable[:namespace] = namespace
+        parent_namespace_stackable[:mount_path] = ['/api']
+
+        child_namespace = instance_double('child_namespace', options: {})
+        child_namespace_stackable = Grape::Util::StackableValues.new
+        child_namespace_stackable[:namespace] = child_namespace
+        child_namespace_stackable[:mount_path] = ['/api', '/v1']
+
+        child_endpoint = instance_double(
+          'child_endpoint',
+          endpoints: nil,
+          namespace: '/widgets',
+          inheritable_setting: instance_double('child_inheritable_setting', namespace_stackable: child_namespace_stackable)
+        )
+
+        parent_endpoint = instance_double(
+          'parent_endpoint',
+          endpoints: [child_endpoint],
+          namespace: '/parent',
+          inheritable_setting: instance_double('parent_inheritable_setting', namespace_stackable: parent_namespace_stackable)
+        )
+
+        app = Class.new
+        app.extend(GrapeSwagger::SwaggerDocumentationAdder)
+
+        allow(app).to receive(:endpoints).and_return([parent_endpoint])
+
+        expect(app.send(:combine_namespaces, app)).to eq(
+          'api/parent' => namespace,
+          'api/v1/widgets' => child_namespace
+        )
+      end
+    end
   end
 
   describe '#route_path_start_with?' do


### PR DESCRIPTION
### Summary

`combine_namespaces` collected a mounted API's endpoints by reaching into the endpoint's options bag with `endpoint.options[:app].endpoints`. This switches to the first-class `endpoint.endpoints` reader.

```diff
- endpoints.push(*endpoint.options[:app].endpoints) if endpoint.options[:app]
+ endpoints.push(*endpoint.endpoints) if endpoint.endpoints
```

### Why

- **Equivalent** for mounted Grape APIs — `endpoint.endpoints` returns `config.app.endpoints`, exactly what `options[:app].endpoints` computed.
- **Safer** for bare Rack (`Proc`) mounts: `options[:app]` is truthy for a `Proc` but has no `#endpoints` (would raise), whereas `endpoint.endpoints` is `nil`.
- **Works across all supported Grape versions** — `endpoint.endpoints` has existed for a long time (verified on the 1.8 → 2.4 range and HEAD).
- **Drops the `options[:app]` dependency.** Grape is moving endpoint attributes out of the catch-all options Hash toward named accessors (`http_methods`, `path`, `mounted_app`, …) and plans to remove `:app` from it; this keeps grape-swagger forward-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)