### PR TITLE
Add Grape 4.0.0 to the CI test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
           - { ruby: '3.3', grape: '3.2.1' }
           - { ruby: '3.4', grape: '3.2.1' }
           - { ruby: 'head', grape: '3.2.1' }
+          - { ruby: '3.3', grape: '4.0.0' }
+          - { ruby: '3.4', grape: '4.0.0' }
+          - { ruby: 'head', grape: '4.0.0' }
           - { ruby: '3.3', grape: 'HEAD' }
           - { ruby: '3.4', grape: 'HEAD' }
     name: test (ruby=${{ matrix.entry.ruby }}, grape=${{ matrix.entry.grape }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * [#986](https://github.com/ruby-grape/grape-swagger/pull/986): Read a route's tags through `route.tags` instead of `route.options`; a blank `tags:` (`nil` or `[]`) now means "not specified" and derives the tag from the path. See [UPGRADING](UPGRADING.md) - [@ericproulx](https://github.com/ericproulx).
 * [#988](https://github.com/ruby-grape/grape-swagger/pull/988): Fix CI by replacing single-statement `rubocop:disable`/`enable` pairs with `rubocop:disable-next`, per rubocop 1.90's new `Style/DirectiveScope` cop - [@numbata](https://github.com/numbata).
 * [#992](https://github.com/ruby-grape/grape-swagger/pull/992): Fix CI by pinning `json` to `< 3.0` in the Gemfile; `json` 3.0 dropped support for the `quirks_mode:` keyword that `multi_json`'s adapter still passes by default, breaking JSON request parsing wherever Grape resolves `Grape::Json` to `MultiJson` - [@numbata](https://github.com/numbata).
+* [#993](https://github.com/ruby-grape/grape-swagger/pull/993): Add Grape 4.0.0 to the CI test matrix and raise the Gemfile's default `grape` upper bound from `< 4.0` to `< 5.0`, matching the gemspec's already-declared support range - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 ### 2.2.0 (2026-08-06)

--- a/Gemfile
+++ b/Gemfile
@@ -4,12 +4,16 @@ source 'https://rubygems.org'
 
 gemspec
 
+grape_version = ENV.fetch('GRAPE_VERSION', nil)
+
 # gem 'grape', git: 'https://github.com/ruby-grape/grape'
-gem 'grape', case version = ENV.fetch('GRAPE_VERSION', '< 5.0')
+gem 'grape', case grape_version
+             when nil
+               '< 5.0'
              when 'HEAD'
                { git: 'https://github.com/ruby-grape/grape' }
              else
-               version
+               grape_version
              end
 
 gem ENV.fetch('MODEL_PARSER', nil) if ENV.key?('MODEL_PARSER')
@@ -20,8 +24,7 @@ group :development, :test do
   gem 'pry', platforms: [:mri]
   gem 'pry-byebug', platforms: [:mri]
 
-  grape_version = ENV.fetch('GRAPE_VERSION', '4.0.0')
-  if grape_version == 'HEAD' || Gem::Version.new(grape_version) >= Gem::Version.new('2.0.0')
+  if grape_version.nil? || grape_version == 'HEAD' || Gem::Version.new(grape_version) >= Gem::Version.new('2.0.0')
     gem 'rack', '>= 3.0'
   else
     gem 'activesupport', '< 7.2'

--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 # gem 'grape', git: 'https://github.com/ruby-grape/grape'
-gem 'grape', case version = ENV.fetch('GRAPE_VERSION', '< 4.0')
+gem 'grape', case version = ENV.fetch('GRAPE_VERSION', '< 5.0')
              when 'HEAD'
                { git: 'https://github.com/ruby-grape/grape' }
              else

--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ group :development, :test do
   gem 'pry', platforms: [:mri]
   gem 'pry-byebug', platforms: [:mri]
 
-  grape_version = ENV.fetch('GRAPE_VERSION', '2.4.0')
+  grape_version = ENV.fetch('GRAPE_VERSION', '4.0.0')
   if grape_version == 'HEAD' || Gem::Version.new(grape_version) >= Gem::Version.new('2.0.0')
     gem 'rack', '>= 3.0'
   else


### PR DESCRIPTION
## Summary
Grape 4.0.0 was released today. This adds it to the CI test matrix as its own pinned entry and widens the Gemfile's default version range so local dev/test setups pick it up too, keeping grape-swagger's tested compatibility in step with the gemspec's already-declared support for Grape up to (but excluding) 5.0.

## Details
- The matrix previously only reached Grape 4.x via the `HEAD` entries, which track the `master` branch. Now that 4.0.0 has shipped, `HEAD` points at unreleased 4.1.0-dev instead - so the actual stable 4.0.0 release wasn't covered anywhere. Added explicit `{ grape: '4.0.0' }` rows on `ruby: '3.3'`, `'3.4'`, and `'head'` (Grape 4 requires Ruby >= 3.3, so no `3.1`/`3.2` rows, same as the existing `3.2.1` entries).
- The Gemfile's default (`ENV.fetch('GRAPE_VERSION', ...)`) was capped at `< 4.0`, so a plain `bundle install`/`update` with no `GRAPE_VERSION` set never resolved to 4.x - even though the gemspec already declares `'>= 2.1', '< 5.0'`. Raised the default to `< 5.0` to match.
- The Gemfile also used to read `ENV['GRAPE_VERSION']` twice, with two separate hardcoded fallbacks (one for the gem requirement, one for a `rack`-version comparison) that had to be kept in sync by hand - which is exactly how the second one went stale in the first place. It's now read once into a `grape_version` local and reused at both call sites, so there's a single default to maintain going forward.

## Test plan
- [x] `bundle update` (no `GRAPE_VERSION`) now resolves `grape 4.0.0`
- [x] `bundle exec rspec` against Grape 4.0.0 - 531 examples, 0 failures, 2 pending (verified for the default, `grape-swagger-entity`, and `grape-swagger-representable` model parsers)
- [x] `bundle exec rubocop` - no offenses