### PR TITLE
Fix CI by pinning json gem below 3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * [#986](https://github.com/ruby-grape/grape-swagger/pull/986): Read a route's tags through `route.tags` instead of `route.options`; a blank `tags:` (`nil` or `[]`) now means "not specified" and derives the tag from the path. See [UPGRADING](UPGRADING.md) - [@ericproulx](https://github.com/ericproulx).
 * [#988](https://github.com/ruby-grape/grape-swagger/pull/988): Fix CI by replacing single-statement `rubocop:disable`/`enable` pairs with `rubocop:disable-next`, per rubocop 1.90's new `Style/DirectiveScope` cop - [@numbata](https://github.com/numbata).
+* Fix CI by pinning `json` to `< 3.0` in the Gemfile; `json` 3.0 dropped support for the `quirks_mode:` keyword that `multi_json`'s adapter still passes by default, breaking JSON request parsing wherever Grape resolves `Grape::Json` to `MultiJson` - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 ### 2.2.0 (2026-08-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 * [#986](https://github.com/ruby-grape/grape-swagger/pull/986): Read a route's tags through `route.tags` instead of `route.options`; a blank `tags:` (`nil` or `[]`) now means "not specified" and derives the tag from the path. See [UPGRADING](UPGRADING.md) - [@ericproulx](https://github.com/ericproulx).
 * [#988](https://github.com/ruby-grape/grape-swagger/pull/988): Fix CI by replacing single-statement `rubocop:disable`/`enable` pairs with `rubocop:disable-next`, per rubocop 1.90's new `Style/DirectiveScope` cop - [@numbata](https://github.com/numbata).
-* Fix CI by pinning `json` to `< 3.0` in the Gemfile; `json` 3.0 dropped support for the `quirks_mode:` keyword that `multi_json`'s adapter still passes by default, breaking JSON request parsing wherever Grape resolves `Grape::Json` to `MultiJson` - [@numbata](https://github.com/numbata).
+* [#992](https://github.com/ruby-grape/grape-swagger/pull/992): Fix CI by pinning `json` to `< 3.0` in the Gemfile; `json` 3.0 dropped support for the `quirks_mode:` keyword that `multi_json`'s adapter still passes by default, breaking JSON request parsing wherever Grape resolves `Grape::Json` to `MultiJson` - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 ### 2.2.0 (2026-08-06)

--- a/Gemfile
+++ b/Gemfile
@@ -29,6 +29,9 @@ group :development, :test do
   end
 
   gem 'cgi'
+  # multi_json's json_gem adapter still passes quirks_mode: true by default,
+  # a keyword json 3.0 dropped support for (https://github.com/intridea/multi_json/issues/163).
+  gem 'json', '< 3.0'
   gem 'multi_json'
   gem 'rack-cors'
   gem 'rack-test'


### PR DESCRIPTION
## Summary
CI on master started failing right after #988 merged, but the actual cause is unrelated to that change: `json` just shipped a 3.0.0 major release that CI's unpinned `bundle update` picked up, and it breaks JSON request parsing across the test suite. This keeps CI's dependency resolution on a compatible `json` version so builds are reliable again.

## Root cause
`json` 3.0.0 dropped support for the `quirks_mode:` keyword. `multi_json`'s built-in JSON adapter still passes `quirks_mode: true` by default, and Grape transparently resolves its `Grape::Json` wrapper to `MultiJson` whenever that gem is loaded in the process. Any spec that goes through that path (JSON request body parsing) crashed with:

```
ArgumentError: unknown keyword: quirks_mode
```

Reproduced directly:
```
$ ruby -e "gem 'json','3.0.0'; require 'json'; JSON.parse('{\"a\":1}', quirks_mode: true)"
unknown keyword: quirks_mode (ArgumentError)
```

Confirmed the merged commit itself (#988, rubocop directive comments only) is unrelated - `rubocop` passes cleanly, and reverting just the json version (independent of that commit) reproduces/fixes the failure.

## Fix
Pin `json` to `< 3.0` in the Gemfile's dev/test group, so `bundle update` (which CI runs on every push, with no committed lockfile) keeps resolving a version compatible with `multi_json`.

## Test plan
- [x] `bundle update` now resolves `json 2.21.2` instead of `3.0.0`
- [x] `bundle exec rspec` - 531 examples, 0 failures, 2 pending
- [x] `bundle exec rubocop` - no offenses