### PR TITLE
Fix rubocop CI failure: use disable-next for single-statement directives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 #### Fixes
 
 * [#986](https://github.com/ruby-grape/grape-swagger/pull/986): Read a route's tags through `route.tags` instead of `route.options`; a blank `tags:` (`nil` or `[]`) now means "not specified" and derives the tag from the path. See [UPGRADING](UPGRADING.md) - [@ericproulx](https://github.com/ericproulx).
+* [#988](https://github.com/ruby-grape/grape-swagger/pull/988): Fix CI by replacing single-statement `rubocop:disable`/`enable` pairs with `rubocop:disable-next`, per rubocop 1.90's new `Style/DirectiveScope` cop - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 ### 2.2.0 (2026-08-06)

--- a/lib/grape-swagger/rake/oapi_tasks.rb
+++ b/lib/grape-swagger/rake/oapi_tasks.rb
@@ -82,7 +82,7 @@ module GrapeSwagger
 
       # helper methods
       #
-      # rubocop:disable Style/StringConcatenation
+      # rubocop:disable-next Style/StringConcatenation
       def make_request(url)
         get url
 
@@ -90,7 +90,6 @@ module GrapeSwagger
           JSON.parse(last_response.body, symbolize_names: true)
         ) + "\n"
       end
-      # rubocop:enable Style/StringConcatenation
 
       def urls_for(api_class)
         api_class.routes

--- a/spec/support/empty_model_parser.rb
+++ b/spec/support/empty_model_parser.rb
@@ -1,9 +1,8 @@
 # frozen_string_literal: true
 
-# rubocop:disable Lint/EmptyClass
+# rubocop:disable-next Lint/EmptyClass
 class EmptyClass
 end
-# rubocop:enable Lint/EmptyClass
 
 module GrapeSwagger
   class EmptyModelParser

--- a/spec/support/namespace_tags.rb
+++ b/spec/support/namespace_tags.rb
@@ -3,9 +3,8 @@
 RSpec.shared_context 'namespace example' do
   before :all do
     module TheApi
-      # rubocop:disable Lint/EmptyClass
+      # rubocop:disable-next Lint/EmptyClass
       class CustomType; end
-      # rubocop:enable Lint/EmptyClass
 
       class NamespaceApi < Grape::API
         namespace :hudson do

--- a/spec/swagger_v2/simple_mounted_api_spec.rb
+++ b/spec/swagger_v2/simple_mounted_api_spec.rb
@@ -4,9 +4,8 @@ require 'spec_helper'
 
 describe 'a simple mounted api' do
   before :all do
-    # rubocop:disable Lint/EmptyClass
+    # rubocop:disable-next Lint/EmptyClass
     class CustomType; end
-    # rubocop:enable Lint/EmptyClass
 
     class SimpleMountedApi < Grape::API
       desc 'Document root',


### PR DESCRIPTION
## Summary

CI on `master` is red: https://github.com/ruby-grape/grape-swagger/actions/runs/33563460032/job/100041130217

Rubocop's `~> 1.50` constraint resolved to `1.90.0` in that run, which introduced the new `Style/DirectiveScope` cop. It flags `# rubocop:disable` / `# rubocop:enable` comment pairs that only ever wrap a single statement, since a `# rubocop:disable-next` comment says the same thing without depending on the matching `enable` staying in sync.

## What changed

Ran `rubocop -A` to apply the cop's own autocorrection at the four flagged sites:

- `lib/grape-swagger/rake/oapi_tasks.rb`
- `spec/support/empty_model_parser.rb`
- `spec/support/namespace_tags.rb`
- `spec/swagger_v2/simple_mounted_api_spec.rb`

No behavior change — `bundle exec rubocop --parallel --format progress` now reports 0 offenses across all 152 files, and the specs in the touched files still pass.