### PR TITLE
Auto-create a GitHub Release when a version tag is pushed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,44 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      - name: Extract changelog
+        id: changelog
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          notes="$(awk -v version="$version" '
+            $0 ~ "^### " version " " {found=1; next}
+            found && $0 ~ "^### " {exit}
+            found {print}
+          ' CHANGELOG.md)"
+          if [[ -z "${notes// }" ]]; then
+            echo "No changelog entry found for ${version}" >&2
+            exit 1
+          fi
+          {
+            echo "notes<<EOF"
+            echo "$notes"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+      - name: Create GitHub release
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: ${{ github.ref_name }}
+          body: ${{ steps.changelog.outputs.notes }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,4 +42,3 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.notes }}
-          generate_release_notes: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,3 +42,4 @@ jobs:
           tag_name: ${{ github.ref_name }}
           name: ${{ github.ref_name }}
           body: ${{ steps.changelog.outputs.notes }}
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * [#988](https://github.com/ruby-grape/grape-swagger/pull/988): Fix CI by replacing single-statement `rubocop:disable`/`enable` pairs with `rubocop:disable-next`, per rubocop 1.90's new `Style/DirectiveScope` cop - [@numbata](https://github.com/numbata).
 * [#992](https://github.com/ruby-grape/grape-swagger/pull/992): Fix CI by pinning `json` to `< 3.0` in the Gemfile; `json` 3.0 dropped support for the `quirks_mode:` keyword that `multi_json`'s adapter still passes by default, breaking JSON request parsing wherever Grape resolves `Grape::Json` to `MultiJson` - [@numbata](https://github.com/numbata).
 * [#993](https://github.com/ruby-grape/grape-swagger/pull/993): Add Grape 4.0.0 to the CI test matrix and raise the Gemfile's default `grape` upper bound from `< 4.0` to `< 5.0`, matching the gemspec's already-declared support range - [@numbata](https://github.com/numbata).
+* [#994](https://github.com/ruby-grape/grape-swagger/pull/994): Publish a GitHub Release with CHANGELOG notes whenever a version tag is pushed - [@numbata](https://github.com/numbata).
 * Your contribution here.
 
 ### 2.2.0 (2026-08-06)


### PR DESCRIPTION
## Summary
Releases here go out via `rake release` (tags `vX.Y.Z`, pushes to RubyGems), but there's never been a corresponding GitHub Release - so anyone checking the Releases page finds nothing, and the per-version changelog only lives inside CHANGELOG.md. This adds a workflow that turns each version tag into a proper GitHub Release automatically, using the existing curated CHANGELOG entry as the notes - no manual step added to the release process.

## Details
- Triggers on `v*` tag pushes (matches the tags `rake release` already creates, e.g. `v2.2.0`).
- Extracts the section of `CHANGELOG.md` for that version (headers look like `### X.Y.Z (date)`).
- Publishes a GitHub Release via `softprops/action-gh-release`, named after the tag, with the extracted section as the body.
- Fails loudly if no matching changelog section is found, instead of silently publishing an empty release.

Doesn't touch the RubyGems push or the `rake release` flow at all - purely additive.

## Test plan
- [x] Validated the workflow YAML parses
- [x] Ran the changelog-extraction `awk` locally against an existing released version (`2.2.0`) and confirmed it pulls exactly the Features/Fixes section, stopping at the next `### ` heading