### PR TITLE
Fix test suite compatibility with Grape 4.0 (grape=HEAD CI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 #### Fixes
 
 * [#978](https://github.com/ruby-grape/grape-swagger/pull/978): Fix Grape 3.2+ compatibility: desc kwargs, custom types, multi-type param recovery; bump Grape to `>= 2.1, < 5.0`. See [UPGRADING](UPGRADING.md) - [@numbata](https://github.com/numbata).
+* [#982](https://github.com/ruby-grape/grape-swagger/pull/982): Fix test suite compatibility with Grape 4.0 (grape=HEAD CI) - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 ### 2.1.4 (2026-02-02)

--- a/spec/lib/endpoint_spec.rb
+++ b/spec/lib/endpoint_spec.rb
@@ -4,8 +4,12 @@ require 'spec_helper'
 
 describe Grape::Endpoint do
   subject do
-    # Grape >= HEAD requires :for (the owner API class) when constructing an Endpoint.
-    described_class.new(Grape::Util::InheritableSetting.new, path: '/', method: :get, for: Class.new(Grape::API))
+    if GrapeVersion.satisfy?('>= 4.0.0')
+      # Grape >= 4.0 requires :http_methods and :api (the owner API class) when constructing an Endpoint.
+      described_class.new(Grape::Util::InheritableSetting.new, path: '/', http_methods: :get, api: Class.new(Grape::API))
+    else
+      described_class.new(Grape::Util::InheritableSetting.new, path: '/', method: :get, for: Class.new(Grape::API))
+    end
   end
 
   describe '.content_types_for' do

--- a/spec/support/route_helper.rb
+++ b/spec/support/route_helper.rb
@@ -2,7 +2,17 @@
 
 module RouteHelper
   def self.build(method:, pattern:, options:, origin: nil)
-    if GrapeVersion.satisfy?('>= 3.1.0')
+    if GrapeVersion.satisfy?('>= 4.0.0')
+      pattern_obj = Grape::Router::Pattern.new(
+        origin: origin || pattern,
+        suffix: nil,
+        anchor: options.fetch(:anchor, true),
+        params: options.fetch(:params, {}),
+        version: nil,
+        requirements: options.fetch(:requirements, {})
+      )
+      Grape::Router::Route.new(nil, method, pattern_obj, options, forward_match: options.fetch(:forward_match, false))
+    elsif GrapeVersion.satisfy?('>= 3.1.0')
       pattern_obj = Grape::Router::Pattern.new(
         origin: origin || pattern,
         suffix: nil,


### PR DESCRIPTION
## Summary

Our `grape=HEAD` CI canary job tracks Grape's development branch to catch upcoming breaking changes before they land in a release, and it started failing because Grape's unreleased branch (now versioned 4.0.0) changed the internal APIs our test helpers rely on. This PR updates those helpers so the suite keeps passing against both the pinned Grape versions we support today and Grape's in-development HEAD, restoring the early-warning signal this job is meant to provide.

## What changed

Grape's master branch (versioned `4.0.0`) made three breaking changes:

1. `Grape::Router::Pattern.new` dropped the dead `format:` keyword.
2. `Grape::Router::Route.new` moved `forward_match` from an optional options-hash entry to a required keyword.
3. `Grape::Endpoint.new` now requires `http_methods:`/`api:` keywords instead of accepting arbitrary options.

`spec/support/route_helper.rb` and `spec/lib/endpoint_spec.rb` now branch on `GrapeVersion.satisfy?('>= 4.0.0')` to use the new call shapes only against Grape HEAD, leaving the existing behavior for pinned versions (2.1.3-3.2.1) untouched.

## Test plan

- [x] Full spec suite + rubocop pass against the locally pinned Grape version (3.3.2)
- [x] Full spec suite + rubocop pass against real Grape HEAD (installed via `GRAPE_VERSION=HEAD bundle update grape`), which reproduced the original CI failures and confirmed this fix resolves them
- [x] CI `grape=HEAD` job goes green