### PR TITLE
Drop the undocumented formats/content_types produces aliases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#978](https://github.com/ruby-grape/grape-swagger/pull/978): Fix Grape 3.2+ compatibility: desc kwargs, custom types, multi-type param recovery; bump Grape to `>= 2.1, < 5.0`. See [UPGRADING](UPGRADING.md) - [@numbata](https://github.com/numbata).
 * [#982](https://github.com/ruby-grape/grape-swagger/pull/982): Fix test suite compatibility with Grape 4.0 (grape=HEAD CI) - [@numbata](https://github.com/numbata).
 * [#981](https://github.com/ruby-grape/grape-swagger/pull/981): Use `endpoint.endpoints` instead of `endpoint.options[:app]` - [@ericproulx](https://github.com/ericproulx).
+* [#983](https://github.com/ruby-grape/grape-swagger/pull/983): Read route metadata via reader methods instead of `route.options[...]` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.1.4 (2026-02-02)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * [#982](https://github.com/ruby-grape/grape-swagger/pull/982): Fix test suite compatibility with Grape 4.0 (grape=HEAD CI) - [@numbata](https://github.com/numbata).
 * [#981](https://github.com/ruby-grape/grape-swagger/pull/981): Use `endpoint.endpoints` instead of `endpoint.options[:app]` - [@ericproulx](https://github.com/ericproulx).
 * [#983](https://github.com/ruby-grape/grape-swagger/pull/983): Read route metadata via reader methods instead of `route.options[...]` - [@ericproulx](https://github.com/ericproulx).
+* [#984](https://github.com/ruby-grape/grape-swagger/pull/984): Drop the undocumented `formats:` / `content_types:` aliases for `produces:` - [@ericproulx](https://github.com/ericproulx).
 * Your contribution here.
 
 ### 2.1.4 (2026-02-02)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,6 +21,7 @@
   ```
 
 - **Multi-type params (`type: [A, B]`) on Grape 3.2+**: swagger output now reflects the first declared type (e.g. `type: [Integer, Float]` produces `"integer"`). Previously, Grape 3.2+ serialized the `VariantCollectionCoercer` wrapper via `#to_s`, leaking `"#<Grape::Validations::Types::VariantCollectionCoercer:0x...>"` into the documentation. No action required, but if you were programmatically post-processing that string, the fix will change the output.
+- **`desc(..., formats:)` and `desc(..., content_types:)` no longer set the swagger `produces` field.** These were undocumented aliases for `produces:`. Use `produces:` instead (e.g. `desc 'x', produces: ['application/xml']`), which is unchanged.
 
 ### Upgrading to >= x.y.z
 

--- a/lib/grape-swagger/doc_methods/move_params.rb
+++ b/lib/grape-swagger/doc_methods/move_params.rb
@@ -34,7 +34,7 @@ module GrapeSwagger
 
           definition[:description] = route.description if route.try(:description)
 
-          build_body_parameter(definition_name, route.options)
+          build_body_parameter(definition_name, route.body_name)
         end
 
         def move_params_to_new(definition, params)
@@ -139,9 +139,9 @@ module GrapeSwagger
           definition[:required].push(*value)
         end
 
-        def build_body_parameter(name, options)
+        def build_body_parameter(name, body_name)
           {}.tap do |x|
-            x[:name] = options[:body_name] || name
+            x[:name] = body_name || name
             x[:in] = 'body'
             x[:required] = true
             x[:schema] = { '$ref' => "#/definitions/#{name}" }

--- a/lib/grape-swagger/doc_methods/operation_id.rb
+++ b/lib/grape-swagger/doc_methods/operation_id.rb
@@ -5,13 +5,12 @@ module GrapeSwagger
     class OperationId
       class << self
         def build(route, path = nil)
-          if route.options[:nickname]
-            route.options[:nickname]
-          else
-            verb = route.request_method.to_s.downcase
-            operation = manipulate(path) unless path.nil?
-            "#{verb}#{operation}"
-          end
+          nickname = route.nickname
+          return nickname if nickname
+
+          verb = route.request_method.to_s.downcase
+          operation = manipulate(path) unless path.nil?
+          "#{verb}#{operation}"
         end
 
         def manipulate(path)

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -100,7 +100,7 @@ module Grape
         next if hidden?(route, options)
 
         @item, path = GrapeSwagger::DocMethods::PathString.build(route, options)
-        @entity = route.entity || route.options[:success]
+        @entity = route.entity || route.success
 
         verb, method_object = method_object(route, options, path)
 
@@ -123,7 +123,7 @@ module Grape
       method[:parameters]  = params_object(route, options, path, method[:consumes])
       method[:security]    = security_object(route)
       method[:responses]   = response_object(route, options)
-      method[:tags]        = route.options.fetch(:tags, tag_object(route, path))
+      method[:tags]        = route.tags || tag_object(route, path)
       method[:operationId] = GrapeSwagger::DocMethods::OperationId.build(route, path)
       method[:deprecated] = deprecated_object(route)
       method.delete_if { |_, value| value.nil? }
@@ -132,36 +132,36 @@ module Grape
     end
 
     def deprecated_object(route)
-      route.options[:deprecated] if route.options.key?(:deprecated)
+      route.deprecated
     end
 
     def security_object(route)
-      route.options[:security] if route.options.key?(:security)
+      route.security
     end
 
     def summary_object(route)
-      summary = route.options[:desc] if route.options.key?(:desc)
-      summary = route.description if route.description.present? && route.options.key?(:detail)
-      summary = route.options[:summary] if route.options.key?(:summary)
+      summary = route.desc if route.desc
+      summary = route.description if route.description.present? && route.detail
+      summary = route.summary if route.summary
 
       summary
     end
 
     def description_object(route)
       description = route.description if route.description.present?
-      description = route.options[:detail] if route.options.key?(:detail)
+      description = route.detail if route.detail
 
       description
     end
 
     def produces_object(route, format)
-      return ['application/octet-stream'] if file_response?(route.options[:success]) &&
-                                             !route.options[:produces].present?
+      return ['application/octet-stream'] if file_response?(route.success) &&
+                                             !route.produces.present?
 
       mime_types = GrapeSwagger::DocMethods::ProducesConsumes.call(format)
 
       route_mime_types = %i[formats content_types produces].map do |producer|
-        possible = route.options[producer]
+        possible = route.public_send(producer)
         GrapeSwagger::DocMethods::ProducesConsumes.call(possible) if possible.present?
       end.flatten.compact.uniq
 
@@ -240,7 +240,7 @@ module Grape
         route.http_codes.clone
       else
         success_codes_from_route(route) + default_code_from_route(route) +
-          (route.http_codes || route.options[:failure] || [])
+          (route.http_codes || route.failure || [])
       end
     end
 
@@ -268,7 +268,7 @@ module Grape
     private
 
     def default_code_from_route(route)
-      entity = route.options[:default_response]
+      entity = route.default_response
       return [] if entity.nil?
 
       default_code = { code: 'default', message: 'Default Response' }
@@ -345,7 +345,7 @@ module Grape
 
       if value.key?(:as) && value.key?(:is_array)
         reference[value[:as]] = build_reference_array(reference[value[:as]])
-      elsif route.options[:is_array]
+      elsif route.is_array
         reference = build_reference_array(reference)
       end
 
@@ -362,7 +362,7 @@ module Grape
 
     def build_root(route, reference, response_model, settings)
       default_root = response_model.underscore
-      default_root = default_root.pluralize if route.options[:is_array]
+      default_root = default_root.pluralize if route.is_array
       case route.settings.dig(:swagger, :root)
       when true
         { type: 'object', properties: { default_root => reference } }
@@ -437,7 +437,8 @@ module Grape
 
     def hidden?(route, options)
       route_hidden = route.settings.try(:[], :swagger).try(:[], :hidden)
-      route_hidden = route.options[:hidden] if route.options.key?(:hidden)
+      hidden_val = route.hidden
+      route_hidden = hidden_val unless hidden_val.nil?
       return route_hidden unless route_hidden.is_a?(Proc)
 
       return route_hidden.call unless options[:token_owner]

--- a/lib/grape-swagger/endpoint.rb
+++ b/lib/grape-swagger/endpoint.rb
@@ -155,17 +155,11 @@ module Grape
     end
 
     def produces_object(route, format)
-      return ['application/octet-stream'] if file_response?(route.success) &&
-                                             !route.produces.present?
+      produces = route.produces
+      return ['application/octet-stream'] if file_response?(route.success) && !produces.present?
 
-      mime_types = GrapeSwagger::DocMethods::ProducesConsumes.call(format)
-
-      route_mime_types = %i[formats content_types produces].map do |producer|
-        possible = route.public_send(producer)
-        GrapeSwagger::DocMethods::ProducesConsumes.call(possible) if possible.present?
-      end.flatten.compact.uniq
-
-      route_mime_types.present? ? route_mime_types : mime_types
+      route_mime_types = GrapeSwagger::DocMethods::ProducesConsumes.call(produces) if produces.present?
+      route_mime_types.presence || GrapeSwagger::DocMethods::ProducesConsumes.call(format)
     end
 
     SUPPORTS_CONSUMES = %i[post put patch].freeze

--- a/spec/lib/move_params_spec.rb
+++ b/spec/lib/move_params_spec.rb
@@ -218,17 +218,17 @@ describe GrapeSwagger::DocMethods::MoveParams do
         { name: name, in: 'body', required: true, schema: { '$ref' => "#/definitions/#{name}" } }
       end
       specify do
-        parameter = subject.send(:build_body_parameter, name, {})
+        parameter = subject.send(:build_body_parameter, name, nil)
         expect(parameter).to eql expected_param
       end
 
       describe 'body_name option specified' do
-        let(:route_options) { { body_name: 'body' } }
+        let(:body_name) { 'body' }
         let(:expected_param) do
-          { name: route_options[:body_name], in: 'body', required: true, schema: { '$ref' => "#/definitions/#{name}" } }
+          { name: body_name, in: 'body', required: true, schema: { '$ref' => "#/definitions/#{name}" } }
         end
         specify do
-          parameter = subject.send(:build_body_parameter, name, route_options)
+          parameter = subject.send(:build_body_parameter, name, body_name)
           expect(parameter).to eql expected_param
         end
       end

--- a/spec/swagger_v2/api_swagger_v2_detail_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_detail_spec.rb
@@ -48,6 +48,12 @@ describe 'details' do
             { 'declared_params' => declared(params) }
           end
 
+          desc 'This returns something', detail: nil, entity: Entities::UseResponse,
+                                         failure: [{ code: 400, model: Entities::ApiError }]
+          get '/use_detail_nil' do
+            { 'declared_params' => declared(params) }
+          end
+
           add_swagger_documentation
         end
       end
@@ -74,6 +80,15 @@ describe 'details' do
       expect(subject['paths']['/use_detail_block']['get']['summary']).to eql 'This returns something'
       expect(subject['paths']['/use_detail_block']['get']).to include('description')
       expect(subject['paths']['/use_detail_block']['get']['description']).to eql 'detailed description of the route inside the `desc` block'
+    end
+
+    # Reading metadata through route readers (instead of route.options.key?(:detail))
+    # means an explicit `detail: nil` is treated the same as an absent detail:
+    # the description holds the text and there is no separate summary.
+    specify do
+      expect(subject['paths']['/use_detail_nil']['get']).not_to include('summary')
+      expect(subject['paths']['/use_detail_nil']['get']).to include('description')
+      expect(subject['paths']['/use_detail_nil']['get']['description']).to eql 'This returns something'
     end
   end
 end

--- a/spec/swagger_v2/api_swagger_v2_format-content_type_spec.rb
+++ b/spec/swagger_v2/api_swagger_v2_format-content_type_spec.rb
@@ -17,22 +17,6 @@ describe 'format, content_type' do
           { 'declared_params' => declared(params) }
         end
 
-        desc 'This uses formats for produces',
-             failure: [{ code: 400, model: Entities::ApiError }],
-             formats: [:xml, :binary, 'application/vdns'],
-             entity: Entities::UseResponse
-        get '/use_formats' do
-          { 'declared_params' => declared(params) }
-        end
-
-        desc 'This uses content_types for produces',
-             failure: [{ code: 400, model: Entities::ApiError }],
-             content_types: [:xml, :binary, 'application/vdns'],
-             entity: Entities::UseResponse
-        get '/use_content_types' do
-          { 'declared_params' => declared(params) }
-        end
-
         desc 'This uses produces for produces',
              failure: [{ code: 400, model: Entities::ApiError }],
              produces: [:xml, :binary, 'application/vdns'],
@@ -83,30 +67,6 @@ describe 'format, content_type' do
     specify do
       expect(subject['paths']['/use_default']['get']).to include('produces')
       expect(subject['paths']['/use_default']['get']['produces']).to eql(['application/json'])
-    end
-  end
-
-  describe 'formats' do
-    subject do
-      get '/swagger_doc/use_formats'
-      JSON.parse(last_response.body)
-    end
-
-    specify do
-      expect(subject['paths']['/use_formats']['get']).to include('produces')
-      expect(subject['paths']['/use_formats']['get']['produces']).to eql(produced)
-    end
-  end
-
-  describe 'content types' do
-    subject do
-      get '/swagger_doc/use_content_types'
-      JSON.parse(last_response.body)
-    end
-
-    specify do
-      expect(subject['paths']['/use_content_types']['get']).to include('produces')
-      expect(subject['paths']['/use_content_types']['get']['produces']).to eql(produced)
     end
   end
 


### PR DESCRIPTION
Follow-up to #983 (stacked on it — until #983 merges, the diff here also shows #983's reader migration; it narrows to just this change once #983 is in).

grape-swagger let you set the swagger `produces` field three ways via `desc`: `produces:`, `formats:`, or `content_types:`. Only `produces` is documented (README `#### produces`); `formats` / `content_types` were undocumented aliases that resolved solely through `Grape::Router::BaseRoute#method_missing` delegating `route.formats` / `route.content_types` to `route.options[...]` — i.e. not real Grape route options.

This consolidates on the documented `produces`:

- `produces_object` reads only `route.produces` (a real Grape `DSL_METHODS` reader), dropping the `%i[formats content_types produces]` `public_send` loop.
- `api_swagger_v2_format-content_type_spec.rb` keeps the `produces` case (plus `use_default` and `consumes`); the `use_formats` / `use_content_types` cases are removed.
- UPGRADING note added.

This is the removal I proposed in the [#983 discussion](https://github.com/ruby-grape/grape-swagger/pull/983#discussion_r3538333406): with it, grape-swagger no longer relies on `method_missing` for route metadata.

### Tests

Full suite: 513 examples, 2 failures (both pre-existing on `master`, unrelated), 2 pending — no new failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)